### PR TITLE
[codex] Poll GitHub issue snapshots

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,12 +3,22 @@ import type { Logger } from "pino";
 import pino from "pino";
 
 import { createHttpApp } from "./http/app.js";
+import type {
+  GitHubIssuesApi,
+  PollConfiguredGitHubIssuesOptions
+} from "./issue-polling.js";
+import {
+  emptyIssuePollStatus,
+  pollConfiguredGitHubIssues
+} from "./issue-polling.js";
 import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
 
 export type StartDaemonOptions = {
   configPath?: string;
   cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  githubIssuesApi?: GitHubIssuesApi;
   host?: string;
   logger?: Logger;
   port?: number;
@@ -36,7 +46,21 @@ export async function startDaemon(
     stateRootOptions.cwd = options.cwd;
   }
   const state = resolveStateRoot(stateRootOptions);
+  let issuePollStatus = emptyIssuePollStatus();
+  if (state.configExists) {
+    const pollOptions: PollConfiguredGitHubIssuesOptions = {
+      configPath: state.configPath
+    };
+    if (options.env !== undefined) {
+      pollOptions.env = options.env;
+    }
+    if (options.githubIssuesApi !== undefined) {
+      pollOptions.githubIssuesApi = options.githubIssuesApi;
+    }
+    issuePollStatus = await pollConfiguredGitHubIssues(pollOptions);
+  }
   const app = createHttpApp({
+    issuePollStatus,
     stateRoot: state.stateRoot,
     version: VERSION
   });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -9,7 +9,9 @@ import type {
 } from "./issue-polling.js";
 import {
   emptyIssuePollStatus,
-  pollConfiguredGitHubIssues
+  pollConfiguredGitHubIssues,
+  readConfiguredPollingIntervalMs,
+  replaceIssuePollStatus
 } from "./issue-polling.js";
 import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
@@ -46,18 +48,37 @@ export async function startDaemon(
     stateRootOptions.cwd = options.cwd;
   }
   const state = resolveStateRoot(stateRootOptions);
-  let issuePollStatus = emptyIssuePollStatus();
+  const issuePollStatus = emptyIssuePollStatus();
+  let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let polling = false;
+  const refreshIssuePollStatus = async (): Promise<void> => {
+    if (!state.configExists || polling) {
+      return;
+    }
+
+    polling = true;
+    try {
+      replaceIssuePollStatus(
+        issuePollStatus,
+        await pollConfiguredGitHubIssues(issuePollOptions(state.configPath, options))
+      );
+    } catch (error) {
+      issuePollStatus.errors = [errorMessage(error)];
+      issuePollStatus.projects = [];
+      issuePollStatus.candidateIssues = [];
+      issuePollStatus.filteredIssues = [];
+    } finally {
+      polling = false;
+    }
+  };
+
   if (state.configExists) {
-    const pollOptions: PollConfiguredGitHubIssuesOptions = {
-      configPath: state.configPath
-    };
-    if (options.env !== undefined) {
-      pollOptions.env = options.env;
-    }
-    if (options.githubIssuesApi !== undefined) {
-      pollOptions.githubIssuesApi = options.githubIssuesApi;
-    }
-    issuePollStatus = await pollConfiguredGitHubIssues(pollOptions);
+    await refreshIssuePollStatus();
+    const intervalMs = await readConfiguredPollingIntervalMs(state.configPath);
+    pollTimer = setInterval(() => {
+      void refreshIssuePollStatus();
+    }, intervalMs);
+    pollTimer.unref?.();
   }
   const app = createHttpApp({
     issuePollStatus,
@@ -89,8 +110,29 @@ export async function startDaemon(
     port,
     stateRoot: state.stateRoot,
     url,
-    stop: () => stopServer(server, logger)
+    stop: () => {
+      if (pollTimer !== undefined) {
+        clearInterval(pollTimer);
+      }
+      return stopServer(server, logger);
+    }
   };
+}
+
+function issuePollOptions(
+  configPath: string,
+  options: StartDaemonOptions
+): PollConfiguredGitHubIssuesOptions {
+  const pollOptions: PollConfiguredGitHubIssuesOptions = {
+    configPath
+  };
+  if (options.env !== undefined) {
+    pollOptions.env = options.env;
+  }
+  if (options.githubIssuesApi !== undefined) {
+    pollOptions.githubIssuesApi = options.githubIssuesApi;
+  }
+  return pollOptions;
 }
 
 function waitForListening(server: ServerType): Promise<void> {
@@ -126,4 +168,8 @@ function stopServer(server: ServerType, logger: Logger): Promise<void> {
       resolve();
     });
   });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,6 +4,10 @@ import { Octokit } from "@octokit/rest";
 import { parse } from "yaml";
 import { z } from "zod";
 
