### PR TITLE
[codex] Render autonomous prompts and persist run evidence

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,6 +5,7 @@ import { parse } from "yaml";
 import { z } from "zod";
 
 import { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
+import { validateWorkflowContract } from "./workflow.js";
 
 export { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
 
@@ -190,38 +191,6 @@ const serviceConfigSchema = z
     projects: z.array(projectSchema).min(1)
   })
   .passthrough();
-
-const allowedTemplateFields: Record<string, ReadonlySet<string>> = {
-  branch: new Set(["name"]),
-  issue: new Set([
-    "body",
-    "created_at",
-    "id",
-    "labels",
-    "number",
-    "priority",
-    "state",
-    "title",
-    "updated_at",
-    "url"
-  ]),
-  project: new Set(["name"]),
-  provider: new Set(["command", "name"]),
-  run: new Set(["attempt", "continuation", "id"]),
-  workspace: new Set(["path", "root"])
-};
-
-const serviceDiscoveryFrontMatterKeys = new Set([
-  "agent",
-  "issue_filters",
-  "priority",
-  "projects",
-  "provider",
-  "providers",
-  "tracker",
-  "workflow",
-  "workspace"
-]);
 
 export async function runDoctor(
   options: DoctorOptions = {}
@@ -541,126 +510,6 @@ async function validateProject(
   };
 }
 
