### PR TITLE
[codex] Validate doctor config contracts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,14 +4,18 @@ import { pathToFileURL } from "node:url";
 
 import type { DaemonHandle, StartDaemonOptions } from "./daemon.js";
 import { startDaemon } from "./daemon.js";
+import type { DoctorOptions, DoctorReport } from "./doctor.js";
+import { runDoctor } from "./doctor.js";
 import { VERSION } from "./version.js";
 
 export type CliDependencies = {
   registerSignalHandlers?: boolean;
+  runDoctor?: (options: DoctorOptions) => Promise<DoctorReport>;
   startDaemon?: (options: StartDaemonOptions) => Promise<DaemonHandle>;
 };
 
 export function buildCli(dependencies: CliDependencies = {}): Command {
+  const doctor = dependencies.runDoctor ?? runDoctor;
   const start = dependencies.startDaemon ?? startDaemon;
   const registerSignalHandlers = dependencies.registerSignalHandlers ?? true;
   const program = new Command();
@@ -20,6 +24,28 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .name("symphonika")
     .description("Local daemon for orchestrating coding-agent runs from GitHub issues")
     .version(VERSION);
+
+  program
+    .command("doctor")
+    .description("validate service config and workflow contracts without dispatching work")
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .action(async (options: { config: string }) => {
+      const report = await doctor({ configPath: options.config });
+
+      if (report.ok) {
+        writeOut(
+          program,
+          `doctor ok: ${report.projects.length} ${pluralize("project", report.projects.length)} valid\n`
+        );
+        return;
+      }
+
+      writeErr(program, "doctor failed:\n");
+      for (const error of report.errors) {
+        writeErr(program, `- ${error}\n`);
+      }
+      process.exitCode = 1;
+    });
 
   program
     .command("daemon")
@@ -52,6 +78,30 @@ function parsePort(value: string): number {
   }
 
   return port;
+}
+
+function pluralize(word: string, count: number): string {
+  return count === 1 ? word : `${word}s`;
+}
+
+function writeOut(program: Command, message: string): void {
+  const output = program.configureOutput();
+  if (output.writeOut !== undefined) {
+    output.writeOut(message);
+    return;
+  }
+
+  process.stdout.write(message);
+}
+
+function writeErr(program: Command, message: string): void {
+  const output = program.configureOutput();
+  if (output.writeErr !== undefined) {
+    output.writeErr(message);
+    return;
+  }
+
+  process.stderr.write(message);
 }
 
 function registerShutdownHandlers(daemon: DaemonHandle): void {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,399 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parse } from "yaml";