+import { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
+
+export { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
+
 export type DoctorOptions = {
   configPath?: string;
   cwd?: string;
@@ -74,13 +78,6 @@ type LabelDescription = {
   color: string;
   description: string;
 };
-
-export const REQUIRED_OPERATIONAL_LABELS = [
-  "sym:claimed",
-  "sym:running",
-  "sym:failed",
-  "sym:stale"
-] as const;
 
 const OPERATIONAL_LABEL_DESCRIPTIONS: Record<
   (typeof REQUIRED_OPERATIONAL_LABELS)[number],

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -1,6 +1,10 @@
 import { Hono } from "hono";
 
+import type { IssuePollStatus } from "../issue-polling.js";
+import { emptyIssuePollStatus } from "../issue-polling.js";
+
 export type HttpAppOptions = {
+  issuePollStatus?: IssuePollStatus;
   stateRoot: string;
   version: string;
   startedAtMs?: number;
@@ -11,6 +15,7 @@ export function createHttpApp(options: HttpAppOptions): Hono {
   const app = new Hono();
   const startedAtMs = options.startedAtMs ?? Date.now();
   const now = options.now ?? Date.now;
+  const issuePollStatus = options.issuePollStatus ?? emptyIssuePollStatus();
 
   app.get("/health", (context) =>
     context.json({
@@ -24,6 +29,12 @@ export function createHttpApp(options: HttpAppOptions): Hono {
 
   app.get("/api/status", (context) =>
     context.json({
+      candidateIssues: issuePollStatus.candidateIssues,
+      filteredIssues: issuePollStatus.filteredIssues,
+      issuePolling: {
+        errors: issuePollStatus.errors,
+        projects: issuePollStatus.projects
+      },
       service: "symphonika",
       state: "idle",
       dispatching: false,

--- a/src/issue-polling.ts
+++ b/src/issue-polling.ts
@@ -1,0 +1,409 @@
+import { readFile } from "node:fs/promises";
+import { Octokit } from "@octokit/rest";
+import { parse } from "yaml";
+import { z } from "zod";
+
+import { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
+
+export type GitHubIssueRepositoryInput = {
+  owner: string;
+  repo: string;
+  token: string;
+};
+
+export type RawGitHubIssue = {
+  body?: string | null;
+  created_at?: string | null;
+  html_url?: string | null;
+  id?: number;
+  labels?: unknown[];
+  number?: number;
+  pull_request?: unknown;
+  state?: string;
+  title?: string;
+  updated_at?: string | null;
+  url?: string | null;
+};
+
+export type GitHubIssuesApi = {
+  listOpenIssues: (
+    input: GitHubIssueRepositoryInput
+  ) => Promise<RawGitHubIssue[]>;
+};
+
+export type IssueSnapshot = {
+  body: string;
+  created_at: string;
+  id: number;
+  labels: string[];
+  number: number;
+  priority: number;
+  state: string;
+  title: string;
+  updated_at: string;
+  url: string;
+};
+
+export type ProjectIssueSnapshot = {
+  issue: IssueSnapshot;
+  project: string;
+};
+
+export type FilteredProjectIssueSnapshot = ProjectIssueSnapshot & {
+  reasons: string[];
+};
+
+export type ProjectIssuePollReport = {
+  fetchedIssues: number;
+  name: string;
+  ok: boolean;
+  error?: string;
+};
+
+export type IssuePollStatus = {
+  candidateIssues: ProjectIssueSnapshot[];
+  errors: string[];
+  filteredIssues: FilteredProjectIssueSnapshot[];
+  projects: ProjectIssuePollReport[];
+};
+
+export type PollConfiguredGitHubIssuesOptions = {
+  configPath: string;
+  env?: NodeJS.ProcessEnv;
+  githubIssuesApi?: GitHubIssuesApi;
+};
+
+type PollingServiceConfig = z.infer<typeof pollingServiceConfigSchema>;
+type PollingProjectConfig = z.infer<typeof pollingProjectSchema>;
+
+const providerNameSchema = z.enum(["codex", "claude"]);
+
+const pollingProjectSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    disabled: z.boolean().optional(),
+    tracker: z
+      .object({
+        kind: z.literal("github"),
+        owner: z.string().trim().min(1),
+        repo: z.string().trim().min(1),
+        token: z.string().trim().min(1)
+      })
+      .passthrough(),
+    issue_filters: z
+      .object({
+        states: z.array(z.literal("open")).min(1),
+        labels_all: z.array(z.string().trim().min(1)),
+        labels_none: z.array(z.string().trim().min(1))
+      })
+      .passthrough(),
+    priority: z
+      .object({
+        labels: z.record(z.number().int().nonnegative()),
+        default: z.number().int().nonnegative()
+      })
+      .passthrough(),
+    agent: z
+      .object({
+        provider: providerNameSchema
+      })
+      .passthrough()
+  })
+  .passthrough();
+
+const pollingServiceConfigSchema = z
+  .object({
+    projects: z.array(pollingProjectSchema).min(1)
+  })
+  .passthrough();
+
+const SILENT_OCTOKIT_LOG = {
+  debug: () => undefined,
+  error: () => undefined,
+  info: () => undefined,
+  warn: () => undefined
+};
+
+class OctokitGitHubIssuesApi implements GitHubIssuesApi {
+  async listOpenIssues(
+    input: GitHubIssueRepositoryInput
+  ): Promise<RawGitHubIssue[]> {
+    const octokit = new Octokit({
+      auth: input.token,
+      log: SILENT_OCTOKIT_LOG
+    });
+    const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
+      owner: input.owner,
+      per_page: 100,
+      repo: input.repo,
+      state: "open"
+    });
+
+    return issues;
+  }
+}
+
+const DEFAULT_GITHUB_ISSUES_API = new OctokitGitHubIssuesApi();
+
+export function emptyIssuePollStatus(): IssuePollStatus {
+  return {
+    candidateIssues: [],
+    errors: [],
+    filteredIssues: [],
+    projects: []
+  };
+}
+
+export async function pollConfiguredGitHubIssues(
+  options: PollConfiguredGitHubIssuesOptions
+): Promise<IssuePollStatus> {
+  const env = options.env ?? process.env;
+  const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
+  const status = emptyIssuePollStatus();
+  const config = await readPollingConfig(options.configPath, status.errors);
+
+  if (config === undefined) {
+    return status;
+  }
+
+  for (const project of config.projects) {
+    if (project.disabled === true) {
+      continue;
+    }
+
+    await pollProject(project, env, githubIssuesApi, status);
+  }
+
+  status.candidateIssues.sort(compareProjectIssues);
+  status.filteredIssues.sort(compareProjectIssues);
+
+  return status;
+}
+
+async function pollProject(
+  project: PollingProjectConfig,
+  env: NodeJS.ProcessEnv,
+  githubIssuesApi: GitHubIssuesApi,
+  status: IssuePollStatus
+): Promise<void> {
+  const token = resolveEnvBackedValue(project.tracker.token, env);
+  if (token === undefined) {
+    const variableName = envReferenceName(project.tracker.token);
+    const error =
+      variableName === undefined
+        ? `projects.${project.name}.tracker.token must reference an environment variable like $GITHUB_TOKEN`
+        : `projects.${project.name}.tracker.token references unset environment variable $${variableName}`;
+    status.errors.push(error);
+    status.projects.push({
+      error,
+      fetchedIssues: 0,
+      name: project.name,
+      ok: false
+    });
+    return;
+  }
+
+  let rawIssues: RawGitHubIssue[];
+  try {
+    rawIssues = await githubIssuesApi.listOpenIssues({
+      owner: project.tracker.owner,
+      repo: project.tracker.repo,
+      token
+    });
+  } catch (error) {
+    const message = `projects.${project.name}.tracker.repository ${project.tracker.owner}/${project.tracker.repo} issues could not be listed: ${errorMessage(error)}`;
+    status.errors.push(message);
+    status.projects.push({
+      error: message,
+      fetchedIssues: 0,
+      name: project.name,
+      ok: false
+    });
+    return;
+  }
+
+  let fetchedIssues = 0;
+  for (const rawIssue of rawIssues) {
+    if (rawIssue.pull_request !== undefined) {
+      continue;
+    }
+
+    fetchedIssues += 1;
+    const issue = normalizeIssueSnapshot(rawIssue, project);
+    const reasons = issueFilterReasons(issue, project);
+
+    if (reasons.length === 0) {
+      status.candidateIssues.push({
+        issue,
+        project: project.name
+      });
+      continue;
+    }
+
+    status.filteredIssues.push({
+      issue,
+      project: project.name,
+      reasons
+    });
+  }
+
+  status.projects.push({
+    fetchedIssues,
+    name: project.name,
+    ok: true
+  });
+}
+
+async function readPollingConfig(
+  configPath: string,
+  errors: string[]
+): Promise<PollingServiceConfig | undefined> {
+  let contents: string;
+
+  try {
+    contents = await readFile(configPath, "utf8");
+  } catch (error) {
+    errors.push(`service config not found at ${configPath}: ${errorMessage(error)}`);
+    return undefined;
+  }
+
+  let rawConfig: unknown;
+  try {
+    rawConfig = parse(contents) ?? {};
+  } catch (error) {
+    errors.push(`service config could not be parsed: ${errorMessage(error)}`);
+    return undefined;
+  }
+
+  const parsed = pollingServiceConfigSchema.safeParse(rawConfig);
+  if (!parsed.success) {
+    errors.push(...parsed.error.issues.map(formatZodIssue));
+    return undefined;
+  }
+
+  return parsed.data;
+}
+
+function normalizeIssueSnapshot(
+  rawIssue: RawGitHubIssue,
+  project: PollingProjectConfig
+): IssueSnapshot {
+  const labels = normalizeLabels(rawIssue.labels ?? []);
+
+  return {
+    body: rawIssue.body ?? "",
+    created_at: rawIssue.created_at ?? "",
+    id: rawIssue.id ?? 0,
+    labels,
+    number: rawIssue.number ?? 0,
+    priority: priorityForLabels(labels, project),
+    state: rawIssue.state ?? "open",
+    title: rawIssue.title ?? "",
+    updated_at: rawIssue.updated_at ?? "",
+    url: rawIssue.html_url ?? rawIssue.url ?? ""
+  };
+}
+
+function normalizeLabels(labels: unknown[]): string[] {
+  const normalized: string[] = [];
+
+  for (const label of labels) {
+    if (typeof label === "string") {
+      normalized.push(label);
+      continue;
+    }
+
+    if (isRecord(label) && typeof label.name === "string") {
+      normalized.push(label.name);
+    }
+  }
+
+  return normalized;
+}
+
+function priorityForLabels(
+  labels: string[],
+  project: PollingProjectConfig
+): number {
+  const priorities = labels.flatMap((label) => {
+    const priority = project.priority.labels[label];
+    return priority === undefined ? [] : [priority];
+  });
+
+  return priorities.length === 0 ? project.priority.default : Math.min(...priorities);
+}
+
+function issueFilterReasons(
+  issue: IssueSnapshot,
+  project: PollingProjectConfig
+): string[] {
+  const reasons: string[] = [];
+  const labels = new Set(issue.labels);
+
+  if (!project.issue_filters.states.includes("open") || issue.state !== "open") {
+    reasons.push(`state ${issue.state} is not eligible`);
+  }
+
+  for (const requiredLabel of project.issue_filters.labels_all) {
+    if (!labels.has(requiredLabel)) {
+      reasons.push(`missing required label ${requiredLabel}`);
+    }
+  }
+
+  for (const excludedLabel of project.issue_filters.labels_none) {
+    if (labels.has(excludedLabel)) {
+      reasons.push(`has excluded label ${excludedLabel}`);
+    }
+  }
+
+  for (const operationalLabel of REQUIRED_OPERATIONAL_LABELS) {
+    if (labels.has(operationalLabel)) {
+      reasons.push(`has operational label ${operationalLabel}`);
+    }
+  }
+
+  return reasons;
+}
+
+function compareProjectIssues(
+  left: ProjectIssueSnapshot,
+  right: ProjectIssueSnapshot
+): number {
+  return (
+    left.project.localeCompare(right.project) ||
+    left.issue.priority - right.issue.priority ||
+    left.issue.created_at.localeCompare(right.issue.created_at) ||
+    left.issue.number - right.issue.number
+  );
+}
+
+function resolveEnvBackedValue(
+  input: string,
+  env: NodeJS.ProcessEnv
+): string | undefined {
+  const variableName = envReferenceName(input);
+  if (variableName === undefined) {
+    return undefined;
+  }
+
+  const value = env[variableName];
+  return value === undefined || value.length === 0 ? undefined : value;
+}
+
+function envReferenceName(input: string): string | undefined {
+  const match = /^\$([A-Za-z_][A-Za-z0-9_]*)$/.exec(input);
+  return match?.[1];
+}
+
+function formatZodIssue(issue: z.ZodIssue): string {
+  const location = issue.path.length === 0 ? "service config" : issue.path.join(".");
+  return `${location}: ${issue.message}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/issue-polling.ts
+++ b/src/issue-polling.ts
@@ -73,8 +73,13 @@ export type PollConfiguredGitHubIssuesOptions = {
   githubIssuesApi?: GitHubIssuesApi;
 };
 
-type PollingServiceConfig = z.infer<typeof pollingServiceConfigSchema>;
 type PollingProjectConfig = z.infer<typeof pollingProjectSchema>;
+type PollingServiceConfig = {
+  polling?: {
+    interval_ms?: number | undefined;
+  };
+  projects: PollingProjectConfig[];
+};
 
 const providerNameSchema = z.enum(["codex", "claude"]);
 
@@ -113,7 +118,13 @@ const pollingProjectSchema = z
 
 const pollingServiceConfigSchema = z
   .object({
-    projects: z.array(pollingProjectSchema).min(1)
+    polling: z
+      .object({
+        interval_ms: z.number().int().positive().optional()
+      })
+      .passthrough()
+      .optional(),
+    projects: z.array(z.unknown()).min(1)
   })
   .passthrough();
 
@@ -144,6 +155,7 @@ class OctokitGitHubIssuesApi implements GitHubIssuesApi {
 }
 
 const DEFAULT_GITHUB_ISSUES_API = new OctokitGitHubIssuesApi();
+export const DEFAULT_POLLING_INTERVAL_MS = 30_000;
 
 export function emptyIssuePollStatus(): IssuePollStatus {
   return {
@@ -152,6 +164,23 @@ export function emptyIssuePollStatus(): IssuePollStatus {
     filteredIssues: [],
     projects: []
   };
+}
+
+export function replaceIssuePollStatus(
+  target: IssuePollStatus,
+  source: IssuePollStatus
+): void {
+  target.candidateIssues = source.candidateIssues;
+  target.errors = source.errors;
+  target.filteredIssues = source.filteredIssues;
+  target.projects = source.projects;
+}
+
+export async function readConfiguredPollingIntervalMs(
+  configPath: string
+): Promise<number> {
+  const config = await readPollingConfig(configPath, []);
+  return config?.polling?.interval_ms ?? DEFAULT_POLLING_INTERVAL_MS;
 }
 
 export async function pollConfiguredGitHubIssues(
@@ -281,7 +310,29 @@ async function readPollingConfig(
     return undefined;
   }
 
-  return parsed.data;
+  const projects: PollingProjectConfig[] = [];
+  parsed.data.projects.forEach((rawProject, index) => {
+    const parsedProject = pollingProjectSchema.safeParse(rawProject);
+    if (parsedProject.success) {
+      projects.push(parsedProject.data);
+      return;
+    }
+
+    errors.push(
+      ...parsedProject.error.issues.map((issue) =>
+        formatZodIssueWithPrefix(issue, ["projects", String(index)])
+      )
+    );
+  });
+
+  const config: PollingServiceConfig = {
+    projects
+  };
+  if (parsed.data.polling !== undefined) {
+    config.polling = parsed.data.polling;
+  }
+
+  return config;
 }
 
 function normalizeIssueSnapshot(
@@ -397,6 +448,14 @@ function envReferenceName(input: string): string | undefined {
 
 function formatZodIssue(issue: z.ZodIssue): string {
   const location = issue.path.length === 0 ? "service config" : issue.path.join(".");
+  return `${location}: ${issue.message}`;
+}
+
+function formatZodIssueWithPrefix(
+  issue: z.ZodIssue,
+  prefix: string[]
+): string {
+  const location = [...prefix, ...issue.path].join(".");
   return `${location}: ${issue.message}`;
 }
 

--- a/src/operational-labels.ts
+++ b/src/operational-labels.ts
@@ -1,0 +1,6 @@
+export const REQUIRED_OPERATIONAL_LABELS = [
+  "sym:claimed",
+  "sym:running",
+  "sym:failed",
+  "sym:stale"
+] as const;

--- a/tests/daemon-issue-polling.test.ts
+++ b/tests/daemon-issue-polling.test.ts
@@ -221,6 +221,100 @@ describe("daemon GitHub issue polling", () => {
       await daemon.stop();
     }
   });
+
+  it("refreshes issue snapshots on the configured polling interval", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root, { pollingIntervalMs: 10 });
+    const githubIssuesApi = {
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 30,
+            title: "Startup snapshot"
+          })
+        ])
+        .mockResolvedValue([
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 31,
+            title: "Refreshed snapshot"
+          })
+        ])
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      await waitFor(async () => {
+        const response = await fetch(`${daemon.url}/api/status`);
+        const body = (await response.json()) as {
+          candidateIssues: Array<{ issue: { number: number } }>;
+        };
+
+        return (
+          githubIssuesApi.listOpenIssues.mock.calls.length >= 2 &&
+          body.candidateIssues.map((entry) => entry.issue.number).includes(31)
+        );
+      });
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("continues polling valid projects when another project entry is invalid", async () => {
+    const root = await makeTempRoot();
+    await writeConfigWithInvalidAndValidProjects(root);
+    const githubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 40,
+          title: "Valid project issue"
+        })
+      ])
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      const response = await fetch(`${daemon.url}/api/status`);
+      const body = (await response.json()) as {
+        candidateIssues: Array<{ issue: { number: number }; project: string }>;
+        issuePolling: { errors: string[] };
+      };
+
+      expect(githubIssuesApi.listOpenIssues).toHaveBeenCalledWith({
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret-token"
+      });
+      expect(
+        body.candidateIssues.map((entry) => ({
+          number: entry.issue.number,
+          project: entry.project
+        }))
+      ).toEqual([{ number: 40, project: "symphonika" }]);
+      expect(body.issuePolling.errors.join("\n")).toContain(
+        "projects.0.tracker.repo"
+      );
+    } finally {
+      await daemon.stop();
+    }
+  });
 });
 
 function issueFixture(overrides: {
@@ -251,7 +345,10 @@ function issueFixture(overrides: {
   };
 }
 
-async function writeValidProject(root: string): Promise<void> {
+async function writeValidProject(
+  root: string,
+  options: { pollingIntervalMs?: number } = {}
+): Promise<void> {
   await mkdir(root, { recursive: true });
   await writeFile(
     path.join(root, "symphonika.yml"),
@@ -259,7 +356,7 @@ async function writeValidProject(root: string): Promise<void> {
       "state:",
       "  root: ./.symphonika",
       "polling:",
-      "  interval_ms: 30000",
+      `  interval_ms: ${options.pollingIntervalMs ?? 30000}`,
       "providers:",
       "  codex:",
       '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
@@ -297,4 +394,72 @@ async function writeValidProject(root: string): Promise<void> {
     ].join("\n")
   );
   await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+}
+
+async function writeConfigWithInvalidAndValidProjects(root: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: malformed",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    agent:",
+      "      provider: codex",
+      "  - name: symphonika",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    agent:",
+      "      provider: codex",
+      ""
+    ].join("\n")
+  );
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 1_000;
+  const intervalMs = options.intervalMs ?? 10;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error("condition was not met before timeout");
 }

--- a/tests/daemon-issue-polling.test.ts
+++ b/tests/daemon-issue-polling.test.ts
@@ -1,0 +1,300 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-polling-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("daemon GitHub issue polling", () => {
+  it("exposes normalized eligible issue snapshots through the status API", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        {
+          body: "Implement the polling slice.",
+          created_at: "2026-04-20T10:00:00Z",
+          html_url: "https://github.com/pmatos/symphonika/issues/5",
+          id: 5005,
+          labels: [{ name: "agent-ready" }, { name: "priority:high" }],
+          number: 5,
+          state: "open",
+          title: "Poll GitHub and display eligible issue snapshots",
+          updated_at: "2026-04-21T11:00:00Z"
+        }
+      ])
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      const response = await fetch(`${daemon.url}/api/status`);
+      const body: unknown = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(githubIssuesApi.listOpenIssues).toHaveBeenCalledWith({
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret-token"
+      });
+      expect(body).toMatchObject({
+        candidateIssues: [
+          {
+            issue: {
+              body: "Implement the polling slice.",
+              created_at: "2026-04-20T10:00:00Z",
+              id: 5005,
+              labels: ["agent-ready", "priority:high"],
+              number: 5,
+              priority: 1,
+              state: "open",
+              title: "Poll GitHub and display eligible issue snapshots",
+              updated_at: "2026-04-21T11:00:00Z",
+              url: "https://github.com/pmatos/symphonika/issues/5"
+            },
+            project: "symphonika"
+          }
+        ],
+        filteredIssues: []
+      });
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("shows filtered snapshots when required, excluded, or operational labels block eligibility", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["priority:low"],
+          number: 10,
+          title: "Missing required label"
+        }),
+        issueFixture({
+          labels: ["agent-ready", "blocked"],
+          number: 11,
+          title: "Blocked by workflow label"
+        }),
+        issueFixture({
+          labels: ["agent-ready", "sym:running"],
+          number: 12,
+          title: "Already running"
+        }),
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 13,
+          title: "Ready to work"
+        })
+      ])
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      const response = await fetch(`${daemon.url}/api/status`);
+      const body = (await response.json()) as {
+        candidateIssues: Array<{ issue: { number: number } }>;
+        filteredIssues: Array<{
+          issue: { number: number };
+          reasons: string[];
+        }>;
+      };
+
+      expect(body.candidateIssues.map((entry) => entry.issue.number)).toEqual([
+        13
+      ]);
+      expect(
+        body.filteredIssues.map((entry) => ({
+          number: entry.issue.number,
+          reasons: entry.reasons
+        }))
+      ).toEqual([
+        {
+          number: 10,
+          reasons: ["missing required label agent-ready"]
+        },
+        {
+          number: 11,
+          reasons: ["has excluded label blocked"]
+        },
+        {
+          number: 12,
+          reasons: ["has operational label sym:running"]
+        }
+      ]);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("sorts candidate snapshots by priority and ignores pull requests from the issues endpoint", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready", "priority:low"],
+          number: 20,
+          title: "Low priority issue"
+        }),
+        issueFixture({
+          labels: ["agent-ready", "priority:critical"],
+          number: 21,
+          title: "Critical issue"
+        }),
+        {
+          ...issueFixture({
+            labels: ["agent-ready", "priority:critical"],
+            number: 22,
+            title: "Pull request returned by issues endpoint"
+          }),
+          pull_request: {
+            html_url: "https://github.com/pmatos/symphonika/pull/22"
+          }
+        },
+        issueFixture({
+          labels: ["agent-ready", "priority:medium"],
+          number: 23,
+          title: "Medium priority issue"
+        })
+      ])
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      const response = await fetch(`${daemon.url}/api/status`);
+      const body = (await response.json()) as {
+        candidateIssues: Array<{
+          issue: { number: number; priority: number };
+        }>;
+      };
+
+      expect(
+        body.candidateIssues.map((entry) => ({
+          number: entry.issue.number,
+          priority: entry.issue.priority
+        }))
+      ).toEqual([
+        { number: 21, priority: 0 },
+        { number: 23, priority: 2 },
+        { number: 20, priority: 3 }
+      ]);
+    } finally {
+      await daemon.stop();
+    }
+  });
+});
+
+function issueFixture(overrides: {
+  labels: unknown[];
+  number: number;
+  title: string;
+}): {
+  body: string;
+  created_at: string;
+  html_url: string;
+  id: number;
+  labels: unknown[];
+  number: number;
+  state: string;
+  title: string;
+  updated_at: string;
+} {
+  return {
+    body: `${overrides.title} body.`,
+    created_at: "2026-04-20T10:00:00Z",
+    html_url: `https://github.com/pmatos/symphonika/issues/${overrides.number}`,
+    id: 5000 + overrides.number,
+    labels: overrides.labels,
+    number: overrides.number,
+    state: "open",
+    title: overrides.title,
+    updated_at: "2026-04-21T11:00:00Z"
+  };
+}
+
+async function writeValidProject(root: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels:",
+      '        "priority:critical": 0',
+      '        "priority:high": 1',
+      '        "priority:medium": 2',
+      '        "priority:low": 3',
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+}

--- a/tests/http-app.test.ts
+++ b/tests/http-app.test.ts
@@ -37,9 +37,15 @@ describe("HTTP app", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({
+      candidateIssues: [],
+      dispatching: false,
+      filteredIssues: [],
+      issuePolling: {
+        errors: [],
+        projects: []
+      },
       service: "symphonika",
       state: "idle",
-      dispatching: false,
       stateRoot: "/tmp/symphonika-state",
       uptimeMs: 100
     });


### PR DESCRIPTION
## Summary

- Adds a read-only GitHub issue polling path for configured Symphonika Projects.
- Normalizes open issue snapshots with the fields required by `SPEC.md`, computes priority labels, filters by required/excluded/operational labels, and skips PR-shaped entries returned by the GitHub issues endpoint.
- Exposes candidate and filtered issue snapshots through `/api/status` without claiming or dispatching work.

Closes #5.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`