### PR TITLE
[codex] Prepare deterministic Git workspaces

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,244 @@
+import { execFile } from "node:child_process";
+import { mkdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type WorkspaceProject = {
+  name: string;
+  workspace: {
+    git: {
+      base_branch: string;
+      remote: string;
+    };
+    root: string;
+  };
+};
+
+export type WorkspaceIssue = {
+  number: number;
+  title: string;
+};
+
+export type PrepareIssueWorkspaceInput = {
+  configDir?: string;
+  issue: WorkspaceIssue;
+  project: WorkspaceProject;
+};
+
+export type PreparedIssueWorkspace = {
+  branchName: string;
+  branchRef: string;
+  cachePath: string;
+  issueDirectoryName: string;
+  reused: boolean;
+  workspacePath: string;
+};
+
+export type WorkspacePreparationErrorCode =
+  | "branch_conflict"
+  | "workspace_conflict";
+
+export class WorkspacePreparationError extends Error {
+  readonly code: WorkspacePreparationErrorCode;
+
+  constructor(
+    code: WorkspacePreparationErrorCode,
+    message: string,
+    cause?: unknown
+  ) {
+    if (cause === undefined) {
+      super(message);
+    } else {
+      super(message, { cause });
+    }
+    this.name = "WorkspacePreparationError";
+    this.code = code;
+  }
+}
+
+export async function prepareIssueWorkspace(
+  input: PrepareIssueWorkspaceInput
+): Promise<PreparedIssueWorkspace> {
+  const prepared = issueWorkspacePaths(input);
+
+  await ensureRepositoryCache(input.project, prepared.cachePath);
+  await ensureIssueBranch(input.project, prepared.cachePath, prepared.branchName);
+  if (await exists(prepared.workspacePath)) {
+    let currentBranch: string;
+    try {
+      currentBranch = await git([
+        "-C",
+        prepared.workspacePath,
+        "rev-parse",
+        "--abbrev-ref",
+        "HEAD"
+      ]);
+    } catch (error) {
+      throw new WorkspacePreparationError(
+        "workspace_conflict",
+        `workspace path ${prepared.workspacePath} exists but is not a reusable Git worktree for ${prepared.branchName}`,
+        error
+      );
+    }
+
+    if (currentBranch === prepared.branchName) {
+      return {
+        ...prepared,
+        reused: true
+      };
+    }
+
+    throw new WorkspacePreparationError(
+      "workspace_conflict",
+      `workspace path ${prepared.workspacePath} is already checked out on ${currentBranch}, expected ${prepared.branchName}`
+    );
+  }
+
+  const conflictingWorktreePath = await worktreePathForBranch(
+    prepared.cachePath,
+    prepared.branchName
+  );
+  if (conflictingWorktreePath !== undefined) {
+    throw new WorkspacePreparationError(
+      "branch_conflict",
+      `issue branch ${prepared.branchName} is already checked out at ${conflictingWorktreePath}`
+    );
+  }
+
+  await mkdir(path.dirname(prepared.workspacePath), { recursive: true });
+  await git([
+    "-C",
+    prepared.cachePath,
+    "worktree",
+    "add",
+    prepared.workspacePath,
+    prepared.branchName
+  ]);
+
+  return prepared;
+}
+
+async function worktreePathForBranch(
+  cachePath: string,
+  branchName: string
+): Promise<string | undefined> {
+  const output = await git(["-C", cachePath, "worktree", "list", "--porcelain"]);
+  let currentWorktreePath: string | undefined;
+  const expectedBranchLine = `branch refs/heads/${branchName}`;
+
+  for (const line of output.split(/\r?\n/)) {
+    if (line.startsWith("worktree ")) {
+      currentWorktreePath = line.slice("worktree ".length);
+      continue;
+    }
+
+    if (line === expectedBranchLine) {
+      return currentWorktreePath;
+    }
+  }
+
+  return undefined;
+}
+
+function issueWorkspacePaths(
+  input: PrepareIssueWorkspaceInput
+): PreparedIssueWorkspace {
+  const projectSlug = slugify(input.project.name, "project");
+  const issueSlug = slugify(input.issue.title, "issue");
+  const issueDirectoryName = `${input.issue.number}-${issueSlug}`;
+  const workspaceRoot = path.resolve(
+    input.configDir ?? process.cwd(),
+    input.project.workspace.root
+  );
+  const branchName = `sym/${projectSlug}/${issueDirectoryName}`;
+
+  return {
+    branchName,
+    branchRef: `refs/heads/${branchName}`,
+    cachePath: path.join(workspaceRoot, ".cache", "repo.git"),
+    issueDirectoryName,
+    reused: false,
+    workspacePath: path.join(workspaceRoot, "issues", issueDirectoryName)
+  };
+}
+
+async function ensureRepositoryCache(
+  project: WorkspaceProject,
+  cachePath: string
+): Promise<void> {
+  if (!(await exists(cachePath))) {
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await git(["clone", "--bare", project.workspace.git.remote, cachePath]);
+  }
+
+  await git([
+    "-C",
+    cachePath,
+    "fetch",
+    "origin",
+    `${project.workspace.git.base_branch}:refs/remotes/origin/${project.workspace.git.base_branch}`
+  ]);
+}
+
+async function ensureIssueBranch(
+  project: WorkspaceProject,
+  cachePath: string,
+  branchName: string
+): Promise<void> {
+  if (await gitSucceeds(["-C", cachePath, "show-ref", "--verify", `refs/heads/${branchName}`])) {
+    return;
+  }
+
+  await git([
+    "-C",
+    cachePath,
+    "branch",
+    branchName,
+    `origin/${project.workspace.git.base_branch}`
+  ]);
+}
+
+function slugify(input: string, fallback: string): string {
+  const asciiInput = Array.from(input.normalize("NFKD"))
+    .filter((character) => character.charCodeAt(0) <= 0x7f)
+    .join("");
+  const slug = asciiInput
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug.length === 0 ? fallback : slug;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function git(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args);
+  return stdout.trim();
+}
+
+async function gitSucceeds(args: string[]): Promise<boolean> {
+  try {
+    await git(args);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -38,6 +38,7 @@ export type PreparedIssueWorkspace = {
 
 export type WorkspacePreparationErrorCode =
   | "branch_conflict"
+  | "cache_conflict"
   | "workspace_conflict";
 
 export class WorkspacePreparationError extends Error {
@@ -197,6 +198,8 @@ async function ensureRepositoryCache(
   if (!(await exists(cachePath))) {
     await mkdir(path.dirname(cachePath), { recursive: true });
     await git(["clone", "--bare", project.workspace.git.remote, cachePath]);
+  } else {
+    await ensureRepositoryCacheRemote(project, cachePath);
   }
 
   await git([
@@ -206,6 +209,29 @@ async function ensureRepositoryCache(
     "origin",
     `${project.workspace.git.base_branch}:refs/remotes/origin/${project.workspace.git.base_branch}`
   ]);
+}
+
+async function ensureRepositoryCacheRemote(
+  project: WorkspaceProject,
+  cachePath: string
+): Promise<void> {
+  let originUrl: string;
+  try {
+    originUrl = await git(["-C", cachePath, "config", "--get", "remote.origin.url"]);
+  } catch (error) {
+    throw new WorkspacePreparationError(
+      "cache_conflict",
+      `repository cache ${cachePath} is not a reusable Git repository with origin ${project.workspace.git.remote}`,
+      error
+    );
+  }
+
+  if (originUrl !== project.workspace.git.remote) {
+    throw new WorkspacePreparationError(
+      "cache_conflict",
+      `repository cache ${cachePath} has origin ${originUrl}, expected ${project.workspace.git.remote}`
+    );
+  }
 }
 
 async function ensureIssueBranch(

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
@@ -84,6 +84,13 @@ export async function prepareIssueWorkspace(
     }
 
     if (currentBranch === prepared.branchName) {
+      if (!(await isWorktreeForCache(prepared.workspacePath, prepared.cachePath))) {
+        throw new WorkspacePreparationError(
+          "workspace_conflict",
+          `workspace path ${prepared.workspacePath} is checked out on ${prepared.branchName} but is not linked to cache ${prepared.cachePath}`
+        );
+      }
+
       return {
         ...prepared,
         reused: true
@@ -118,6 +125,25 @@ export async function prepareIssueWorkspace(
   ]);
 
   return prepared;
+}
+
+async function isWorktreeForCache(
+  workspacePath: string,
+  cachePath: string
+): Promise<boolean> {
+  const commonDirectory = await git([
+    "-C",
+    workspacePath,
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-common-dir"
+  ]);
+  const [actualCommonDirectory, expectedCommonDirectory] = await Promise.all([
+    realpath(commonDirectory),
+    realpath(cachePath)
+  ]);
+
+  return actualCommonDirectory === expectedCommonDirectory;
 }
 
 async function worktreePathForBranch(

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -85,6 +85,13 @@ export async function prepareIssueWorkspace(
     }
 
     if (currentBranch === prepared.branchName) {
+      if (!(await isWorktreeRoot(prepared.workspacePath))) {
+        throw new WorkspacePreparationError(
+          "workspace_conflict",
+          `workspace path ${prepared.workspacePath} is checked out on ${prepared.branchName} but is not the Git worktree root`
+        );
+      }
+
       if (!(await isWorktreeForCache(prepared.workspacePath, prepared.cachePath))) {
         throw new WorkspacePreparationError(
           "workspace_conflict",
@@ -126,6 +133,21 @@ export async function prepareIssueWorkspace(
   ]);
 
   return prepared;
+}
+
+async function isWorktreeRoot(workspacePath: string): Promise<boolean> {
+  const topLevel = await git([
+    "-C",
+    workspacePath,
+    "rev-parse",
+    "--show-toplevel"
+  ]);
+  const [actualTopLevel, expectedTopLevel] = await Promise.all([
+    realpath(topLevel),
+    realpath(workspacePath)
+  ]);
+
+  return actualTopLevel === expectedTopLevel;
 }
 
 async function isWorktreeForCache(

--- a/tests/workspace-preparation.test.ts
+++ b/tests/workspace-preparation.test.ts
@@ -261,6 +261,53 @@ describe("Git workspace preparation", () => {
     ).resolves.toBe(wrongRemotePath);
   });
 
+  it("rejects a nested directory inside the issue branch worktree", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "symphonika");
+    const cachePath = path.join(workspaceRoot, ".cache", "repo.git");
+    const branchName =
+      "sym/symphonika/6-prepare-deterministic-git-workspaces-and-issue-branches";
+    const parentWorktreePath = path.join(workspaceRoot, "issues");
+    const nestedWorkspacePath = path.join(
+      parentWorktreePath,
+      "6-prepare-deterministic-git-workspaces-and-issue-branches"
+    );
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await git(["clone", "--bare", remotePath, cachePath]);
+    await git(["-C", cachePath, "fetch", "origin", "main:refs/remotes/origin/main"]);
+    await git(["-C", cachePath, "branch", branchName, "origin/main"]);
+    await git(["-C", cachePath, "worktree", "add", parentWorktreePath, branchName]);
+    await mkdir(nestedWorkspacePath);
+
+    const preparation = prepareIssueWorkspace({
+      issue: {
+        number: 6,
+        title: "Prepare deterministic Git workspaces and issue branches"
+      },
+      project: {
+        name: "symphonika",
+        workspace: {
+          git: {
+            base_branch: "main",
+            remote: remotePath
+          },
+          root: workspaceRoot
+        }
+      }
+    });
+
+    const error = await rejectionOf(preparation);
+    expect(error).toBeInstanceOf(WorkspacePreparationError);
+    if (!(error instanceof WorkspacePreparationError)) {
+      throw new Error("expected workspace preparation error");
+    }
+    expect(error.code).toBe("workspace_conflict");
+    await expect(
+      git(["-C", nestedWorkspacePath, "rev-parse", "--show-toplevel"])
+    ).resolves.toBe(parentWorktreePath);
+  });
+
   it("surfaces an issue branch checked out elsewhere as a deterministic conflict", async () => {
     const root = await makeTempRoot();
     const remotePath = await createRemoteRepository(root);

--- a/tests/workspace-preparation.test.ts
+++ b/tests/workspace-preparation.test.ts
@@ -224,6 +224,43 @@ describe("Git workspace preparation", () => {
     ).resolves.toBe("Wrong repo");
   });
 
+  it("rejects an existing repository cache with a mismatched origin remote", async () => {
+    const root = await makeTempRoot();
+    const expectedRemotePath = await createRemoteRepository(root, "expected");
+    const wrongRemotePath = await createRemoteRepository(root, "wrong");
+    const workspaceRoot = path.join(root, "workspaces", "symphonika");
+    const cachePath = path.join(workspaceRoot, ".cache", "repo.git");
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await git(["clone", "--bare", wrongRemotePath, cachePath]);
+
+    const preparation = prepareIssueWorkspace({
+      issue: {
+        number: 6,
+        title: "Prepare deterministic Git workspaces and issue branches"
+      },
+      project: {
+        name: "symphonika",
+        workspace: {
+          git: {
+            base_branch: "main",
+            remote: expectedRemotePath
+          },
+          root: workspaceRoot
+        }
+      }
+    });
+
+    const error = await rejectionOf(preparation);
+    expect(error).toBeInstanceOf(WorkspacePreparationError);
+    if (!(error instanceof WorkspacePreparationError)) {
+      throw new Error("expected workspace preparation error");
+    }
+    expect(error.code).toBe("cache_conflict");
+    await expect(
+      git(["-C", cachePath, "config", "--get", "remote.origin.url"])
+    ).resolves.toBe(wrongRemotePath);
+  });
+
   it("surfaces an issue branch checked out elsewhere as a deterministic conflict", async () => {
     const root = await makeTempRoot();
     const remotePath = await createRemoteRepository(root);
@@ -301,9 +338,12 @@ describe("Git workspace preparation", () => {
   });
 });
 
-async function createRemoteRepository(root: string): Promise<string> {
-  const remotePath = path.join(root, "remote.git");
-  const seedPath = path.join(root, "seed");
+async function createRemoteRepository(
+  root: string,
+  name = "remote"
+): Promise<string> {
+  const remotePath = path.join(root, `${name}.git`);
+  const seedPath = path.join(root, `${name}-seed`);
 
   await git(["init", "--bare", remotePath]);
   await git(["init", "--initial-branch=main", seedPath]);

--- a/tests/workspace-preparation.test.ts
+++ b/tests/workspace-preparation.test.ts
@@ -178,6 +178,52 @@ describe("Git workspace preparation", () => {
     ).rejects.toThrow();
   });
 
+  it("rejects an unrelated Git repository even when it has the deterministic issue branch", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "symphonika");
+    const branchName =
+      "sym/symphonika/6-prepare-deterministic-git-workspaces-and-issue-branches";
+    const workspacePath = path.join(
+      workspaceRoot,
+      "issues",
+      "6-prepare-deterministic-git-workspaces-and-issue-branches"
+    );
+    await git(["init", "--initial-branch", branchName, workspacePath]);
+    await git(["-C", workspacePath, "config", "user.email", "test@example.com"]);
+    await git(["-C", workspacePath, "config", "user.name", "Symphonika Test"]);
+    await writeFile(path.join(workspacePath, "README.md"), "# Wrong repo\n");
+    await git(["-C", workspacePath, "add", "README.md"]);
+    await git(["-C", workspacePath, "commit", "-m", "Wrong repo"]);
+
+    const preparation = prepareIssueWorkspace({
+      issue: {
+        number: 6,
+        title: "Prepare deterministic Git workspaces and issue branches"
+      },
+      project: {
+        name: "symphonika",
+        workspace: {
+          git: {
+            base_branch: "main",
+            remote: remotePath
+          },
+          root: workspaceRoot
+        }
+      }
+    });
+
+    const error = await rejectionOf(preparation);
+    expect(error).toBeInstanceOf(WorkspacePreparationError);
+    if (!(error instanceof WorkspacePreparationError)) {
+      throw new Error("expected workspace preparation error");
+    }
+    expect(error.code).toBe("workspace_conflict");
+    await expect(
+      git(["-C", workspacePath, "show", "--no-patch", "--format=%s"])
+    ).resolves.toBe("Wrong repo");
+  });
+
   it("surfaces an issue branch checked out elsewhere as a deterministic conflict", async () => {
     const root = await makeTempRoot();
     const remotePath = await createRemoteRepository(root);

--- a/tests/workspace-preparation.test.ts
+++ b/tests/workspace-preparation.test.ts
@@ -1,0 +1,288 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  prepareIssueWorkspace,
+  WorkspacePreparationError
+} from "../src/workspace.js";
+
+const execFileAsync = promisify(execFile);
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-workspace-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("Git workspace preparation", () => {
+  it("creates the repository cache, deterministic issue branch, and issue worktree on first preparation", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "Sym Project");
+
+    const prepared = await prepareIssueWorkspace({
+      issue: {
+        number: 6,
+        title: "Prepare deterministic Git workspaces and issue branches"
+      },
+      project: {
+        name: "Sym Project",
+        workspace: {
+          git: {
+            base_branch: "main",
+            remote: remotePath
+          },
+          root: workspaceRoot
+        }
+      }
+    });
+
+    expect(prepared).toEqual({
+      branchName: "sym/sym-project/6-prepare-deterministic-git-workspaces-and-issue-branches",
+      branchRef:
+        "refs/heads/sym/sym-project/6-prepare-deterministic-git-workspaces-and-issue-branches",
+      cachePath: path.join(workspaceRoot, ".cache", "repo.git"),
+      issueDirectoryName: "6-prepare-deterministic-git-workspaces-and-issue-branches",
+      reused: false,
+      workspacePath: path.join(
+        workspaceRoot,
+        "issues",
+        "6-prepare-deterministic-git-workspaces-and-issue-branches"
+      )
+    });
+    await expect(
+      git(["-C", prepared.cachePath, "show-ref", "--verify", prepared.branchRef])
+    ).resolves.toContain(prepared.branchRef);
+    await expect(
+      git(["-C", prepared.workspacePath, "rev-parse", "--abbrev-ref", "HEAD"])
+    ).resolves.toBe(prepared.branchName);
+    await expect(
+      git(["-C", prepared.workspacePath, "show", "--no-patch", "--format=%s"])
+    ).resolves.toBe("Initial commit");
+  });
+
+  it("reuses the deterministic issue worktree and branch on later preparations", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "symphonika");
+    const input = {
+      issue: {
+        number: 6,
+        title: "Prepare deterministic Git workspaces and issue branches"
+      },
+      project: {
+        name: "symphonika",
+        workspace: {
+          git: {
+            base_branch: "main",
+            remote: remotePath
+          },
+          root: workspaceRoot
+        }
+      }
+    };
+
+    const first = await prepareIssueWorkspace(input);
+    const second = await prepareIssueWorkspace(input);
+
+    expect(second).toEqual({
+      ...first,
+      reused: true
+    });
+    await expect(
+      git(["-C", second.workspacePath, "rev-parse", "--abbrev-ref", "HEAD"])
+    ).resolves.toBe(second.branchName);
+  });
+
+  it("preserves dirty issue worktrees during later preparations", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "symphonika");
+    const input = {
+      issue: {
+        number: 6,
+        title: "Prepare deterministic Git workspaces and issue branches"
+      },
+      project: {
+        name: "symphonika",
+        workspace: {
+          git: {
+            base_branch: "main",
+            remote: remotePath
+          },
+          root: workspaceRoot
+        }
+      }
+    };
+    const first = await prepareIssueWorkspace(input);
+    await writeFile(path.join(first.workspacePath, "agent-notes.txt"), "keep me\n");
+
+    const second = await prepareIssueWorkspace(input);
+
+    expect(second.reused).toBe(true);
+    await expect(
+      git(["-C", second.workspacePath, "status", "--short"])
+    ).resolves.toContain("?? agent-notes.txt");
+  });
+
+  it("surfaces an occupied issue workspace path as a deterministic conflict", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "symphonika");
+    const occupiedPath = path.join(
+      workspaceRoot,
+      "issues",
+      "6-prepare-deterministic-git-workspaces-and-issue-branches"
+    );
+    await mkdir(occupiedPath, { recursive: true });
+    await writeFile(path.join(occupiedPath, "do-not-delete.txt"), "operator state\n");
+
+    const preparation = prepareIssueWorkspace({
+      issue: {
+        number: 6,
+        title: "Prepare deterministic Git workspaces and issue branches"
+      },
+      project: {
+        name: "symphonika",
+        workspace: {
+          git: {
+            base_branch: "main",
+            remote: remotePath
+          },
+          root: workspaceRoot
+        }
+      }
+    });
+
+    const error = await rejectionOf(preparation);
+    expect(error).toBeInstanceOf(WorkspacePreparationError);
+    if (!(error instanceof WorkspacePreparationError)) {
+      throw new Error("expected workspace preparation error");
+    }
+    expect(error.code).toBe("workspace_conflict");
+    await expect(
+      git(["-C", occupiedPath, "status", "--short"])
+    ).rejects.toThrow();
+  });
+
+  it("surfaces an issue branch checked out elsewhere as a deterministic conflict", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "symphonika");
+    const cachePath = path.join(workspaceRoot, ".cache", "repo.git");
+    const branchName =
+      "sym/symphonika/6-prepare-deterministic-git-workspaces-and-issue-branches";
+    const alternateWorktreePath = path.join(workspaceRoot, "manual", "issue-6");
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await git(["clone", "--bare", remotePath, cachePath]);
+    await git(["-C", cachePath, "fetch", "origin", "main:refs/remotes/origin/main"]);
+    await git(["-C", cachePath, "branch", branchName, "origin/main"]);
+    await mkdir(path.dirname(alternateWorktreePath), { recursive: true });
+    await git(["-C", cachePath, "worktree", "add", alternateWorktreePath, branchName]);
+
+    const preparation = prepareIssueWorkspace({
+      issue: {
+        number: 6,
+        title: "Prepare deterministic Git workspaces and issue branches"
+      },
+      project: {
+        name: "symphonika",
+        workspace: {
+          git: {
+            base_branch: "main",
+            remote: remotePath
+          },
+          root: workspaceRoot
+        }
+      }
+    });
+
+    const error = await rejectionOf(preparation);
+    expect(error).toBeInstanceOf(WorkspacePreparationError);
+    if (!(error instanceof WorkspacePreparationError)) {
+      throw new Error("expected workspace preparation error");
+    }
+    expect(error.code).toBe("branch_conflict");
+    expect(error.message).toContain(alternateWorktreePath);
+  });
+
+  it("uses path-safe deterministic slugs for issue branches and worktree directories", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "project");
+
+    const prepared = await prepareIssueWorkspace({
+      issue: {
+        number: 42,
+        title: "../Fix: Codex & Claude / workspace prep?!"
+      },
+      project: {
+        name: "../Sym Phonika!",
+        workspace: {
+          git: {
+            base_branch: "main",
+            remote: remotePath
+          },
+          root: workspaceRoot
+        }
+      }
+    });
+
+    expect(prepared.branchName).toBe(
+      "sym/sym-phonika/42-fix-codex-claude-workspace-prep"
+    );
+    expect(prepared.issueDirectoryName).toBe(
+      "42-fix-codex-claude-workspace-prep"
+    );
+    expect(prepared.workspacePath).toBe(
+      path.join(workspaceRoot, "issues", "42-fix-codex-claude-workspace-prep")
+    );
+    expect(prepared.issueDirectoryName).not.toContain("/");
+    expect(prepared.issueDirectoryName).not.toContain("..");
+  });
+});
+
+async function createRemoteRepository(root: string): Promise<string> {
+  const remotePath = path.join(root, "remote.git");
+  const seedPath = path.join(root, "seed");
+
+  await git(["init", "--bare", remotePath]);
+  await git(["init", "--initial-branch=main", seedPath]);
+  await git(["-C", seedPath, "config", "user.email", "test@example.com"]);
+  await git(["-C", seedPath, "config", "user.name", "Symphonika Test"]);
+  await writeFile(path.join(seedPath, "README.md"), "# Symphonika\n");
+  await git(["-C", seedPath, "add", "README.md"]);
+  await git(["-C", seedPath, "commit", "-m", "Initial commit"]);
+  await git(["-C", seedPath, "remote", "add", "origin", remotePath]);
+  await git(["-C", seedPath, "push", "origin", "main"]);
+
+  return remotePath;
+}
+
+async function git(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args);
+  return stdout.trim();
+}
+
+async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error("expected promise to reject");
+}


### PR DESCRIPTION
## Summary

- Add first-class Git workspace preparation for normalized issues.
- Maintain a bare repository cache, fetch the configured base branch, create deterministic issue branches, and create or reuse deterministic issue worktrees.
- Preserve dirty worktrees and surface occupied workspace paths or branch-in-use states as deterministic preparation errors.
- Cover issue #6 behavior with temp Git repository tests for creation, reuse, dirty state, conflict handling, and path-safe slugging.

Closes #6

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`