### PR TITLE
[codex] Validate GitHub project labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.14.4",
+        "@octokit/rest": "^22.0.1",
         "commander": "^12.1.0",
         "hono": "^4.6.14",
         "pino": "^9.5.0",
@@ -753,6 +754,161 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1597,6 +1753,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -1974,6 +2136,22 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2236,6 +2414,12 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
     },
     "node_modules/keyv": {
@@ -3186,6 +3370,12 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.14.4",
+    "@octokit/rest": "^22.0.1",
     "commander": "^12.1.0",
     "hono": "^4.6.14",
     "pino": "^9.5.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,18 +4,25 @@ import { pathToFileURL } from "node:url";
 
 import type { DaemonHandle, StartDaemonOptions } from "./daemon.js";
 import { startDaemon } from "./daemon.js";
-import type { DoctorOptions, DoctorReport } from "./doctor.js";
-import { runDoctor } from "./doctor.js";
+import type {
+  DoctorOptions,
+  DoctorReport,
+  InitProjectOptions,
+  InitProjectReport
+} from "./doctor.js";
+import { runDoctor, runInitProject } from "./doctor.js";
 import { VERSION } from "./version.js";
 
 export type CliDependencies = {
   registerSignalHandlers?: boolean;
   runDoctor?: (options: DoctorOptions) => Promise<DoctorReport>;
+  runInitProject?: (options: InitProjectOptions) => Promise<InitProjectReport>;
   startDaemon?: (options: StartDaemonOptions) => Promise<DaemonHandle>;
 };
 
 export function buildCli(dependencies: CliDependencies = {}): Command {
   const doctor = dependencies.runDoctor ?? runDoctor;
+  const initProject = dependencies.runInitProject ?? runInitProject;
   const start = dependencies.startDaemon ?? startDaemon;
   const registerSignalHandlers = dependencies.registerSignalHandlers ?? true;
   const program = new Command();
@@ -45,6 +52,54 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         writeErr(program, `- ${error}\n`);
       }
       process.exitCode = 1;
+    });
+
+  program
+    .command("init-project")
+    .description("create missing GitHub operational labels after explicit confirmation")
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .option("--yes", "create missing operational labels without an interactive prompt")
+    .action(async (options: { config: string; yes?: boolean }) => {
+      const emittedWarnings = new Set<string>();
+      const report = await initProject({
+        configPath: options.config,
+        onWarning: (warning) => {
+          emittedWarnings.add(warning);
+          writeErr(program, `warning: ${warning}\n`);
+        },
+        yes: options.yes === true
+      });
+
+      for (const warning of report.warnings) {
+        if (emittedWarnings.has(warning)) {
+          continue;
+        }
+        writeErr(program, `warning: ${warning}\n`);
+      }
+
+      if (!report.ok) {
+        writeErr(program, "init-project failed:\n");
+        for (const error of report.errors) {
+          writeErr(program, `- ${error}\n`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const createdLabels = report.projects.flatMap((project) =>
+        project.createdOperationalLabels.map((label) => ({
+          label,
+          repository: project.repository
+        }))
+      );
+
+      writeOut(
+        program,
+        `init-project ok: created ${createdLabels.length} ${pluralize("label", createdLabels.length)}\n`
+      );
+      for (const created of createdLabels) {
+        writeOut(program, `- ${created.label} in ${created.repository}\n`);
+      }
     });
 
   program

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { Octokit } from "@octokit/rest";
 import { parse } from "yaml";
 import { z } from "zod";
 
@@ -7,10 +8,13 @@ export type DoctorOptions = {
   configPath?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  githubApi?: GitHubApi;
 };
 
 export type DoctorProjectReport = {
+  missingOperationalLabels: string[];
   name: string;
+  validForDispatch: boolean;
   workflowPath: string;
 };
 
@@ -21,8 +25,91 @@ export type DoctorReport = {
   projects: DoctorProjectReport[];
 };
 
+export type InitProjectOptions = DoctorOptions & {
+  onWarning?: (warning: string) => void;
+  yes?: boolean;
+};
+
+export type InitProjectProjectReport = {
+  createdOperationalLabels: string[];
+  missingOperationalLabels: string[];
+  name: string;
+  repository: string;
+};
+
+export type InitProjectReport = {
+  configPath: string;
+  errors: string[];
+  ok: boolean;
+  projects: InitProjectProjectReport[];
+  warnings: string[];
+};
+
+export type GitHubRepositoryInput = {
+  owner: string;
+  repo: string;
+  token: string;
+};
+
+export type GitHubRepositoryAccess = {
+  message?: string;
+  ok: boolean;
+};
+
+export type GitHubApi = {
+  createLabel: (input: GitHubRepositoryInput & { name: string }) => Promise<void>;
+  listLabels: (input: GitHubRepositoryInput) => Promise<string[]>;
+  validateRepositoryAccess: (
+    input: GitHubRepositoryInput
+  ) => Promise<GitHubRepositoryAccess>;
+};
+
 type ServiceConfig = z.infer<typeof serviceConfigSchema>;
 type ProjectConfig = z.infer<typeof projectSchema>;
+type ProjectValidation = Pick<
+  DoctorProjectReport,
+  "missingOperationalLabels" | "validForDispatch"
+>;
+type LabelDescription = {
+  color: string;
+  description: string;
+};
+
+export const REQUIRED_OPERATIONAL_LABELS = [
+  "sym:claimed",
+  "sym:running",
+  "sym:failed",
+  "sym:stale"
+] as const;
+
+const OPERATIONAL_LABEL_DESCRIPTIONS: Record<
+  (typeof REQUIRED_OPERATIONAL_LABELS)[number],
+  LabelDescription
+> = {
+  "sym:claimed": {
+    color: "5319e7",
+    description: "Symphonika has claimed this issue for an orchestrated run."
+  },
+  "sym:failed": {
+    color: "d73a4a",
+    description: "A Symphonika run reached a deterministic failed state."
+  },
+  "sym:running": {
+    color: "0e8a16",
+    description: "A Symphonika coding-agent run is currently active."
+  },
+  "sym:stale": {
+    color: "fbca04",
+    description: "A Symphonika claim exists without a live local run."
+  }
+};
+
+const SILENT_OCTOKIT_LOG = {
+  debug: () => undefined,
+  error: () => undefined,
+  info: () => undefined,
+  warn: () => undefined
+};
 
 const providerNameSchema = z.enum(["codex", "claude"]);
 const pathStringSchema = z
@@ -145,6 +232,7 @@ export async function runDoctor(
   const cwd = options.cwd ?? process.cwd();
   const configPath = path.resolve(cwd, options.configPath ?? "symphonika.yml");
   const env = options.env ?? process.env;
+  const githubApi = options.githubApi ?? DEFAULT_GITHUB_API;
   const errors: string[] = [];
   const projects: DoctorProjectReport[] = [];
   const rawConfig = await readConfig(configPath, errors);
@@ -159,11 +247,18 @@ export async function runDoctor(
   }
 
   for (const project of parsedConfig.projects) {
-    validateProject(project, parsedConfig, env, errors);
+    const validation = await validateProject(
+      project,
+      parsedConfig,
+      env,
+      errors,
+      githubApi
+    );
     const workflowPath = path.resolve(path.dirname(configPath), project.workflow);
     const workflowErrors = await validateWorkflowContract(workflowPath);
     errors.push(...workflowErrors);
     projects.push({
+      ...validation,
       name: project.name,
       workflowPath
     });
@@ -171,6 +266,147 @@ export async function runDoctor(
 
   return report(configPath, errors, projects);
 }
+
+export async function runInitProject(
+  options: InitProjectOptions = {}
+): Promise<InitProjectReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const configPath = path.resolve(cwd, options.configPath ?? "symphonika.yml");
+  const env = options.env ?? process.env;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const projects: InitProjectProjectReport[] = [];
+  const rawConfig = await readConfig(configPath, errors);
+
+  if (rawConfig === undefined) {
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+
+  const parsedConfig = parseServiceConfig(rawConfig, errors);
+  if (parsedConfig === undefined) {
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+
+  const githubApi = options.githubApi ?? DEFAULT_GITHUB_API;
+
+  for (const project of parsedConfig.projects) {
+    const token = resolveEnvBackedValue(project.tracker.token, env);
+    if (token === undefined) {
+      const variableName = envReferenceName(project.tracker.token);
+      errors.push(
+        variableName === undefined
+          ? `projects.${project.name}.tracker.token must reference an environment variable like $GITHUB_TOKEN`
+          : `projects.${project.name}.tracker.token references unset environment variable $${variableName}`
+      );
+      continue;
+    }
+
+    const repository = {
+      owner: project.tracker.owner,
+      repo: project.tracker.repo,
+      token
+    };
+    const repositoryName = `${project.tracker.owner}/${project.tracker.repo}`;
+    const access = await githubApi.validateRepositoryAccess(repository);
+    if (!access.ok) {
+      errors.push(
+        `projects.${project.name}.tracker.repository ${repositoryName} is not accessible: ${access.message ?? "unknown GitHub error"}`
+      );
+      continue;
+    }
+
+    const labels = new Set(await githubApi.listLabels(repository));
+    const missingOperationalLabels = REQUIRED_OPERATIONAL_LABELS.filter(
+      (label) => !labels.has(label)
+    );
+    const createdOperationalLabels: string[] = [];
+
+    if (missingOperationalLabels.length > 0) {
+      const warning = `init-project ${options.yes === true ? "will" : "would"} create operational labels in ${repositoryName}: ${missingOperationalLabels.join(", ")}`;
+      warnings.push(warning);
+      options.onWarning?.(warning);
+
+      if (options.yes !== true) {
+        errors.push(
+          "pass --yes to create missing operational labels non-interactively"
+        );
+      } else {
+        for (const label of missingOperationalLabels) {
+          await githubApi.createLabel({
+            ...repository,
+            name: label
+          });
+          createdOperationalLabels.push(label);
+        }
+      }
+    }
+
+    projects.push({
+      createdOperationalLabels,
+      missingOperationalLabels,
+      name: project.name,
+      repository: repositoryName
+    });
+  }
+
+  return initProjectReport(configPath, errors, warnings, projects);
+}
+
+class OctokitGitHubApi implements GitHubApi {
+  async validateRepositoryAccess(
+    input: GitHubRepositoryInput
+  ): Promise<GitHubRepositoryAccess> {
+    const octokit = this.octokit(input.token);
+
+    try {
+      await octokit.rest.repos.get({
+        owner: input.owner,
+        repo: input.repo
+      });
+      return { ok: true };
+    } catch (error) {
+      return {
+        message: githubErrorMessage(error),
+        ok: false
+      };
+    }
+  }
+
+  async listLabels(input: GitHubRepositoryInput): Promise<string[]> {
+    const octokit = this.octokit(input.token);
+    const labels = await octokit.paginate(octokit.rest.issues.listLabelsForRepo, {
+      owner: input.owner,
+      per_page: 100,
+      repo: input.repo
+    });
+
+    return labels.map((label) => label.name);
+  }
+
+  async createLabel(
+    input: GitHubRepositoryInput & { name: string }
+  ): Promise<void> {
+    const octokit = this.octokit(input.token);
+    const labelDescription = operationalLabelDescription(input.name);
+
+    await octokit.rest.issues.createLabel({
+      color: labelDescription.color,
+      description: labelDescription.description,
+      name: input.name,
+      owner: input.owner,
+      repo: input.repo
+    });
+  }
+
+  private octokit(token: string): Octokit {
+    return new Octokit({
+      auth: token,
+      log: SILENT_OCTOKIT_LOG
+    });
+  }
+}
+
+const DEFAULT_GITHUB_API = new OctokitGitHubApi();
 
 async function readConfig(
   configPath: string,
@@ -207,20 +443,25 @@ function parseServiceConfig(
   return parsed.data;
 }
 
-function validateProject(
+async function validateProject(
   project: ProjectConfig,
   config: ServiceConfig,
   env: NodeJS.ProcessEnv,
-  errors: string[]
-): void {
+  errors: string[],
+  githubApi: GitHubApi | undefined
+): Promise<ProjectValidation> {
   const provider = config.providers[project.agent.provider];
+  let validForDispatch = true;
+
   if (provider.command.trim().length === 0) {
     errors.push(
       `projects.${project.name}.agent.provider references ${project.agent.provider}, but its command is empty`
     );
+    validForDispatch = false;
   }
 
-  if (resolveEnvBackedValue(project.tracker.token, env) === undefined) {
+  const token = resolveEnvBackedValue(project.tracker.token, env);
+  if (token === undefined) {
     const variableName = envReferenceName(project.tracker.token);
     if (variableName === undefined) {
       errors.push(
@@ -231,7 +472,49 @@ function validateProject(
         `projects.${project.name}.tracker.token references unset environment variable $${variableName}`
       );
     }
+    return {
+      missingOperationalLabels: [],
+      validForDispatch: false
+    };
   }
+
+  if (githubApi === undefined) {
+    return {
+      missingOperationalLabels: [],
+      validForDispatch
+    };
+  }
+
+  const repository = {
+    owner: project.tracker.owner,
+    repo: project.tracker.repo,
+    token
+  };
+  const access = await githubApi.validateRepositoryAccess(repository);
+  if (!access.ok) {
+    errors.push(
+      `projects.${project.name}.tracker.repository ${project.tracker.owner}/${project.tracker.repo} is not accessible: ${access.message ?? "unknown GitHub error"}`
+    );
+    return {
+      missingOperationalLabels: [],
+      validForDispatch: false
+    };
+  }
+
+  const labels = new Set(await githubApi.listLabels(repository));
+  const missingOperationalLabels = REQUIRED_OPERATIONAL_LABELS.filter(
+    (label) => !labels.has(label)
+  );
+  if (missingOperationalLabels.length > 0) {
+    errors.push(
+      `projects.${project.name}.tracker.repository ${project.tracker.owner}/${project.tracker.repo} is missing operational labels: ${missingOperationalLabels.join(", ")}`
+    );
+  }
+
+  return {
+    missingOperationalLabels,
+    validForDispatch: validForDispatch && missingOperationalLabels.length === 0
+  };
 }
 
 async function validateWorkflowContract(
@@ -385,9 +668,52 @@ function report(
   };
 }
 
+function initProjectReport(
+  configPath: string,
+  errors: string[],
+  warnings: string[],
+  projects: InitProjectProjectReport[]
+): InitProjectReport {
+  return {
+    configPath,
+    errors,
+    ok: errors.length === 0,
+    projects,
+    warnings
+  };
+}
+
 function formatZodIssue(issue: z.ZodIssue): string {
   const location = issue.path.length === 0 ? "service config" : issue.path.join(".");
   return `${location}: ${issue.message}`;
+}
+
+function operationalLabelDescription(name: string): LabelDescription {
+  if (isOperationalLabel(name)) {
+    return OPERATIONAL_LABEL_DESCRIPTIONS[name];
+  }
+
+  return {
+    color: "6a737d",
+    description: "Symphonika operational label."
+  };
+}
+
+function isOperationalLabel(
+  name: string
+): name is (typeof REQUIRED_OPERATIONAL_LABELS)[number] {
+  return (REQUIRED_OPERATIONAL_LABELS as readonly string[]).includes(name);
+}
+
+function githubErrorMessage(error: unknown): string {
+  if (error instanceof Error && "status" in error) {
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === "number") {
+      return `${error.message} (HTTP ${status})`;
+    }
+  }
+
+  return errorMessage(error);
 }
 
 function errorMessage(error: unknown): string {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -315,7 +315,16 @@ export async function runInitProject(
       continue;
     }
 
-    const labels = new Set(await githubApi.listLabels(repository));
+    let labels: Set<string>;
+    try {
+      labels = new Set(await githubApi.listLabels(repository));
+    } catch (error) {
+      errors.push(
+        `projects.${project.name}.tracker.repository ${repositoryName} labels could not be listed: ${errorMessage(error)}`
+      );
+      continue;
+    }
+
     const missingOperationalLabels = REQUIRED_OPERATIONAL_LABELS.filter(
       (label) => !labels.has(label)
     );
@@ -332,11 +341,17 @@ export async function runInitProject(
         );
       } else {
         for (const label of missingOperationalLabels) {
-          await githubApi.createLabel({
-            ...repository,
-            name: label
-          });
-          createdOperationalLabels.push(label);
+          try {
+            await githubApi.createLabel({
+              ...repository,
+              name: label
+            });
+            createdOperationalLabels.push(label);
+          } catch (error) {
+            errors.push(
+              `projects.${project.name}.tracker.repository ${repositoryName} could not create operational label ${label}: ${errorMessage(error)}`
+            );
+          }
         }
       }
     }
@@ -501,7 +516,19 @@ async function validateProject(
     };
   }
 
-  const labels = new Set(await githubApi.listLabels(repository));
+  let labels: Set<string>;
+  try {
+    labels = new Set(await githubApi.listLabels(repository));
+  } catch (error) {
+    errors.push(
+      `projects.${project.name}.tracker.repository ${project.tracker.owner}/${project.tracker.repo} labels could not be listed: ${errorMessage(error)}`
+    );
+    return {
+      missingOperationalLabels: [],
+      validForDispatch: false
+    };
+  }
+
   const missingOperationalLabels = REQUIRED_OPERATIONAL_LABELS.filter(
     (label) => !labels.has(label)
   );

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { buildCli } from "../src/cli.js";
 import type { StartDaemonOptions } from "../src/daemon.js";
+import type { InitProjectOptions } from "../src/doctor.js";
 
 describe("CLI", () => {
   it("starts the daemon with the selected config path and port", async () => {
@@ -35,5 +36,58 @@ describe("CLI", () => {
       configPath: "custom.yml",
       port: 4001
     });
+  });
+
+  it("runs init-project with the selected config path and explicit confirmation", async () => {
+    const initializations: InitProjectOptions[] = [];
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({
+      registerSignalHandlers: false,
+      runInitProject: (options) => {
+        initializations.push(options);
+        return Promise.resolve({
+          configPath: "/tmp/custom.yml",
+          errors: [],
+          ok: true,
+          projects: [
+            {
+              createdOperationalLabels: ["sym:running"],
+              missingOperationalLabels: ["sym:running"],
+              name: "symphonika",
+              repository: "pmatos/symphonika"
+            }
+          ],
+          warnings: [
+            "init-project will create operational labels in pmatos/symphonika: sym:running"
+          ]
+        });
+      }
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "init-project",
+      "--config",
+      "custom.yml",
+      "--yes"
+    ]);
+
+    expect(initializations).toHaveLength(1);
+    expect(initializations[0]).toMatchObject({
+      configPath: "custom.yml",
+      yes: true
+    });
+    expect(output.stderr).toContain("will create operational labels");
+    expect(output.stdout).toContain("init-project ok");
+    expect(output.stdout).toContain("sym:running");
   });
 });

--- a/tests/doctor-github.test.ts
+++ b/tests/doctor-github.test.ts
@@ -1,0 +1,268 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  runDoctor,
+  runInitProject,
+  type GitHubApi
+} from "../src/doctor.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-github-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("GitHub Project validation", () => {
+  it("marks a Project valid for dispatch when repository access and operational labels are present", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue([
+        "agent-ready",
+        "sym:claimed",
+        "sym:running",
+        "sym:failed",
+        "sym:stale"
+      ]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runDoctor({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.projects[0]).toMatchObject({
+      missingOperationalLabels: [],
+      validForDispatch: true
+    });
+    expect(githubApi.listLabels).toHaveBeenCalledWith({
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
+  });
+
+  it("reports repository access failures during doctor validation", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({
+        message: "Bad credentials",
+        ok: false
+      })
+    };
+
+    const report = await runDoctor({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "projects.symphonika.tracker.repository pmatos/symphonika is not accessible: Bad credentials"
+    );
+    expect(githubApi.validateRepositoryAccess).toHaveBeenCalledWith({
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
+    expect(githubApi.listLabels).not.toHaveBeenCalled();
+  });
+
+  it("reports missing operational labels without creating them", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue(["sym:claimed"]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runDoctor({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "projects.symphonika.tracker.repository pmatos/symphonika is missing operational labels: sym:running, sym:failed, sym:stale"
+    );
+    expect(report.projects[0]).toMatchObject({
+      missingOperationalLabels: ["sym:running", "sym:failed", "sym:stale"],
+      validForDispatch: false
+    });
+    expect(githubApi.createLabel).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitHub Project initialization", () => {
+  it("warns about the target repository and labels without mutating unless confirmed", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue(["sym:claimed"]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runInitProject({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.warnings).toContain(
+      "init-project would create operational labels in pmatos/symphonika: sym:running, sym:failed, sym:stale"
+    );
+    expect(report.errors).toContain(
+      "pass --yes to create missing operational labels non-interactively"
+    );
+    expect(githubApi.createLabel).not.toHaveBeenCalled();
+  });
+
+  it("creates missing operational labels when non-interactively confirmed", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn().mockResolvedValue(undefined),
+      listLabels: vi.fn().mockResolvedValue(["sym:claimed", "sym:failed"]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runInitProject({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      yes: true
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.warnings).toContain(
+      "init-project will create operational labels in pmatos/symphonika: sym:running, sym:stale"
+    );
+    expect(report.projects[0]).toMatchObject({
+      createdOperationalLabels: ["sym:running", "sym:stale"],
+      missingOperationalLabels: ["sym:running", "sym:stale"]
+    });
+    expect(githubApi.createLabel).toHaveBeenCalledTimes(2);
+    expect(githubApi.createLabel).toHaveBeenNthCalledWith(1, {
+      name: "sym:running",
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
+    expect(githubApi.createLabel).toHaveBeenNthCalledWith(2, {
+      name: "sym:stale",
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
+  });
+
+  it("emits the mutation warning before confirmed label creation starts", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const events: string[] = [];
+    const createLabel: GitHubApi["createLabel"] = (input) => {
+      events.push(`create:${input.name}`);
+      return Promise.resolve();
+    };
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(createLabel),
+      listLabels: vi.fn().mockResolvedValue(["sym:claimed", "sym:running"]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    await runInitProject({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      onWarning: (warning) => {
+        events.push(`warning:${warning}`);
+      },
+      yes: true
+    });
+
+    expect(events).toEqual([
+      "warning:init-project will create operational labels in pmatos/symphonika: sym:failed, sym:stale",
+      "create:sym:failed",
+      "create:sym:stale"
+    ]);
+  });
+});
+
+async function writeValidProject(root: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human", "sym:stale"]',
+      "    priority:",
+      "      labels:",
+      '        "priority:critical": 0',
+      '        "priority:high": 1',
+      '        "priority:medium": 2',
+      '        "priority:low": 3',
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+}

--- a/tests/doctor-github.test.ts
+++ b/tests/doctor-github.test.ts
@@ -117,6 +117,32 @@ describe("GitHub Project validation", () => {
     });
     expect(githubApi.createLabel).not.toHaveBeenCalled();
   });
+
+  it("reports label-listing failures without throwing", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockRejectedValue(new Error("rate limited")),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runDoctor({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "projects.symphonika.tracker.repository pmatos/symphonika labels could not be listed: rate limited"
+    );
+    expect(report.projects[0]).toMatchObject({
+      missingOperationalLabels: [],
+      validForDispatch: false
+    });
+  });
 });
 
 describe("GitHub Project initialization", () => {
@@ -216,6 +242,39 @@ describe("GitHub Project initialization", () => {
       "create:sym:failed",
       "create:sym:stale"
     ]);
+  });
+
+  it("reports createLabel failures without throwing during confirmed initialization", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const createLabel: GitHubApi["createLabel"] = (input) => {
+      if (input.name === "sym:stale") {
+        return Promise.reject(new Error("already exists"));
+      }
+      return Promise.resolve();
+    };
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(createLabel),
+      listLabels: vi.fn().mockResolvedValue(["sym:claimed", "sym:failed"]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runInitProject({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      yes: true
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "projects.symphonika.tracker.repository pmatos/symphonika could not create operational label sym:stale: already exists"
+    );
+    expect(report.projects[0]).toMatchObject({
+      createdOperationalLabels: ["sym:running"],
+      missingOperationalLabels: ["sym:running", "sym:stale"]
+    });
   });
 });
 

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { buildCli } from "../src/cli.js";
+import {
+  REQUIRED_OPERATIONAL_LABELS,
+  runDoctor,
+  type GitHubApi
+} from "../src/doctor.js";
 
 const tempRoots: string[] = [];
 const originalGithubToken = process.env.GITHUB_TOKEN;
@@ -204,10 +209,18 @@ describe("doctor", () => {
 });
 
 async function runDoctorCommand(
-  configPath: string
+  configPath: string,
+  githubApi: GitHubApi = successfulGitHubApi()
 ): Promise<{ stderr: string; stdout: string }> {
   const output = { stderr: "", stdout: "" };
-  const program = buildCli({ registerSignalHandlers: false });
+  const program = buildCli({
+    registerSignalHandlers: false,
+    runDoctor: (options) =>
+      runDoctor({
+        ...options,
+        githubApi
+      })
+  });
   program.configureOutput({
     writeErr: (message) => {
       output.stderr += message;
@@ -226,6 +239,14 @@ async function runDoctorCommand(
   ]);
 
   return output;
+}
+
+function successfulGitHubApi(): GitHubApi {
+  return {
+    createLabel: () => Promise.resolve(),
+    listLabels: () => Promise.resolve([...REQUIRED_OPERATIONAL_LABELS]),
+    validateRepositoryAccess: () => Promise.resolve({ ok: true })
+  };
 }
 
 async function writeValidConfig(


### PR DESCRIPTION
## Summary

- connect doctor validation to GitHub repository access and required operational labels
- add init-project label creation behind explicit --yes confirmation
- add mocked GitHub API tests for access failures, missing labels, and confirmed creation

Closes #4

## Validation

- npm test
- npm run typecheck
- npm run lint
- npm run build