+import { z } from "zod";
+
+export type DoctorOptions = {
+  configPath?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type DoctorProjectReport = {
+  name: string;
+  workflowPath: string;
+};
+
+export type DoctorReport = {
+  configPath: string;
+  errors: string[];
+  ok: boolean;
+  projects: DoctorProjectReport[];
+};
+
+type ServiceConfig = z.infer<typeof serviceConfigSchema>;
+type ProjectConfig = z.infer<typeof projectSchema>;
+
+const providerNameSchema = z.enum(["codex", "claude"]);
+const pathStringSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => !value.includes("\0"), "path must not contain NUL bytes");
+
+const providerCommandSchema = z
+  .object({
+    command: z.string().trim().min(1)
+  })
+  .passthrough();
+
+const projectSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    disabled: z.boolean().optional(),
+    weight: z.number().int().positive().optional(),
+    tracker: z
+      .object({
+        kind: z.literal("github"),
+        owner: z.string().trim().min(1),
+        repo: z.string().trim().min(1),
+        token: z.string().trim().min(1)
+      })
+      .passthrough(),
+    issue_filters: z
+      .object({
+        states: z.array(z.literal("open")).min(1),
+        labels_all: z.array(z.string().trim().min(1)),
+        labels_none: z.array(z.string().trim().min(1))
+      })
+      .passthrough(),
+    priority: z
+      .object({
+        labels: z.record(z.number().int().nonnegative()),
+        default: z.number().int().nonnegative()
+      })
+      .passthrough(),
+    workspace: z
+      .object({
+        root: pathStringSchema,
+        git: z
+          .object({
+            remote: z.string().trim().min(1),
+            base_branch: z.string().trim().min(1)
+          })
+          .passthrough()
+      })
+      .passthrough(),
+    agent: z
+      .object({
+        provider: providerNameSchema
+      })
+      .passthrough(),
+    workflow: pathStringSchema
+  })
+  .passthrough();
+
+const serviceConfigSchema = z
+  .object({
+    state: z
+      .object({
+        root: pathStringSchema.optional()
+      })
+      .passthrough()
+      .optional(),
+    polling: z
+      .object({
+        interval_ms: z.number().int().positive().optional()
+      })
+      .passthrough()
+      .optional(),
+    providers: z
+      .object({
+        codex: providerCommandSchema,
+        claude: providerCommandSchema
+      })
+      .passthrough(),
+    projects: z.array(projectSchema).min(1)
+  })
+  .passthrough();
+
+const allowedTemplateFields: Record<string, ReadonlySet<string>> = {
+  branch: new Set(["name"]),
+  issue: new Set([
+    "body",
+    "created_at",
+    "id",
+    "labels",
+    "number",
+    "priority",
+    "state",
+    "title",
+    "updated_at",
+    "url"
+  ]),
+  project: new Set(["name"]),
+  provider: new Set(["command", "name"]),
+  run: new Set(["attempt", "continuation", "id"]),
+  workspace: new Set(["path", "root"])
+};
+
+const serviceDiscoveryFrontMatterKeys = new Set([
+  "agent",
+  "issue_filters",
+  "priority",
+  "projects",
+  "provider",
+  "providers",
+  "tracker",
+  "workflow",
+  "workspace"
+]);
+
+export async function runDoctor(
+  options: DoctorOptions = {}
+): Promise<DoctorReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const configPath = path.resolve(cwd, options.configPath ?? "symphonika.yml");
+  const env = options.env ?? process.env;
+  const errors: string[] = [];
+  const projects: DoctorProjectReport[] = [];
+  const rawConfig = await readConfig(configPath, errors);
+
+  if (rawConfig === undefined) {
+    return report(configPath, errors, projects);
+  }
+
+  const parsedConfig = parseServiceConfig(rawConfig, errors);
+  if (parsedConfig === undefined) {
+    return report(configPath, errors, projects);
+  }
+
+  for (const project of parsedConfig.projects) {
+    validateProject(project, parsedConfig, env, errors);
+    const workflowPath = path.resolve(path.dirname(configPath), project.workflow);
+    const workflowErrors = await validateWorkflowContract(workflowPath);
+    errors.push(...workflowErrors);
+    projects.push({
+      name: project.name,
+      workflowPath
+    });
+  }
+
+  return report(configPath, errors, projects);
+}
+
+async function readConfig(
+  configPath: string,
+  errors: string[]
+): Promise<unknown> {
+  let contents: string;
+
+  try {
+    contents = await readFile(configPath, "utf8");
+  } catch (error) {
+    errors.push(`service config not found at ${configPath}: ${errorMessage(error)}`);
+    return undefined;
+  }
+
+  try {
+    return parse(contents) ?? {};
+  } catch (error) {
+    errors.push(`service config could not be parsed: ${errorMessage(error)}`);
+    return undefined;
+  }
+}
+
+function parseServiceConfig(
+  rawConfig: unknown,
+  errors: string[]
+): ServiceConfig | undefined {
+  const parsed = serviceConfigSchema.safeParse(rawConfig);
+
+  if (!parsed.success) {
+    errors.push(...parsed.error.issues.map(formatZodIssue));
+    return undefined;
+  }
+
+  return parsed.data;
+}
+
+function validateProject(
+  project: ProjectConfig,
+  config: ServiceConfig,
+  env: NodeJS.ProcessEnv,
+  errors: string[]
+): void {
+  const provider = config.providers[project.agent.provider];
+  if (provider.command.trim().length === 0) {
+    errors.push(
+      `projects.${project.name}.agent.provider references ${project.agent.provider}, but its command is empty`
+    );
+  }
+
+  if (resolveEnvBackedValue(project.tracker.token, env) === undefined) {
+    const variableName = envReferenceName(project.tracker.token);
+    if (variableName === undefined) {
+      errors.push(
+        `projects.${project.name}.tracker.token must reference an environment variable like $GITHUB_TOKEN`
+      );
+    } else {
+      errors.push(
+        `projects.${project.name}.tracker.token references unset environment variable $${variableName}`
+      );
+    }
+  }
+}
+
+async function validateWorkflowContract(
+  workflowPath: string
+): Promise<string[]> {
+  const errors: string[] = [];
+  let contents: string;
+
+  try {
+    contents = await readFile(workflowPath, "utf8");
+  } catch (error) {
+    return [`workflow contract not found at ${workflowPath}: ${errorMessage(error)}`];
+  }
+
+  const workflow = parseWorkflowContract(contents, workflowPath);
+  errors.push(...workflow.errors);
+
+  if (workflow.body.trim().length === 0) {
+    errors.push(`workflow contract at ${workflowPath} must not be empty`);
+  }
+
+  errors.push(...validateTemplateVariables(workflow.body, workflowPath));
+  return errors;
+}
+
+function parseWorkflowContract(
+  contents: string,
+  workflowPath: string
+): { body: string; errors: string[] } {
+  const lines = contents.split(/\r?\n/);
+
+  if (lines[0]?.trim() !== "---") {
+    return { body: contents, errors: [] };
+  }
+
+  const closingLine = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === "---"
+  );
+  if (closingLine === -1) {
+    return {
+      body: "",
+      errors: [`workflow front matter at ${workflowPath} is missing a closing ---`]
+    };
+  }
+
+  const frontMatterSource = lines.slice(1, closingLine).join("\n");
+  const errors: string[] = [];
+  const frontMatter = parseFrontMatter(frontMatterSource, workflowPath, errors);
+
+  if (frontMatter !== undefined) {
+    for (const key of Object.keys(frontMatter)) {
+      if (serviceDiscoveryFrontMatterKeys.has(key)) {
+        errors.push(
+          `workflow front matter at ${workflowPath} must not define service config key ${key}`
+        );
+      }
+    }
+  }
+
+  return {
+    body: lines.slice(closingLine + 1).join("\n"),
+    errors
+  };
+}
+
+function parseFrontMatter(
+  source: string,
+  workflowPath: string,
+  errors: string[]
+): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = parse(source) ?? {};
+    if (isRecord(parsed)) {
+      return parsed;
+    }
+    errors.push(`workflow front matter at ${workflowPath} must be a mapping`);
+    return undefined;
+  } catch (error) {
+    errors.push(
+      `workflow front matter at ${workflowPath} could not be parsed: ${errorMessage(error)}`
+    );
+    return undefined;
+  }
+}
+
+function validateTemplateVariables(
+  template: string,
+  workflowPath: string
+): string[] {
+  const errors: string[] = [];
+  const tagPattern = /{{\s*([^{}]+?)\s*}}/g;
+
+  for (const match of template.matchAll(tagPattern)) {
+    const expression = match[1]?.trim() ?? "";
+    const parts = expression.split(".");
+    const topLevel = parts[0];
+
+    if (!/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(expression)) {
+      errors.push(
+        `workflow template at ${workflowPath} has unsupported tag {{${expression}}}`
+      );
+      continue;
+    }
+
+    if (topLevel === undefined || !(topLevel in allowedTemplateFields)) {
+      errors.push(
+        `workflow template at ${workflowPath} references unknown variable {{${expression}}}`
+      );
+      continue;
+    }
+
+    const field = parts[1];
+    if (field !== undefined && !allowedTemplateFields[topLevel]!.has(field)) {
+      errors.push(
+        `workflow template at ${workflowPath} references unknown variable {{${expression}}}`
+      );
+    }
+  }
+
+  return errors;
+}
+
+function resolveEnvBackedValue(
+  input: string,
+  env: NodeJS.ProcessEnv
+): string | undefined {
+  const variableName = envReferenceName(input);
+  if (variableName === undefined) {
+    return undefined;
+  }
+
+  const value = env[variableName];
+  return value === undefined || value.length === 0 ? undefined : value;
+}
+
+function envReferenceName(input: string): string | undefined {
+  const match = /^\$([A-Za-z_][A-Za-z0-9_]*)$/.exec(input);
+  return match?.[1];
+}
+
+function report(
+  configPath: string,
+  errors: string[],
+  projects: DoctorProjectReport[]
+): DoctorReport {
+  return {
+    configPath,
+    errors,
+    ok: errors.length === 0,
+    projects
+  };
+}
+
+function formatZodIssue(issue: z.ZodIssue): string {
+  const location = issue.path.length === 0 ? "service config" : issue.path.join(".");
+  return `${location}: ${issue.message}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,285 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildCli } from "../src/cli.js";
+
+const tempRoots: string[] = [];
+const originalGithubToken = process.env.GITHUB_TOKEN;
+const originalExitCode = process.exitCode;
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-doctor-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  if (originalGithubToken === undefined) {
+    delete process.env.GITHUB_TOKEN;
+  } else {
+    process.env.GITHUB_TOKEN = originalGithubToken;
+  }
+  delete process.env.SYMPHONIKA_MISSING_TOKEN;
+  delete process.env.SYMPHONIKA_TEST_TOKEN;
+  process.exitCode = originalExitCode;
+
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("doctor", () => {
+  it("accepts a valid final-shaped service config and workflow contract", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath);
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}} for {{project.name}} using {{provider.name}}.\n"
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).not.toBe(1);
+    expect(output.stderr).toBe("");
+    expect(output.stdout).toContain("doctor ok");
+    expect(output.stdout).toContain("1 project");
+  });
+
+  it("reports clear errors for a missing Projects list", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeFile(
+      configPath,
+      [
+        "providers:",
+        "  codex:",
+        '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+        "  claude:",
+        '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+        ""
+      ].join("\n")
+    );
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stdout).toBe("");
+    expect(output.stderr).toContain("doctor failed");
+    expect(output.stderr).toContain("projects");
+  });
+
+  it("reports invalid provider names and unsupported tracker kinds", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath, {
+      agentProvider: "gpt",
+      trackerKind: "linear"
+    });
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stderr).toContain("projects.0.tracker.kind");
+    expect(output.stderr).toContain("github");
+    expect(output.stderr).toContain("projects.0.agent.provider");
+    expect(output.stderr).toContain("codex");
+  });
+
+  it("reports missing workflow contract paths", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath, {
+      workflowPath: "./missing/WORKFLOW.md"
+    });
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stderr).toContain("workflow contract not found");
+  });
+
+  it("resolves environment-backed tracker tokens without printing secret values", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath, {
+      token: "$SYMPHONIKA_TEST_TOKEN"
+    });
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}} for {{project.name}}.\n"
+    );
+    process.env.SYMPHONIKA_TEST_TOKEN = "super-secret-do-not-print";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).not.toBe(1);
+    expect(output.stdout).toContain("doctor ok");
+    expect(output.stdout).not.toContain("super-secret-do-not-print");
+    expect(output.stderr).not.toContain("super-secret-do-not-print");
+  });
+
+  it("reports missing environment-backed tracker tokens by variable name", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath, {
+      token: "$SYMPHONIKA_MISSING_TOKEN"
+    });
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}} for {{project.name}}.\n"
+    );
+    delete process.env.SYMPHONIKA_MISSING_TOKEN;
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stderr).toContain("$SYMPHONIKA_MISSING_TOKEN");
+  });
+
+  it("accepts workflow front matter for prompt-adjacent policy", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath);
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      [
+        "---",
+        "autonomy:",
+        "  max_turns: 8",
+        "---",
+        "Work on {{issue.title}} for {{project.name}}.",
+        ""
+      ].join("\n")
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).not.toBe(1);
+    expect(output.stdout).toContain("doctor ok");
+  });
+
+  it("rejects workflow front matter service discovery keys", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath);
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      ["---", "tracker:", "  kind: github", "---", "Work on {{issue.title}}.", ""].join(
+        "\n"
+      )
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stderr).toContain("front matter");
+    expect(output.stderr).toContain("tracker");
+  });
+
+  it("rejects unknown workflow template variables", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath);
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{ticket.title}} for {{project.name}}.\n"
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stderr).toContain("unknown variable");
+    expect(output.stderr).toContain("{{ticket.title}}");
+  });
+});
+
+async function runDoctorCommand(
+  configPath: string
+): Promise<{ stderr: string; stdout: string }> {
+  const output = { stderr: "", stdout: "" };
+  const program = buildCli({ registerSignalHandlers: false });
+  program.configureOutput({
+    writeErr: (message) => {
+      output.stderr += message;
+    },
+    writeOut: (message) => {
+      output.stdout += message;
+    }
+  });
+
+  await program.parseAsync([
+    "node",
+    "symphonika",
+    "doctor",
+    "--config",
+    configPath
+  ]);
+
+  return output;
+}
+
+async function writeValidConfig(
+  configPath: string,
+  overrides: {
+    agentProvider?: string;
+    token?: string;
+    trackerKind?: string;
+    workflowPath?: string;
+  } = {}
+): Promise<void> {
+  const configDir = path.dirname(configPath);
+  await mkdir(configDir, { recursive: true });
+  await writeFile(
+    configPath,
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      `      kind: ${overrides.trackerKind ?? "github"}`,
+      "      owner: pmatos",
+      "      repo: symphonika",
+      `      token: "${overrides.token ?? "$GITHUB_TOKEN"}"`,
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human", "sym:stale"]',
+      "    priority:",
+      "      labels:",
+      '        "priority:critical": 0',
+      '        "priority:high": 1',
+      '        "priority:medium": 2',
+      '        "priority:low": 3',
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      `      provider: ${overrides.agentProvider ?? "codex"}`,
+      `    workflow: ${overrides.workflowPath ?? "./WORKFLOW.md"}`,
+      ""
+    ].join("\n")
+  );
+}


### PR DESCRIPTION
## Summary

- Add `symphonika doctor --config <path>` to validate service config and workflow contracts without dispatching work.
- Introduce a reusable doctor validator for final-shaped Project config, provider/tracker shape, env-backed tracker tokens, workflow file parsing, front matter scope, and strict template variables.
- Add CLI-level tests for valid config, invalid config, env resolution/redaction, workflow front matter, and strict template failures.

Closes #3.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`