-async function validateWorkflowContract(
-  workflowPath: string
-): Promise<string[]> {
-  const errors: string[] = [];
-  let contents: string;
-
-  try {
-    contents = await readFile(workflowPath, "utf8");
-  } catch (error) {
-    return [`workflow contract not found at ${workflowPath}: ${errorMessage(error)}`];
-  }
-
-  const workflow = parseWorkflowContract(contents, workflowPath);
-  errors.push(...workflow.errors);
-
-  if (workflow.body.trim().length === 0) {
-    errors.push(`workflow contract at ${workflowPath} must not be empty`);
-  }
-
-  errors.push(...validateTemplateVariables(workflow.body, workflowPath));
-  return errors;
-}
-
-function parseWorkflowContract(
-  contents: string,
-  workflowPath: string
-): { body: string; errors: string[] } {
-  const lines = contents.split(/\r?\n/);
-
-  if (lines[0]?.trim() !== "---") {
-    return { body: contents, errors: [] };
-  }
-
-  const closingLine = lines.findIndex(
-    (line, index) => index > 0 && line.trim() === "---"
-  );
-  if (closingLine === -1) {
-    return {
-      body: "",
-      errors: [`workflow front matter at ${workflowPath} is missing a closing ---`]
-    };
-  }
-
-  const frontMatterSource = lines.slice(1, closingLine).join("\n");
-  const errors: string[] = [];
-  const frontMatter = parseFrontMatter(frontMatterSource, workflowPath, errors);
-
-  if (frontMatter !== undefined) {
-    for (const key of Object.keys(frontMatter)) {
-      if (serviceDiscoveryFrontMatterKeys.has(key)) {
-        errors.push(
-          `workflow front matter at ${workflowPath} must not define service config key ${key}`
-        );
-      }
-    }
-  }
-
-  return {
-    body: lines.slice(closingLine + 1).join("\n"),
-    errors
-  };
-}
-
-function parseFrontMatter(
-  source: string,
-  workflowPath: string,
-  errors: string[]
-): Record<string, unknown> | undefined {
-  try {
-    const parsed: unknown = parse(source) ?? {};
-    if (isRecord(parsed)) {
-      return parsed;
-    }
-    errors.push(`workflow front matter at ${workflowPath} must be a mapping`);
-    return undefined;
-  } catch (error) {
-    errors.push(
-      `workflow front matter at ${workflowPath} could not be parsed: ${errorMessage(error)}`
-    );
-    return undefined;
-  }
-}
-
-function validateTemplateVariables(
-  template: string,
-  workflowPath: string
-): string[] {
-  const errors: string[] = [];
-  const tagPattern = /{{\s*([^{}]+?)\s*}}/g;
-
-  for (const match of template.matchAll(tagPattern)) {
-    const expression = match[1]?.trim() ?? "";
-    const parts = expression.split(".");
-    const topLevel = parts[0];
-
-    if (!/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(expression)) {
-      errors.push(
-        `workflow template at ${workflowPath} has unsupported tag {{${expression}}}`
-      );
-      continue;
-    }
-
-    if (topLevel === undefined || !(topLevel in allowedTemplateFields)) {
-      errors.push(
-        `workflow template at ${workflowPath} references unknown variable {{${expression}}}`
-      );
-      continue;
-    }
-
-    const field = parts[1];
-    if (field !== undefined && !allowedTemplateFields[topLevel]!.has(field)) {
-      errors.push(
-        `workflow template at ${workflowPath} references unknown variable {{${expression}}}`
-      );
-    }
-  }
-
-  return errors;
-}
-
 function resolveEnvBackedValue(
   input: string,
   env: NodeJS.ProcessEnv
@@ -742,8 +591,4 @@ function githubErrorMessage(error: unknown): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -361,7 +361,7 @@ function stringifyTemplateValue(value: unknown, workflowPath: string): string {
 }
 
 function isPromptObjectName(input: string): input is keyof PromptContext {
-  return input in allowedTemplateFields;
+  return Object.hasOwn(allowedTemplateFields, input);
 }
 
 function templateExpressionError(

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,0 +1,430 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parse } from "yaml";
+import type { IssueSnapshot } from "./issue-polling.js";
+
+export const AUTONOMY_PREAMBLE_VERSION = "autonomy-preamble-v1";
+
+export type PromptProject = {
+  name: string;
+};
+
+export type PromptWorkspace = {
+  path: string;
+  previous_attempt: boolean;
+  root: string;
+};
+
+export type PromptBranch = {
+  name: string;
+  ref: string;
+};
+
+export type PromptRun = {
+  attempt: number;
+  continuation: boolean;
+  id: string;
+};
+
+export type PromptProvider = {
+  command: string;
+  name: "codex" | "claude";
+};
+
+export type RenderAutonomousPromptInput = {
+  branch: PromptBranch;
+  issue: IssueSnapshot;
+  project: PromptProject;
+  provider: PromptProvider;
+  run: PromptRun;
+  template: string;
+  workflowContentHash?: string;
+  workflowPath: string;
+  workspace: PromptWorkspace;
+};
+
+export type RenderedAutonomousPrompt = {
+  preambleVersion: string;
+  prompt: string;
+  workflowContentHash: string;
+};
+
+export type PersistRunEvidenceInput = RenderAutonomousPromptInput & {
+  renderedPrompt: RenderedAutonomousPrompt;
+  stateRoot: string;
+};
+
+export type RunEvidencePaths = {
+  issueSnapshotPath: string;
+  metadataPath: string;
+  promptPath: string;
+  runEvidenceDirectory: string;
+};
+
+export type WorkflowContract = {
+  body: string;
+  contentHash: string;
+  errors: string[];
+  path: string;
+};
+
+type PromptContext = {
+  branch: PromptBranch;
+  issue: IssueSnapshot;
+  project: PromptProject;
+  provider: PromptProvider;
+  run: PromptRun;
+  workspace: PromptWorkspace;
+};
+
+const allowedTemplateFields: Record<keyof PromptContext, ReadonlySet<string>> = {
+  branch: new Set(["name", "ref"]),
+  issue: new Set([
+    "body",
+    "created_at",
+    "id",
+    "labels",
+    "number",
+    "priority",
+    "state",
+    "title",
+    "updated_at",
+    "url"
+  ]),
+  project: new Set(["name"]),
+  provider: new Set(["command", "name"]),
+  run: new Set(["attempt", "continuation", "id"]),
+  workspace: new Set(["path", "previous_attempt", "root"])
+};
+
+const serviceDiscoveryFrontMatterKeys = new Set([
+  "agent",
+  "issue_filters",
+  "priority",
+  "projects",
+  "provider",
+  "providers",
+  "tracker",
+  "workflow",
+  "workspace"
+]);
+
+const tagPattern = /{{\s*([^{}]+?)\s*}}/g;
+
+const AUTONOMY_PREAMBLE = [
+  "# Autonomous run instructions",
+  "",
+  "You are running as an autonomous full-permission coding worker.",
+  "Do not ask the operator for interactive input; make reasonable decisions when ambiguity is low.",
+  "Use the prepared workspace as your current working directory and stay on the assigned issue branch.",
+  "Work only on the assigned issue unless the workflow contract explicitly says otherwise.",
+  "Preserve useful evidence in the workspace when blocked or when you cannot complete the task.",
+  ""
+].join("\n");
+
+export function renderAutonomousPrompt(
+  input: RenderAutonomousPromptInput
+): RenderedAutonomousPrompt {
+  const context: PromptContext = {
+    branch: input.branch,
+    issue: input.issue,
+    project: input.project,
+    provider: input.provider,
+    run: input.run,
+    workspace: input.workspace
+  };
+  const renderedWorkflow = input.template.replace(tagPattern, (_tag, expression) =>
+    stringifyTemplateValue(
+      resolveTemplateValue(String(expression).trim(), context, input.workflowPath),
+      input.workflowPath
+    )
+  );
+
+  return {
+    preambleVersion: AUTONOMY_PREAMBLE_VERSION,
+    prompt: [
+      AUTONOMY_PREAMBLE,
+      previousAttemptNotice(input.workspace),
+      renderedWorkflow
+    ]
+      .filter((section) => section.length > 0)
+      .join("\n"),
+    workflowContentHash: input.workflowContentHash ?? contentHash(input.template)
+  };
+}
+
+export async function loadWorkflowContract(
+  workflowPath: string
+): Promise<WorkflowContract> {
+  const contents = await readFile(workflowPath, "utf8");
+  return parseWorkflowContract(contents, workflowPath);
+}
+
+export async function validateWorkflowContract(
+  workflowPath: string
+): Promise<string[]> {
+  let contents: string;
+
+  try {
+    contents = await readFile(workflowPath, "utf8");
+  } catch (error) {
+    return [`workflow contract not found at ${workflowPath}: ${errorMessage(error)}`];
+  }
+
+  const workflow = parseWorkflowContract(contents, workflowPath);
+  const errors = [...workflow.errors];
+
+  if (workflow.body.trim().length === 0) {
+    errors.push(`workflow contract at ${workflowPath} must not be empty`);
+  }
+
+  errors.push(...validateWorkflowTemplate(workflow.body, workflowPath));
+  return errors;
+}
+
+export function parseWorkflowContract(
+  contents: string,
+  workflowPath: string
+): WorkflowContract {
+  const lines = contents.split(/\r?\n/);
+
+  if (lines[0]?.trim() !== "---") {
+    return {
+      body: contents,
+      contentHash: contentHash(contents),
+      errors: [],
+      path: workflowPath
+    };
+  }
+
+  const closingLine = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === "---"
+  );
+  if (closingLine === -1) {
+    return {
+      body: "",
+      contentHash: contentHash(contents),
+      errors: [`workflow front matter at ${workflowPath} is missing a closing ---`],
+      path: workflowPath
+    };
+  }
+
+  const frontMatterSource = lines.slice(1, closingLine).join("\n");
+  const errors: string[] = [];
+  const frontMatter = parseFrontMatter(frontMatterSource, workflowPath, errors);
+
+  if (frontMatter !== undefined) {
+    for (const key of Object.keys(frontMatter)) {
+      if (serviceDiscoveryFrontMatterKeys.has(key)) {
+        errors.push(
+          `workflow front matter at ${workflowPath} must not define service config key ${key}`
+        );
+      }
+    }
+  }
+
+  return {
+    body: lines.slice(closingLine + 1).join("\n"),
+    contentHash: contentHash(contents),
+    errors,
+    path: workflowPath
+  };
+}
+
+export function validateWorkflowTemplate(
+  template: string,
+  workflowPath: string
+): string[] {
+  const errors: string[] = [];
+
+  for (const match of template.matchAll(tagPattern)) {
+    const expression = match[1]?.trim() ?? "";
+    const error = templateExpressionError(expression, workflowPath);
+    if (error !== undefined) {
+      errors.push(error);
+    }
+  }
+
+  return errors;
+}
+
+export async function persistRunEvidence(
+  input: PersistRunEvidenceInput
+): Promise<RunEvidencePaths> {
+  const runEvidenceDirectory = path.join(
+    path.resolve(input.stateRoot),
+    "logs",
+    "runs",
+    safePathSegment(input.run.id)
+  );
+
+  if (isPathInside(runEvidenceDirectory, input.workspace.path)) {
+    throw new Error(
+      `run evidence directory ${runEvidenceDirectory} must be outside issue workspace ${input.workspace.path}`
+    );
+  }
+
+  await mkdir(runEvidenceDirectory, { recursive: true });
+
+  const promptPath = path.join(runEvidenceDirectory, "prompt.md");
+  const metadataPath = path.join(runEvidenceDirectory, "prompt-metadata.json");
+  const issueSnapshotPath = path.join(runEvidenceDirectory, "issue-snapshot.json");
+  const metadata = {
+    autonomy_preamble_version: input.renderedPrompt.preambleVersion,
+    branch: input.branch,
+    issue_snapshot_path: issueSnapshotPath,
+    prompt_path: promptPath,
+    project: input.project,
+    provider: input.provider,
+    run: input.run,
+    workspace: input.workspace,
+    workflow: {
+      content_hash: input.renderedPrompt.workflowContentHash,
+      path: input.workflowPath
+    }
+  };
+
+  await Promise.all([
+    writeFile(promptPath, input.renderedPrompt.prompt, "utf8"),
+    writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8"),
+    writeFile(
+      issueSnapshotPath,
+      `${JSON.stringify(input.issue, null, 2)}\n`,
+      "utf8"
+    )
+  ]);
+
+  return {
+    issueSnapshotPath,
+    metadataPath,
+    promptPath,
+    runEvidenceDirectory
+  };
+}
+
+function previousAttemptNotice(workspace: PromptWorkspace): string {
+  if (!workspace.previous_attempt) {
+    return "";
+  }
+
+  return [
+    "## Previous-attempt workspace",
+    "",
+    "This workspace was reused from an earlier attempt for this issue; inspect the existing work before editing.",
+    "Check git status, local commits, notes, logs, and partial changes so useful prior progress is preserved.",
+    ""
+  ].join("\n");
+}
+
+function resolveTemplateValue(
+  expression: string,
+  context: PromptContext,
+  workflowPath: string
+): unknown {
+  const expressionError = templateExpressionError(expression, workflowPath);
+  if (expressionError !== undefined) {
+    throw new Error(expressionError);
+  }
+
+  const parts = expression.split(".");
+  const topLevel = parts[0];
+
+  if (topLevel === undefined || !isPromptObjectName(topLevel)) {
+    throw new Error("unreachable validated template expression");
+  }
+
+  const field = parts[1];
+  if (field === undefined) {
+    return context[topLevel];
+  }
+
+  return context[topLevel][field as keyof (typeof context)[typeof topLevel]];
+}
+
+function stringifyTemplateValue(value: unknown, workflowPath: string): string {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+
+  if (value === null || value === undefined) {
+    throw new Error(
+      `workflow template at ${workflowPath} resolved to an empty value`
+    );
+  }
+
+  return JSON.stringify(value);
+}
+
+function isPromptObjectName(input: string): input is keyof PromptContext {
+  return input in allowedTemplateFields;
+}
+
+function templateExpressionError(
+  expression: string,
+  workflowPath: string
+): string | undefined {
+  const parts = expression.split(".");
+  const topLevel = parts[0];
+
+  if (!/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(expression)) {
+    return `workflow template at ${workflowPath} has unsupported tag {{${expression}}}`;
+  }
+
+  if (topLevel === undefined || !isPromptObjectName(topLevel)) {
+    return `workflow template at ${workflowPath} references unknown variable {{${expression}}}`;
+  }
+
+  const field = parts[1];
+  if (field !== undefined && !allowedTemplateFields[topLevel].has(field)) {
+    return `workflow template at ${workflowPath} references unknown variable {{${expression}}}`;
+  }
+
+  return undefined;
+}
+
+function parseFrontMatter(
+  source: string,
+  workflowPath: string,
+  errors: string[]
+): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = parse(source) ?? {};
+    if (isRecord(parsed)) {
+      return parsed;
+    }
+    errors.push(`workflow front matter at ${workflowPath} must be a mapping`);
+    return undefined;
+  } catch (error) {
+    errors.push(
+      `workflow front matter at ${workflowPath} could not be parsed: ${errorMessage(error)}`
+    );
+    return undefined;
+  }
+}
+
+function contentHash(contents: string): string {
+  return `sha256:${createHash("sha256").update(contents).digest("hex")}`;
+}
+
+function safePathSegment(input: string): string {
+  const segment = input.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return segment.length === 0 ? "run" : segment;
+}
+
+function isPathInside(candidatePath: string, parentPath: string): boolean {
+  const relative = path.relative(path.resolve(parentPath), path.resolve(candidatePath));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1,0 +1,298 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  loadWorkflowContract,
+  persistRunEvidence,
+  renderAutonomousPrompt
+} from "../src/workflow.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-workflow-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("workflow prompt rendering", () => {
+  it("renders normalized run variables and prepends the autonomy preamble", () => {
+    const rendered = renderAutonomousPrompt({
+      branch: {
+        name: "sym/symphonika/7-render-prompts",
+        ref: "refs/heads/sym/symphonika/7-render-prompts"
+      },
+      issue: issueSnapshot(),
+      project: {
+        name: "symphonika"
+      },
+      provider: {
+        command: "codex --dangerously-bypass-approvals-and-sandbox app-server",
+        name: "codex"
+      },
+      run: {
+        attempt: 1,
+        continuation: false,
+        id: "run-7"
+      },
+      template: [
+        "Work on #{{issue.number}} {{issue.title}} for {{project.name}} using {{provider.name}}.",
+        "Run {{run.id}} attempt {{run.attempt}} continuation {{run.continuation}}.",
+        "Workspace {{workspace.path}} rooted at {{workspace.root}} previous {{workspace.previous_attempt}}.",
+        "Branch {{branch.name}} at {{branch.ref}}.",
+        "Provider command {{provider.command}} with labels {{issue.labels}}."
+      ].join("\n"),
+      workflowPath: "/repo/WORKFLOW.md",
+      workspace: {
+        path: "/state/workspaces/symphonika/issues/7-render-prompts",
+        previous_attempt: false,
+        root: "/state/workspaces/symphonika"
+      }
+    });
+
+    expect(rendered.prompt).toContain("Autonomous run instructions");
+    expect(rendered.prompt).toContain(
+      "Work on #7 Render autonomous prompts and persist run evidence for symphonika using codex."
+    );
+    expect(rendered.prompt).toContain("Run run-7 attempt 1 continuation false.");
+    expect(rendered.prompt).toContain(
+      "Workspace /state/workspaces/symphonika/issues/7-render-prompts rooted at /state/workspaces/symphonika previous false."
+    );
+    expect(rendered.prompt).toContain(
+      "Branch sym/symphonika/7-render-prompts at refs/heads/sym/symphonika/7-render-prompts."
+    );
+    expect(rendered.prompt).toContain(
+      'Provider command codex --dangerously-bypass-approvals-and-sandbox app-server with labels ["agent-ready"].'
+    );
+    expect(rendered.preambleVersion).toBe("autonomy-preamble-v1");
+  });
+
+  it("fails rendering when the workflow references an unknown variable", () => {
+    expect(() =>
+      renderAutonomousPrompt({
+        branch: {
+          name: "sym/symphonika/7-render-prompts",
+          ref: "refs/heads/sym/symphonika/7-render-prompts"
+        },
+        issue: issueSnapshot(),
+        project: {
+          name: "symphonika"
+        },
+        provider: {
+          command: "codex --dangerously-bypass-approvals-and-sandbox app-server",
+          name: "codex"
+        },
+        run: {
+          attempt: 1,
+          continuation: false,
+          id: "run-7"
+        },
+        template: "Work on {{issue.assignee}}.",
+        workflowPath: "/repo/WORKFLOW.md",
+        workspace: {
+          path: "/state/workspaces/symphonika/issues/7-render-prompts",
+          previous_attempt: false,
+          root: "/state/workspaces/symphonika"
+        }
+      })
+    ).toThrow("references unknown variable {{issue.assignee}}");
+  });
+
+  it("calls out previous-attempt workspaces in the rendered prompt", () => {
+    const rendered = renderAutonomousPrompt({
+      branch: {
+        name: "sym/symphonika/7-render-prompts",
+        ref: "refs/heads/sym/symphonika/7-render-prompts"
+      },
+      issue: issueSnapshot(),
+      project: {
+        name: "symphonika"
+      },
+      provider: {
+        command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json",
+        name: "claude"
+      },
+      run: {
+        attempt: 2,
+        continuation: true,
+        id: "run-7b"
+      },
+      template: "Continue work on {{issue.title}}.",
+      workflowPath: "/repo/WORKFLOW.md",
+      workspace: {
+        path: "/state/workspaces/symphonika/issues/7-render-prompts",
+        previous_attempt: true,
+        root: "/state/workspaces/symphonika"
+      }
+    });
+
+    expect(rendered.prompt).toContain("Previous-attempt workspace");
+    expect(rendered.prompt).toContain("inspect the existing work before editing");
+  });
+
+  it("persists rendered prompt evidence outside the issue workspace", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "7-render-prompts"
+    );
+    const input = {
+      branch: {
+        name: "sym/symphonika/7-render-prompts",
+        ref: "refs/heads/sym/symphonika/7-render-prompts"
+      },
+      issue: issueSnapshot(),
+      project: {
+        name: "symphonika"
+      },
+      provider: {
+        command: "codex --dangerously-bypass-approvals-and-sandbox app-server",
+        name: "codex" as const
+      },
+      run: {
+        attempt: 1,
+        continuation: false,
+        id: "run-7"
+      },
+      template: "Work on {{issue.title}}.",
+      workflowPath: path.join(root, "WORKFLOW.md"),
+      workspace: {
+        path: workspacePath,
+        previous_attempt: false,
+        root: path.dirname(path.dirname(workspacePath))
+      }
+    };
+    const rendered = renderAutonomousPrompt(input);
+
+    const evidence = await persistRunEvidence({
+      ...input,
+      renderedPrompt: rendered,
+      stateRoot
+    });
+
+    expect(evidence.runEvidenceDirectory).toBe(
+      path.join(stateRoot, "logs", "runs", "run-7")
+    );
+    expect(path.relative(workspacePath, evidence.promptPath)).toMatch(/^\.\./);
+    await expect(readFile(evidence.promptPath, "utf8")).resolves.toBe(
+      rendered.prompt
+    );
+    const metadata = parseJsonRecord(await readFile(evidence.metadataPath, "utf8"));
+    expect(metadata).toMatchObject({
+      autonomy_preamble_version: "autonomy-preamble-v1",
+      branch: input.branch,
+      provider: input.provider,
+      project: input.project,
+      run: input.run,
+      workspace: input.workspace,
+      workflow: {
+        path: input.workflowPath
+      }
+    });
+    const workflowMetadata = metadata.workflow;
+    if (!isRecord(workflowMetadata)) {
+      throw new Error("expected workflow metadata record");
+    }
+    expect(workflowMetadata.content_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    await expect(readFile(evidence.issueSnapshotPath, "utf8")).resolves.toContain(
+      "Render autonomous prompts and persist run evidence"
+    );
+  });
+
+  it("loads WORKFLOW.md body without front matter and carries its content hash into the rendered prompt", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(
+      workflowPath,
+      [
+        "---",
+        "autonomy:",
+        "  max_turns: 8",
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n")
+    );
+
+    const workflow = await loadWorkflowContract(workflowPath);
+    const rendered = renderAutonomousPrompt({
+      branch: {
+        name: "sym/symphonika/7-render-prompts",
+        ref: "refs/heads/sym/symphonika/7-render-prompts"
+      },
+      issue: issueSnapshot(),
+      project: {
+        name: "symphonika"
+      },
+      provider: {
+        command: "codex --dangerously-bypass-approvals-and-sandbox app-server",
+        name: "codex"
+      },
+      run: {
+        attempt: 1,
+        continuation: false,
+        id: "run-7"
+      },
+      template: workflow.body,
+      workflowContentHash: workflow.contentHash,
+      workflowPath: workflow.path,
+      workspace: {
+        path: "/state/workspaces/symphonika/issues/7-render-prompts",
+        previous_attempt: false,
+        root: "/state/workspaces/symphonika"
+      }
+    });
+
+    expect(workflow.errors).toEqual([]);
+    expect(workflow.body).toBe("Work on {{issue.title}}.\n");
+    expect(workflow.contentHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(rendered.prompt).toContain(
+      "Work on Render autonomous prompts and persist run evidence."
+    );
+    expect(rendered.prompt).not.toContain("max_turns");
+    expect(rendered.workflowContentHash).toBe(workflow.contentHash);
+  });
+});
+
+function issueSnapshot() {
+  return {
+    body: "Implement prompt evidence.",
+    created_at: "2026-04-28T10:00:00Z",
+    id: 700,
+    labels: ["agent-ready"],
+    number: 7,
+    priority: 99,
+    state: "open",
+    title: "Render autonomous prompts and persist run evidence",
+    updated_at: "2026-04-29T10:00:00Z",
+    url: "https://github.com/pmatos/symphonika/issues/7"
+  };
+}
+
+function parseJsonRecord(contents: string): Record<string, unknown> {
+  const parsed = JSON.parse(contents) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error("expected JSON object");
+  }
+
+  return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -108,6 +108,37 @@ describe("workflow prompt rendering", () => {
     ).toThrow("references unknown variable {{issue.assignee}}");
   });
 
+  it("rejects inherited object property names as template variables", () => {
+    expect(() =>
+      renderAutonomousPrompt({
+        branch: {
+          name: "sym/symphonika/7-render-prompts",
+          ref: "refs/heads/sym/symphonika/7-render-prompts"
+        },
+        issue: issueSnapshot(),
+        project: {
+          name: "symphonika"
+        },
+        provider: {
+          command: "codex --dangerously-bypass-approvals-and-sandbox app-server",
+          name: "codex"
+        },
+        run: {
+          attempt: 1,
+          continuation: false,
+          id: "run-7"
+        },
+        template: "Work on {{toString}} and {{constructor}}.",
+        workflowPath: "/repo/WORKFLOW.md",
+        workspace: {
+          path: "/state/workspaces/symphonika/issues/7-render-prompts",
+          previous_attempt: false,
+          root: "/state/workspaces/symphonika"
+        }
+      })
+    ).toThrow("references unknown variable {{toString}}");
+  });
+
   it("calls out previous-attempt workspaces in the rendered prompt", () => {
     const rendered = renderAutonomousPrompt({
       branch: {


### PR DESCRIPTION
## Summary

- add a workflow module for strict WORKFLOW.md loading, validation, prompt rendering, and autonomy preamble injection
- include previous-attempt workspace notices and rendered prompt metadata with workflow hashes
- persist run evidence outside issue workspaces and reuse the shared workflow validator from doctor

## Validation

- npm run typecheck
- npm run lint
- npm test
- npm run build
- git diff --check

Closes #7