### PR TITLE
[codex] Dispatch fake-provider issue runs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@hono/node-server": "^1.14.4",
         "@octokit/rest": "^22.0.1",
+        "@types/better-sqlite3": "^7.6.13",
+        "better-sqlite3": "^12.9.0",
         "commander": "^12.1.0",
         "hono": "^4.6.14",
         "pino": "^9.5.0",
@@ -1227,6 +1229,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1263,7 +1274,6 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1753,11 +1763,65 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -1768,6 +1832,30 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/callsites": {
@@ -1806,6 +1894,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1883,6 +1977,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1894,10 +2012,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2126,6 +2252,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2204,6 +2339,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2242,6 +2383,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2269,6 +2416,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -2315,6 +2468,26 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2351,6 +2524,18 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2752,6 +2937,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2764,6 +2961,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2791,12 +3003,30 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -2816,6 +3046,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -2994,6 +3233,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3020,6 +3286,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3035,6 +3311,44 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -3099,6 +3413,26 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -3112,7 +3446,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3150,6 +3483,51 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
@@ -3193,6 +3571,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3217,6 +3604,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/thread-stream": {
@@ -3313,6 +3728,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3368,7 +3795,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -3386,6 +3812,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.10",
@@ -3597,6 +4029,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "dependencies": {
     "@hono/node-server": "^1.14.4",
     "@octokit/rest": "^22.0.1",
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.9.0",
     "commander": "^12.1.0",
     "hono": "^4.6.14",
     "pino": "^9.5.0",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,28 +2,41 @@ import { serve, type ServerType } from "@hono/node-server";
 import type { Logger } from "pino";
 import pino from "pino";
 
+import { dispatchOneEligibleIssue } from "./dispatch.js";
 import { createHttpApp } from "./http/app.js";
 import type {
   GitHubIssuesApi,
   PollConfiguredGitHubIssuesOptions
 } from "./issue-polling.js";
 import {
+  DEFAULT_GITHUB_ISSUES_API,
   emptyIssuePollStatus,
   pollConfiguredGitHubIssues,
   readConfiguredPollingIntervalMs,
   replaceIssuePollStatus
 } from "./issue-polling.js";
+import type { AgentProviderRegistry } from "./provider.js";
+import { openRunStore } from "./run-store.js";
 import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
+import type {
+  PreparedIssueWorkspace,
+  PrepareIssueWorkspaceInput
+} from "./workspace.js";
 
 export type StartDaemonOptions = {
+  agentProviders?: AgentProviderRegistry;
   configPath?: string;
+  createRunId?: () => string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   githubIssuesApi?: GitHubIssuesApi;
   host?: string;
   logger?: Logger;
   port?: number;
+  prepareIssueWorkspace?: (
+    input: PrepareIssueWorkspaceInput
+  ) => Promise<PreparedIssueWorkspace>;
 };
 
 export type DaemonHandle = {
@@ -49,6 +62,12 @@ export async function startDaemon(
   }
   const state = resolveStateRoot(stateRootOptions);
   const issuePollStatus = emptyIssuePollStatus();
+  const runStore = openRunStore({
+    stateRoot: state.stateRoot
+  });
+  const dispatchRuntime = {
+    dispatching: false
+  };
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let polling = false;
   const refreshIssuePollStatus = async (): Promise<void> => {
@@ -71,6 +90,40 @@ export async function startDaemon(
       polling = false;
     }
   };
+  const dispatchEligibleIssue = async (): Promise<void> => {
+    if (
+      !state.configExists ||
+      dispatchRuntime.dispatching ||
+      !hasRegisteredProviders(options.agentProviders)
+    ) {
+      return;
+    }
+
+    dispatchRuntime.dispatching = true;
+    try {
+      await dispatchOneEligibleIssue({
+        agentProviders: options.agentProviders,
+        configDir: state.configDir,
+        configPath: state.configPath,
+        githubIssuesApi: options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API,
+        issuePollStatus,
+        runStore,
+        stateRoot: state.stateRoot,
+        ...(options.createRunId === undefined
+          ? {}
+          : { createRunId: options.createRunId }),
+        ...(options.env === undefined ? {} : { env: options.env }),
+        ...(options.prepareIssueWorkspace === undefined
+          ? {}
+          : { prepareIssueWorkspace: options.prepareIssueWorkspace })
+      });
+    } catch (error) {
+      issuePollStatus.errors.push(errorMessage(error));
+      logger.error({ err: error }, "symphonika dispatch failed");
+    } finally {
+      dispatchRuntime.dispatching = false;
+    }
+  };
 
   if (state.configExists) {
     await refreshIssuePollStatus();
@@ -81,6 +134,8 @@ export async function startDaemon(
     pollTimer.unref?.();
   }
   const app = createHttpApp({
+    dispatchRuntime,
+    getRuns: () => runStore.listRuns(),
     issuePollStatus,
     stateRoot: state.stateRoot,
     version: VERSION
@@ -94,6 +149,7 @@ export async function startDaemon(
   await waitForListening(server);
   const port = resolveListeningPort(server, requestedPort);
   const url = `http://${host}:${port}`;
+  const dispatchPromise = dispatchEligibleIssue();
 
   logger.info(
     {
@@ -110,11 +166,15 @@ export async function startDaemon(
     port,
     stateRoot: state.stateRoot,
     url,
-    stop: () => {
+    stop: async () => {
       if (pollTimer !== undefined) {
         clearInterval(pollTimer);
       }
-      return stopServer(server, logger);
+      if (dispatchPromise !== undefined) {
+        await dispatchPromise;
+      }
+      await stopServer(server, logger);
+      runStore.close();
     }
   };
 }
@@ -172,4 +232,10 @@ function stopServer(server: ServerType, logger: Logger): Promise<void> {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function hasRegisteredProviders(
+  providers: AgentProviderRegistry | undefined
+): providers is AgentProviderRegistry {
+  return providers !== undefined && Object.values(providers).some(Boolean);
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -70,6 +70,7 @@ export async function startDaemon(
   };
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let polling = false;
+  let scheduledWork = Promise.resolve();
   const refreshIssuePollStatus = async (): Promise<void> => {
     if (!state.configExists || polling) {
       return;
@@ -124,13 +125,19 @@ export async function startDaemon(
       dispatchRuntime.dispatching = false;
     }
   };
+  const refreshAndDispatch = async (): Promise<void> => {
+    await refreshIssuePollStatus();
+    await dispatchEligibleIssue();
+  };
+  const scheduleRefreshAndDispatch = (): void => {
+    scheduledWork = scheduledWork.then(refreshAndDispatch, refreshAndDispatch);
+    void scheduledWork;
+  };
 
   if (state.configExists) {
     await refreshIssuePollStatus();
     const intervalMs = await readConfiguredPollingIntervalMs(state.configPath);
-    pollTimer = setInterval(() => {
-      void refreshIssuePollStatus();
-    }, intervalMs);
+    pollTimer = setInterval(scheduleRefreshAndDispatch, intervalMs);
     pollTimer.unref?.();
   }
   const app = createHttpApp({
@@ -173,6 +180,7 @@ export async function startDaemon(
       if (dispatchPromise !== undefined) {
         await dispatchPromise;
       }
+      await scheduledWork;
       await stopServer(server, logger);
       runStore.close();
     }

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -1,0 +1,547 @@
+import { randomUUID } from "node:crypto";
+import { appendFile, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parse } from "yaml";
+import { z } from "zod";
+
+import type {
+  GitHubIssueLabelInput,
+  GitHubIssueRepositoryInput,
+  GitHubIssuesApi,
+  IssuePollStatus,
+  IssueSnapshot,
+  ProjectIssueSnapshot
+} from "./issue-polling.js";
+import type {
+  AgentProvider,
+  AgentProviderName,
+  AgentProviderRegistry,
+  NormalizedProviderEvent,
+  ProviderEvent
+} from "./provider.js";
+import type { RunState, RunStore } from "./run-store.js";
+import type {
+  PreparedIssueWorkspace,
+  PrepareIssueWorkspaceInput
+} from "./workspace.js";
+import { prepareIssueWorkspace as prepareRealIssueWorkspace } from "./workspace.js";
+import {
+  loadWorkflowContract,
+  persistRunEvidence,
+  renderAutonomousPrompt
+} from "./workflow.js";
+
+export type LabelWritingGitHubIssuesApi = GitHubIssuesApi & {
+  addLabelsToIssue: (input: GitHubIssueLabelInput) => Promise<void>;
+  removeLabelsFromIssue: (input: GitHubIssueLabelInput) => Promise<void>;
+};
+
+export type DispatchIssueOptions = {
+  agentProviders: AgentProviderRegistry;
+  configDir: string;
+  configPath: string;
+  createRunId?: () => string;
+  env?: NodeJS.ProcessEnv;
+  githubIssuesApi: GitHubIssuesApi;
+  issuePollStatus: IssuePollStatus;
+  prepareIssueWorkspace?: (
+    input: PrepareIssueWorkspaceInput
+  ) => Promise<PreparedIssueWorkspace>;
+  runStore: RunStore;
+  stateRoot: string;
+};
+
+export type DispatchIssueResult =
+  | {
+      dispatched: false;
+      reason: string;
+    }
+  | {
+      dispatched: true;
+      runId: string;
+    };
+
+type DispatchServiceConfig = z.infer<typeof dispatchServiceConfigSchema>;
+type DispatchProjectConfig = z.infer<typeof dispatchProjectSchema>;
+
+const providerNameSchema = z.enum(["codex", "claude"]);
+const providerCommandSchema = z
+  .object({
+    command: z.string().trim().min(1)
+  })
+  .passthrough();
+
+const dispatchProjectSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    disabled: z.boolean().optional(),
+    tracker: z
+      .object({
+        kind: z.literal("github"),
+        owner: z.string().trim().min(1),
+        repo: z.string().trim().min(1),
+        token: z.string().trim().min(1)
+      })
+      .passthrough(),
+    workspace: z
+      .object({
+        root: z.string().trim().min(1),
+        git: z
+          .object({
+            remote: z.string().trim().min(1),
+            base_branch: z.string().trim().min(1)
+          })
+          .passthrough()
+      })
+      .passthrough(),
+    agent: z
+      .object({
+        provider: providerNameSchema
+      })
+      .passthrough(),
+    workflow: z.string().trim().min(1)
+  })
+  .passthrough();
+
+const dispatchServiceConfigSchema = z
+  .object({
+    providers: z
+      .object({
+        codex: providerCommandSchema,
+        claude: providerCommandSchema
+      })
+      .passthrough(),
+    projects: z.array(dispatchProjectSchema).min(1)
+  })
+  .passthrough();
+
+export async function dispatchOneEligibleIssue(
+  options: DispatchIssueOptions
+): Promise<DispatchIssueResult> {
+  const config = await readDispatchConfig(options.configPath);
+  const target = dispatchTarget(config, options.issuePollStatus, options.agentProviders);
+
+  if (target === undefined) {
+    return {
+      dispatched: false,
+      reason: "no eligible issue has a registered provider"
+    };
+  }
+
+  if (!isLabelWritingGitHubIssuesApi(options.githubIssuesApi)) {
+    return {
+      dispatched: false,
+      reason: "GitHub tracker does not support operational label writes"
+    };
+  }
+
+  const token = resolveEnvBackedValue(
+    target.project.tracker.token,
+    options.env ?? process.env
+  );
+  if (token === undefined) {
+    return {
+      dispatched: false,
+      reason: `projects.${target.project.name}.tracker.token is not available`
+    };
+  }
+
+  const providerName = target.project.agent.provider;
+  const provider = target.provider;
+  const providerCommand = config.providers[providerName].command;
+  const runId = options.createRunId?.() ?? randomUUID();
+  const attemptId = `${runId}-attempt-1`;
+  const issue = target.candidate.issue;
+  const repository = {
+    owner: target.project.tracker.owner,
+    repo: target.project.tracker.repo,
+    token
+  };
+
+  options.runStore.createRun({
+    id: runId,
+    issue,
+    projectName: target.project.name,
+    providerCommand,
+    providerName
+  });
+  await options.githubIssuesApi.addLabelsToIssue({
+    ...repository,
+    issueNumber: issue.number,
+    labels: ["sym:claimed"]
+  });
+
+  try {
+    options.runStore.updateRunState(runId, "preparing_workspace");
+    const prepared = await (options.prepareIssueWorkspace ?? prepareRealIssueWorkspace)({
+      configDir: options.configDir,
+      issue: {
+        number: issue.number,
+        title: issue.title
+      },
+      project: target.project
+    });
+    const promptInput = await buildPromptInput({
+      configDir: options.configDir,
+      issue,
+      prepared,
+      project: target.project,
+      providerCommand,
+      providerName,
+      runId
+    });
+    const renderedPrompt = renderAutonomousPrompt(promptInput);
+    const evidence = await persistRunEvidence({
+      ...promptInput,
+      renderedPrompt,
+      stateRoot: options.stateRoot
+    });
+    const rawLogPath = path.join(
+      evidence.runEvidenceDirectory,
+      "provider.raw.jsonl"
+    );
+    const normalizedLogPath = path.join(
+      evidence.runEvidenceDirectory,
+      "provider.normalized.jsonl"
+    );
+
+    await Promise.all([
+      writeFile(rawLogPath, "", "utf8"),
+      writeFile(normalizedLogPath, "", "utf8")
+    ]);
+    const runEvidence = {
+      branchName: prepared.branchName,
+      branchRef: prepared.branchRef,
+      issueSnapshotPath: evidence.issueSnapshotPath,
+      metadataPath: evidence.metadataPath,
+      normalizedLogPath,
+      promptPath: evidence.promptPath,
+      rawLogPath,
+      workspacePath: prepared.workspacePath
+    };
+    options.runStore.updateRunEvidence(runId, runEvidence);
+
+    await provider.validate(providerCommand);
+    await options.githubIssuesApi.addLabelsToIssue({
+      ...repository,
+      issueNumber: issue.number,
+      labels: ["sym:running"]
+    });
+    options.runStore.updateRunState(runId, "running");
+    options.runStore.createAttempt({
+      ...runEvidence,
+      attemptNumber: 1,
+      id: attemptId,
+      providerCommand,
+      providerName,
+      runId,
+      state: "running"
+    });
+    const finalState = await runProviderAttempt({
+      attemptId,
+      branchName: prepared.branchName,
+      issue,
+      normalizedLogPath,
+      prompt: renderedPrompt.prompt,
+      promptPath: evidence.promptPath,
+      provider,
+      providerCommand,
+      providerName,
+      rawLogPath,
+      runId,
+      runStore: options.runStore,
+      workspacePath: prepared.workspacePath
+    });
+
+    options.runStore.updateAttemptState(attemptId, finalState);
+    options.runStore.updateRunState(runId, finalState);
+    await options.githubIssuesApi.removeLabelsFromIssue({
+      ...repository,
+      issueNumber: issue.number,
+      labels: ["sym:running"]
+    });
+    if (finalState === "failed" || finalState === "input_required") {
+      await options.githubIssuesApi.addLabelsToIssue({
+        ...repository,
+        issueNumber: issue.number,
+        labels: ["sym:failed"]
+      });
+    }
+
+    return {
+      dispatched: true,
+      runId
+    };
+  } catch (error) {
+    options.runStore.updateRunState(runId, "failed");
+    await bestEffortRemoveRunningLabel(
+      options.githubIssuesApi,
+      repository,
+      issue.number
+    );
+    await bestEffortAddFailedLabel(
+      options.githubIssuesApi,
+      repository,
+      issue.number
+    );
+    throw error;
+  }
+}
+
+async function buildPromptInput(input: {
+  configDir: string;
+  issue: IssueSnapshot;
+  prepared: PreparedIssueWorkspace;
+  project: DispatchProjectConfig;
+  providerCommand: string;
+  providerName: AgentProviderName;
+  runId: string;
+}): Promise<Parameters<typeof renderAutonomousPrompt>[0]> {
+  const workflowPath = path.resolve(input.configDir, input.project.workflow);
+  const workflow = await loadWorkflowContract(workflowPath);
+  if (workflow.errors.length > 0) {
+    throw new Error(workflow.errors.join("\n"));
+  }
+
+  return {
+    branch: {
+      name: input.prepared.branchName,
+      ref: input.prepared.branchRef
+    },
+    issue: input.issue,
+    project: {
+      name: input.project.name
+    },
+    provider: {
+      command: input.providerCommand,
+      name: input.providerName
+    },
+    run: {
+      attempt: 1,
+      continuation: false,
+      id: input.runId
+    },
+    template: workflow.body,
+    workflowContentHash: workflow.contentHash,
+    workflowPath,
+    workspace: {
+      path: input.prepared.workspacePath,
+      previous_attempt: input.prepared.reused,
+      root: path.resolve(input.configDir, input.project.workspace.root)
+    }
+  };
+}
+
+async function runProviderAttempt(input: {
+  attemptId: string;
+  branchName: string;
+  issue: IssueSnapshot;
+  normalizedLogPath: string;
+  prompt: string;
+  promptPath: string;
+  provider: AgentProvider;
+  providerCommand: string;
+  providerName: AgentProviderName;
+  rawLogPath: string;
+  runId: string;
+  runStore: RunStore;
+  workspacePath: string;
+}): Promise<RunState> {
+  let finalState: RunState = "succeeded";
+  let sequence = 0;
+
+  for await (const event of input.provider.runAttempt({
+    branchName: input.branchName,
+    issue: input.issue,
+    prompt: input.prompt,
+    promptPath: input.promptPath,
+    provider: {
+      command: input.providerCommand,
+      name: input.providerName
+    },
+    run: {
+      attempt: 1,
+      id: input.runId
+    },
+    workspacePath: input.workspacePath
+  })) {
+    sequence += 1;
+    await persistProviderEvent({
+      attemptId: input.attemptId,
+      event,
+      normalizedLogPath: input.normalizedLogPath,
+      rawLogPath: input.rawLogPath,
+      runId: input.runId,
+      runStore: input.runStore,
+      sequence
+    });
+    finalState = terminalStateAfterEvent(finalState, event.normalized);
+  }
+
+  return finalState;
+}
+
+async function persistProviderEvent(input: {
+  attemptId: string;
+  event: ProviderEvent;
+  normalizedLogPath: string;
+  rawLogPath: string;
+  runId: string;
+  runStore: RunStore;
+  sequence: number;
+}): Promise<void> {
+  await Promise.all([
+    appendJsonl(input.rawLogPath, input.event.raw),
+    appendJsonl(input.normalizedLogPath, input.event.normalized)
+  ]);
+  input.runStore.recordProviderEvent({
+    attemptId: input.attemptId,
+    normalized: input.event.normalized,
+    raw: input.event.raw,
+    runId: input.runId,
+    sequence: input.sequence
+  });
+}
+
+function terminalStateAfterEvent(
+  current: RunState,
+  event: NormalizedProviderEvent
+): RunState {
+  if (current === "input_required" || current === "failed") {
+    return current;
+  }
+
+  if (event.type === "input_required") {
+    return "input_required";
+  }
+
+  if (event.type === "turn_failed" || event.type === "malformed_event") {
+    return "failed";
+  }
+
+  if (event.type === "process_exit" && processExitFailed(event)) {
+    return "failed";
+  }
+
+  return current;
+}
+
+function processExitFailed(event: NormalizedProviderEvent): boolean {
+  const exitCode = event.exitCode;
+  return typeof exitCode === "number" && exitCode !== 0;
+}
+
+async function appendJsonl(filePath: string, value: unknown): Promise<void> {
+  await appendFile(filePath, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function dispatchTarget(
+  config: DispatchServiceConfig,
+  issuePollStatus: IssuePollStatus,
+  providers: AgentProviderRegistry
+):
+  | {
+      candidate: ProjectIssueSnapshot;
+      project: DispatchProjectConfig;
+      provider: AgentProvider;
+    }
+  | undefined {
+  for (const candidate of issuePollStatus.candidateIssues) {
+    const project = config.projects.find(
+      (entry) => entry.name === candidate.project && entry.disabled !== true
+    );
+    if (project === undefined) {
+      continue;
+    }
+
+    const provider = providers[project.agent.provider];
+    if (provider !== undefined) {
+      return {
+        candidate,
+        project,
+        provider
+      };
+    }
+  }
+
+  return undefined;
+}
+
+async function readDispatchConfig(
+  configPath: string
+): Promise<DispatchServiceConfig> {
+  const contents = await readFile(configPath, "utf8");
+  const parsed = dispatchServiceConfigSchema.safeParse(parse(contents) ?? {});
+
+  if (!parsed.success) {
+    throw new Error(
+      parsed.error.issues
+        .map((issue) =>
+          `${issue.path.length === 0 ? "service config" : issue.path.join(".")}: ${issue.message}`
+        )
+        .join("\n")
+    );
+  }
+
+  return parsed.data;
+}
+
+function isLabelWritingGitHubIssuesApi(
+  api: GitHubIssuesApi
+): api is LabelWritingGitHubIssuesApi {
+  const candidate = api as Partial<LabelWritingGitHubIssuesApi>;
+  return (
+    typeof candidate.addLabelsToIssue === "function" &&
+    typeof candidate.removeLabelsFromIssue === "function"
+  );
+}
+
+function resolveEnvBackedValue(
+  input: string,
+  env: NodeJS.ProcessEnv
+): string | undefined {
+  const variableName = envReferenceName(input);
+  if (variableName === undefined) {
+    return undefined;
+  }
+
+  const value = env[variableName];
+  return value === undefined || value.length === 0 ? undefined : value;
+}
+
+function envReferenceName(input: string): string | undefined {
+  const match = /^\$([A-Za-z_][A-Za-z0-9_]*)$/.exec(input);
+  return match?.[1];
+}
+
+async function bestEffortRemoveRunningLabel(
+  api: LabelWritingGitHubIssuesApi,
+  repository: GitHubIssueRepositoryInput,
+  issueNumber: number
+): Promise<void> {
+  try {
+    await api.removeLabelsFromIssue({
+      ...repository,
+      issueNumber,
+      labels: ["sym:running"]
+    });
+  } catch {
+    // Preserve the original failure; reconciliation will surface stale labels later.
+  }
+}
+
+async function bestEffortAddFailedLabel(
+  api: LabelWritingGitHubIssuesApi,
+  repository: GitHubIssueRepositoryInput,
+  issueNumber: number
+): Promise<void> {
+  try {
+    await api.addLabelsToIssue({
+      ...repository,
+      issueNumber,
+      labels: ["sym:failed"]
+    });
+  } catch {
+    // Preserve the original failure; the run store remains the durable failure record.
+  }
+}

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -158,20 +158,26 @@ export async function dispatchOneEligibleIssue(
     token
   };
 
-  options.runStore.createRun({
-    id: runId,
-    issue,
-    projectName: target.project.name,
-    providerCommand,
-    providerName
-  });
-  await options.githubIssuesApi.addLabelsToIssue({
-    ...repository,
-    issueNumber: issue.number,
-    labels: ["sym:claimed"]
-  });
+  let runCreated = false;
+  let attemptCreated = false;
+  let claimed = false;
+  let running = false;
 
   try {
+    await options.githubIssuesApi.addLabelsToIssue({
+      ...repository,
+      issueNumber: issue.number,
+      labels: ["sym:claimed"]
+    });
+    claimed = true;
+    options.runStore.createRun({
+      id: runId,
+      issue,
+      projectName: target.project.name,
+      providerCommand,
+      providerName
+    });
+    runCreated = true;
     options.runStore.updateRunState(runId, "preparing_workspace");
     const prepared = await (options.prepareIssueWorkspace ?? prepareRealIssueWorkspace)({
       configDir: options.configDir,
@@ -227,6 +233,7 @@ export async function dispatchOneEligibleIssue(
       issueNumber: issue.number,
       labels: ["sym:running"]
     });
+    running = true;
     options.runStore.updateRunState(runId, "running");
     options.runStore.createAttempt({
       ...runEvidence,
@@ -237,6 +244,7 @@ export async function dispatchOneEligibleIssue(
       runId,
       state: "running"
     });
+    attemptCreated = true;
     const finalState = await runProviderAttempt({
       attemptId,
       branchName: prepared.branchName,
@@ -273,17 +281,26 @@ export async function dispatchOneEligibleIssue(
       runId
     };
   } catch (error) {
-    options.runStore.updateRunState(runId, "failed");
-    await bestEffortRemoveRunningLabel(
-      options.githubIssuesApi,
-      repository,
-      issue.number
-    );
-    await bestEffortAddFailedLabel(
-      options.githubIssuesApi,
-      repository,
-      issue.number
-    );
+    if (attemptCreated) {
+      options.runStore.updateAttemptState(attemptId, "failed");
+    }
+    if (runCreated) {
+      options.runStore.updateRunState(runId, "failed");
+    }
+    if (running) {
+      await bestEffortRemoveRunningLabel(
+        options.githubIssuesApi,
+        repository,
+        issue.number
+      );
+    }
+    if (claimed) {
+      await bestEffortAddFailedLabel(
+        options.githubIssuesApi,
+        repository,
+        issue.number
+      );
+    }
     throw error;
   }
 }

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -2,8 +2,13 @@ import { Hono } from "hono";
 
 import type { IssuePollStatus } from "../issue-polling.js";
 import { emptyIssuePollStatus } from "../issue-polling.js";
+import type { RunStatus } from "../run-store.js";
 
 export type HttpAppOptions = {
+  dispatchRuntime?: {
+    dispatching: boolean;
+  };
+  getRuns?: () => RunStatus[];
   issuePollStatus?: IssuePollStatus;
   stateRoot: string;
   version: string;
@@ -16,6 +21,10 @@ export function createHttpApp(options: HttpAppOptions): Hono {
   const startedAtMs = options.startedAtMs ?? Date.now();
   const now = options.now ?? Date.now;
   const issuePollStatus = options.issuePollStatus ?? emptyIssuePollStatus();
+  const dispatchRuntime = options.dispatchRuntime ?? {
+    dispatching: false
+  };
+  const getRuns = options.getRuns ?? (() => []);
 
   app.get("/health", (context) =>
     context.json({
@@ -35,9 +44,10 @@ export function createHttpApp(options: HttpAppOptions): Hono {
         errors: issuePollStatus.errors,
         projects: issuePollStatus.projects
       },
+      runs: getRuns(),
       service: "symphonika",
-      state: "idle",
-      dispatching: false,
+      state: dispatchRuntime.dispatching ? "dispatching" : "idle",
+      dispatching: dispatchRuntime.dispatching,
       stateRoot: options.stateRoot,
       uptimeMs: uptimeMs(startedAtMs, now)
     })

--- a/src/issue-polling.ts
+++ b/src/issue-polling.ts
@@ -11,6 +11,11 @@ export type GitHubIssueRepositoryInput = {
   token: string;
 };
 
+export type GitHubIssueLabelInput = GitHubIssueRepositoryInput & {
+  issueNumber: number;
+  labels: string[];
+};
+
 export type RawGitHubIssue = {
   body?: string | null;
   created_at?: string | null;
@@ -26,9 +31,11 @@ export type RawGitHubIssue = {
 };
 
 export type GitHubIssuesApi = {
+  addLabelsToIssue?: (input: GitHubIssueLabelInput) => Promise<void>;
   listOpenIssues: (
     input: GitHubIssueRepositoryInput
   ) => Promise<RawGitHubIssue[]>;
+  removeLabelsFromIssue?: (input: GitHubIssueLabelInput) => Promise<void>;
 };
 
 export type IssueSnapshot = {
@@ -136,13 +143,20 @@ const SILENT_OCTOKIT_LOG = {
 };
 
 class OctokitGitHubIssuesApi implements GitHubIssuesApi {
+  async addLabelsToIssue(input: GitHubIssueLabelInput): Promise<void> {
+    const octokit = this.octokit(input.token);
+    await octokit.rest.issues.addLabels({
+      issue_number: input.issueNumber,
+      labels: input.labels,
+      owner: input.owner,
+      repo: input.repo
+    });
+  }
+
   async listOpenIssues(
     input: GitHubIssueRepositoryInput
   ): Promise<RawGitHubIssue[]> {
-    const octokit = new Octokit({
-      auth: input.token,
-      log: SILENT_OCTOKIT_LOG
-    });
+    const octokit = this.octokit(input.token);
     const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
       owner: input.owner,
       per_page: 100,
@@ -152,9 +166,28 @@ class OctokitGitHubIssuesApi implements GitHubIssuesApi {
 
     return issues;
   }
+
+  async removeLabelsFromIssue(input: GitHubIssueLabelInput): Promise<void> {
+    const octokit = this.octokit(input.token);
+    for (const label of input.labels) {
+      await octokit.rest.issues.removeLabel({
+        issue_number: input.issueNumber,
+        name: label,
+        owner: input.owner,
+        repo: input.repo
+      });
+    }
+  }
+
+  private octokit(token: string): Octokit {
+    return new Octokit({
+      auth: token,
+      log: SILENT_OCTOKIT_LOG
+    });
+  }
 }
 
-const DEFAULT_GITHUB_ISSUES_API = new OctokitGitHubIssuesApi();
+export const DEFAULT_GITHUB_ISSUES_API = new OctokitGitHubIssuesApi();
 export const DEFAULT_POLLING_INTERVAL_MS = 30_000;
 
 export function emptyIssuePollStatus(): IssuePollStatus {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,0 +1,50 @@
+import type { IssueSnapshot } from "./issue-polling.js";
+
+export type AgentProviderName = "codex" | "claude";
+
+export type NormalizedProviderEventType =
+  | "session_started"
+  | "message"
+  | "tool_call"
+  | "usage_updated"
+  | "rate_limit_updated"
+  | "turn_completed"
+  | "turn_failed"
+  | "input_required"
+  | "process_exit"
+  | "malformed_event";
+
+export type NormalizedProviderEvent = {
+  type: NormalizedProviderEventType;
+  [key: string]: unknown;
+};
+
+export type ProviderEvent = {
+  normalized: NormalizedProviderEvent;
+  raw: unknown;
+};
+
+export type ProviderRunInput = {
+  branchName: string;
+  issue: IssueSnapshot;
+  prompt: string;
+  promptPath: string;
+  provider: {
+    command: string;
+    name: AgentProviderName;
+  };
+  run: {
+    attempt: number;
+    id: string;
+  };
+  workspacePath: string;
+};
+
+export type AgentProvider = {
+  cancel: (runId: string) => Promise<void>;
+  name: AgentProviderName;
+  runAttempt: (input: ProviderRunInput) => AsyncIterable<ProviderEvent>;
+  validate: (command: string) => Promise<void>;
+};
+
+export type AgentProviderRegistry = Partial<Record<AgentProviderName, AgentProvider>>;

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -1,0 +1,359 @@
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import DatabaseConstructor from "better-sqlite3";
+import type { Database as SqliteDatabase } from "better-sqlite3";
+
+import type { IssueSnapshot } from "./issue-polling.js";
+import type { AgentProviderName, NormalizedProviderEvent } from "./provider.js";
+
+export type RunState =
+  | "queued"
+  | "preparing_workspace"
+  | "running"
+  | "input_required"
+  | "failed"
+  | "succeeded"
+  | "cancelled"
+  | "stale";
+
+export type RunStatus = {
+  branchName: string;
+  id: string;
+  issueNumber: number;
+  issueSnapshotPath: string;
+  metadataPath: string;
+  normalizedLogPath: string;
+  project: string;
+  promptPath: string;
+  provider: string;
+  rawLogPath: string;
+  state: RunState;
+  workspacePath: string;
+};
+
+export type OpenRunStoreOptions = {
+  stateRoot: string;
+};
+
+export type CreateRunInput = {
+  id: string;
+  issue: IssueSnapshot;
+  projectName: string;
+  providerCommand: string;
+  providerName: AgentProviderName;
+};
+
+export type RunEvidenceInput = {
+  branchName: string;
+  branchRef: string;
+  issueSnapshotPath: string;
+  metadataPath: string;
+  normalizedLogPath: string;
+  promptPath: string;
+  rawLogPath: string;
+  workspacePath: string;
+};
+
+export type CreateAttemptInput = RunEvidenceInput & {
+  attemptNumber: number;
+  id: string;
+  providerCommand: string;
+  providerName: AgentProviderName;
+  runId: string;
+  state: RunState;
+};
+
+export type ProviderEventMetadataInput = {
+  attemptId: string;
+  normalized: NormalizedProviderEvent;
+  raw: unknown;
+  runId: string;
+  sequence: number;
+};
+
+type RunRow = {
+  branch_name: string | null;
+  id: string;
+  issue_number: number;
+  issue_snapshot_path: string | null;
+  metadata_path: string | null;
+  normalized_log_path: string | null;
+  project_name: string;
+  prompt_path: string | null;
+  provider_name: string | null;
+  raw_log_path: string | null;
+  state: RunState;
+  workspace_path: string | null;
+};
+
+export class RunStore {
+  private readonly database: SqliteDatabase;
+
+  constructor(database: SqliteDatabase) {
+    this.database = database;
+    this.migrate();
+  }
+
+  close(): void {
+    this.database.close();
+  }
+
+  createRun(input: CreateRunInput): void {
+    const now = timestamp();
+    this.database
+      .prepare(
+        [
+          "insert into runs (",
+          "id, project_name, issue_number, issue_title, state, issue_snapshot_json,",
+          "provider_name, provider_command, created_at, updated_at",
+          ") values (",
+          "@id, @project_name, @issue_number, @issue_title, @state, @issue_snapshot_json,",
+          "@provider_name, @provider_command, @created_at, @updated_at",
+          ")"
+        ].join(" ")
+      )
+      .run({
+        created_at: now,
+        id: input.id,
+        issue_number: input.issue.number,
+        issue_snapshot_json: JSON.stringify(input.issue),
+        issue_title: input.issue.title,
+        project_name: input.projectName,
+        provider_command: input.providerCommand,
+        provider_name: input.providerName,
+        state: "queued",
+        updated_at: now
+      });
+    this.recordRunTransition(input.id, "queued", now);
+  }
+
+  updateRunState(runId: string, state: RunState): void {
+    const now = timestamp();
+    this.database
+      .prepare("update runs set state = ?, updated_at = ? where id = ?")
+      .run(state, now, runId);
+    this.recordRunTransition(runId, state, now);
+  }
+
+  updateRunEvidence(runId: string, evidence: RunEvidenceInput): void {
+    this.database
+      .prepare(
+        [
+          "update runs set",
+          "branch_name = @branch_name,",
+          "branch_ref = @branch_ref,",
+          "issue_snapshot_path = @issue_snapshot_path,",
+          "metadata_path = @metadata_path,",
+          "normalized_log_path = @normalized_log_path,",
+          "prompt_path = @prompt_path,",
+          "raw_log_path = @raw_log_path,",
+          "workspace_path = @workspace_path,",
+          "updated_at = @updated_at",
+          "where id = @id"
+        ].join(" ")
+      )
+      .run({
+        branch_name: evidence.branchName,
+        branch_ref: evidence.branchRef,
+        id: runId,
+        issue_snapshot_path: evidence.issueSnapshotPath,
+        metadata_path: evidence.metadataPath,
+        normalized_log_path: evidence.normalizedLogPath,
+        prompt_path: evidence.promptPath,
+        raw_log_path: evidence.rawLogPath,
+        updated_at: timestamp(),
+        workspace_path: evidence.workspacePath
+      });
+  }
+
+  createAttempt(input: CreateAttemptInput): void {
+    const now = timestamp();
+    this.database
+      .prepare(
+        [
+          "insert into attempts (",
+          "id, run_id, attempt_number, state, provider_name, provider_command,",
+          "workspace_path, branch_name, prompt_path, issue_snapshot_path,",
+          "raw_log_path, normalized_log_path, created_at, updated_at",
+          ") values (",
+          "@id, @run_id, @attempt_number, @state, @provider_name, @provider_command,",
+          "@workspace_path, @branch_name, @prompt_path, @issue_snapshot_path,",
+          "@raw_log_path, @normalized_log_path, @created_at, @updated_at",
+          ")"
+        ].join(" ")
+      )
+      .run({
+        attempt_number: input.attemptNumber,
+        branch_name: input.branchName,
+        created_at: now,
+        id: input.id,
+        issue_snapshot_path: input.issueSnapshotPath,
+        normalized_log_path: input.normalizedLogPath,
+        prompt_path: input.promptPath,
+        provider_command: input.providerCommand,
+        provider_name: input.providerName,
+        raw_log_path: input.rawLogPath,
+        run_id: input.runId,
+        state: input.state,
+        updated_at: now,
+        workspace_path: input.workspacePath
+      });
+  }
+
+  updateAttemptState(attemptId: string, state: RunState): void {
+    this.database
+      .prepare("update attempts set state = ?, updated_at = ? where id = ?")
+      .run(state, timestamp(), attemptId);
+  }
+
+  recordProviderEvent(input: ProviderEventMetadataInput): void {
+    this.database
+      .prepare(
+        [
+          "insert into provider_events (",
+          "run_id, attempt_id, sequence, type, raw_json, normalized_json, created_at",
+          ") values (",
+          "@run_id, @attempt_id, @sequence, @type, @raw_json, @normalized_json, @created_at",
+          ")"
+        ].join(" ")
+      )
+      .run({
+        attempt_id: input.attemptId,
+        created_at: timestamp(),
+        normalized_json: JSON.stringify(input.normalized),
+        raw_json: JSON.stringify(input.raw),
+        run_id: input.runId,
+        sequence: input.sequence,
+        type: input.normalized.type
+      });
+  }
+
+  listRuns(): RunStatus[] {
+    const rows = this.database
+      .prepare(
+        [
+          "select id, project_name, issue_number, state, provider_name,",
+          "workspace_path, branch_name, prompt_path, metadata_path,",
+          "issue_snapshot_path, raw_log_path, normalized_log_path",
+          "from runs order by created_at desc, id desc"
+        ].join(" ")
+      )
+      .all() as RunRow[];
+
+    return rows.map((row) => ({
+      branchName: row.branch_name ?? "",
+      id: row.id,
+      issueNumber: row.issue_number,
+      issueSnapshotPath: row.issue_snapshot_path ?? "",
+      metadataPath: row.metadata_path ?? "",
+      normalizedLogPath: row.normalized_log_path ?? "",
+      project: row.project_name,
+      promptPath: row.prompt_path ?? "",
+      provider: row.provider_name ?? "",
+      rawLogPath: row.raw_log_path ?? "",
+      state: row.state,
+      workspacePath: row.workspace_path ?? ""
+    }));
+  }
+
+  private migrate(): void {
+    this.database.exec(`
+      create table if not exists runs (
+        id text primary key,
+        project_name text not null,
+        issue_number integer not null,
+        issue_title text not null,
+        state text not null,
+        issue_snapshot_json text not null,
+        provider_name text,
+        provider_command text,
+        workspace_path text,
+        branch_name text,
+        branch_ref text,
+        prompt_path text,
+        metadata_path text,
+        issue_snapshot_path text,
+        raw_log_path text,
+        normalized_log_path text,
+        created_at text not null,
+        updated_at text not null
+      );
+
+      create table if not exists attempts (
+        id text primary key,
+        run_id text not null,
+        attempt_number integer not null,
+        state text not null,
+        provider_name text not null,
+        provider_command text not null,
+        workspace_path text not null,
+        branch_name text not null,
+        prompt_path text not null,
+        issue_snapshot_path text not null,
+        raw_log_path text not null,
+        normalized_log_path text not null,
+        created_at text not null,
+        updated_at text not null,
+        foreign key (run_id) references runs(id)
+      );
+
+      create table if not exists run_state_transitions (
+        id integer primary key autoincrement,
+        run_id text not null,
+        sequence integer not null,
+        state text not null,
+        created_at text not null,
+        foreign key (run_id) references runs(id)
+      );
+
+      create table if not exists provider_events (
+        id integer primary key autoincrement,
+        run_id text not null,
+        attempt_id text not null,
+        sequence integer not null,
+        type text not null,
+        raw_json text not null,
+        normalized_json text not null,
+        created_at text not null,
+        foreign key (run_id) references runs(id),
+        foreign key (attempt_id) references attempts(id)
+      );
+    `);
+  }
+
+  private recordRunTransition(
+    runId: string,
+    state: RunState,
+    createdAt: string
+  ): void {
+    const sequence = nextTransitionSequence(this.database, runId);
+    this.database
+      .prepare(
+        "insert into run_state_transitions (run_id, sequence, state, created_at) values (?, ?, ?, ?)"
+      )
+      .run(runId, sequence, state, createdAt);
+  }
+}
+
+export function openRunStore(options: OpenRunStoreOptions): RunStore {
+  mkdirSync(options.stateRoot, { recursive: true });
+  return new RunStore(new DatabaseConstructor(databasePath(options.stateRoot)));
+}
+
+export function databasePath(stateRoot: string): string {
+  return path.join(stateRoot, "symphonika.db");
+}
+
+function nextTransitionSequence(database: SqliteDatabase, runId: string): number {
+  const row = database
+    .prepare(
+      "select coalesce(max(sequence), 0) + 1 as next_sequence from run_state_transitions where run_id = ?"
+    )
+    .get(runId) as { next_sequence?: number } | undefined;
+
+  return row?.next_sequence ?? 1;
+}
+
+function timestamp(): string {
+  return new Date().toISOString();
+}

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -317,6 +317,75 @@ describe("daemon dispatch", () => {
     }
   });
 
+  it("dispatches an issue that becomes eligible on a later poll interval", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "8-dispatch-an-end-to-end-run-through-a-test-provider"
+    );
+    await mkdir(workspacePath, { recursive: true });
+    await writeValidProject(root, { pollingIntervalMs: 10 });
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 8,
+            title: "Dispatch an end-to-end run through a test provider"
+          })
+        ])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const prepareIssueWorkspace = vi.fn(
+      (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
+        void input;
+        return Promise.resolve(preparedWorkspaceFixture(root));
+      }
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: {
+        codex: codexProvider
+      },
+      createRunId: () => "run-issue-8-polled",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "succeeded");
+      const run = firstRun(status);
+
+      expect(githubIssuesApi.listOpenIssues.mock.calls.length).toBeGreaterThanOrEqual(
+        2
+      );
+      expect(run).toMatchObject({
+        id: "run-issue-8-polled",
+        issueNumber: 8,
+        state: "succeeded",
+        workspacePath
+      });
+      expect(prepareIssueWorkspace).toHaveBeenCalledOnce();
+      expect(codexProvider.runAttempt).toHaveBeenCalledOnce();
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("marks a fake-provider process failure and preserves logs for inspection", async () => {
     const root = await makeTempRoot();
     const workspacePath = path.join(
@@ -727,14 +796,17 @@ function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
   };
 }
 
-async function writeValidProject(root: string): Promise<void> {
+async function writeValidProject(
+  root: string,
+  options: { pollingIntervalMs?: number } = {}
+): Promise<void> {
   await writeFile(
     path.join(root, "symphonika.yml"),
     [
       "state:",
       "  root: ./.symphonika",
       "polling:",
-      "  interval_ms: 30000",
+      `  interval_ms: ${options.pollingIntervalMs ?? 30000}`,
       "providers:",
       "  codex:",
       '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -475,6 +475,178 @@ describe("daemon dispatch", () => {
       await daemon.stop();
     }
   });
+
+  it("does not persist a queued run when the initial claim label write fails", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockRejectedValue(new Error("claim rejected")),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 8,
+          title: "Dispatch an end-to-end run through a test provider"
+        })
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const prepareIssueWorkspace = vi.fn(
+      (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
+        void input;
+        return Promise.resolve(preparedWorkspaceFixture(root));
+      }
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: {
+        codex: codexProvider
+      },
+      createRunId: () => "run-issue-8-claim-rejected",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitForStatusError(daemon.url, "claim rejected");
+      expect(prepareIssueWorkspace).not.toHaveBeenCalled();
+      expect(codexProvider.validate).not.toHaveBeenCalled();
+
+      const database = new Database(path.join(root, ".symphonika", "symphonika.db"), {
+        readonly: true
+      });
+      try {
+        expect(countRows(database, "runs")).toBe(0);
+        expect(countRows(database, "attempts")).toBe(0);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("marks the attempt failed when provider execution throws after launch", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "8-dispatch-an-end-to-end-run-through-a-test-provider"
+    );
+    await mkdir(workspacePath, { recursive: true });
+    await writeValidProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 8,
+          title: "Dispatch an end-to-end run through a test provider"
+        })
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        yield await Promise.reject(new Error("provider crashed"));
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+    const prepareIssueWorkspace = vi.fn(
+      (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
+        void input;
+        return Promise.resolve(preparedWorkspaceFixture(root));
+      }
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: {
+        codex: codexProvider
+      },
+      createRunId: () => "run-issue-8-provider-crashed",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "failed");
+      const run = firstRun(status);
+
+      expect(githubIssuesApi.addLabelsToIssue.mock.calls).toEqual([
+        [
+          {
+            issueNumber: 8,
+            labels: ["sym:claimed"],
+            owner: "pmatos",
+            repo: "symphonika",
+            token: "secret-token"
+          }
+        ],
+        [
+          {
+            issueNumber: 8,
+            labels: ["sym:running"],
+            owner: "pmatos",
+            repo: "symphonika",
+            token: "secret-token"
+          }
+        ],
+        [
+          {
+            issueNumber: 8,
+            labels: ["sym:failed"],
+            owner: "pmatos",
+            repo: "symphonika",
+            token: "secret-token"
+          }
+        ]
+      ]);
+      expect(githubIssuesApi.removeLabelsFromIssue).toHaveBeenCalledWith({
+        issueNumber: 8,
+        labels: ["sym:running"],
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret-token"
+      });
+      expect(run).toMatchObject({
+        id: "run-issue-8-provider-crashed",
+        issueNumber: 8,
+        state: "failed",
+        workspacePath
+      });
+
+      const database = new Database(path.join(root, ".symphonika", "symphonika.db"), {
+        readonly: true
+      });
+      try {
+        const attempts = database.prepare("select * from attempts").all();
+        expect(attempts).toHaveLength(1);
+        expect(attempts[0]).toMatchObject({
+          run_id: "run-issue-8-provider-crashed",
+          state: "failed"
+        });
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
 });
 
 function issueFixture(overrides: {
@@ -502,6 +674,56 @@ function issueFixture(overrides: {
     state: "open",
     title: overrides.title,
     updated_at: "2026-04-21T11:00:00Z"
+  };
+}
+
+function successfulCodexProvider(): AgentProvider {
+  return {
+    cancel: vi.fn().mockResolvedValue(undefined),
+    name: "codex",
+    runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+      await Promise.resolve();
+      yield {
+        normalized: {
+          exitCode: 0,
+          type: "process_exit"
+        },
+        raw: {
+          code: 0,
+          kind: "exit"
+        }
+      };
+    }),
+    validate: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
+  const workspacePath = path.join(
+    root,
+    ".symphonika",
+    "workspaces",
+    "symphonika",
+    "issues",
+    "8-dispatch-an-end-to-end-run-through-a-test-provider"
+  );
+
+  return {
+    branchName:
+      "sym/symphonika/8-dispatch-an-end-to-end-run-through-a-test-provider",
+    branchRef:
+      "refs/heads/sym/symphonika/8-dispatch-an-end-to-end-run-through-a-test-provider",
+    cachePath: path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      ".cache",
+      "repo.git"
+    ),
+    issueDirectoryName: "8-dispatch-an-end-to-end-run-through-a-test-provider",
+    reused: false,
+    workspacePath
   };
 }
 
@@ -604,6 +826,33 @@ async function waitForRun(
   throw new Error(`run did not reach ${state} before timeout`);
 }
 
+async function waitForStatusError(
+  url: string,
+  message: string,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 1_000;
+  const intervalMs = options.intervalMs ?? 10;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await fetch(`${url}/api/status`);
+    const body = (await response.json()) as {
+      issuePolling?: {
+        errors?: string[];
+      };
+    };
+
+    if (body.issuePolling?.errors?.some((error) => error.includes(message))) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`status error did not include ${message} before timeout`);
+}
+
 function readJsonl(contents: string): unknown[] {
   return contents
     .split(/\r?\n/)
@@ -629,6 +878,25 @@ function firstPrepareIssueWorkspaceInput(
   }
 
   return call[0];
+}
+
+function countRows(
+  database: {
+    prepare: (source: string) => {
+      get: () => unknown;
+    };
+  },
+  table: "attempts" | "runs"
+): number {
+  const row = database.prepare(`select count(*) as count from ${table}`).get();
+  if (typeof row === "object" && row !== null && "count" in row) {
+    const value = row.count;
+    if (typeof value === "number") {
+      return value;
+    }
+  }
+
+  throw new Error(`expected row count for ${table}`);
 }
 
 function stringColumn(row: unknown, key: string): string {

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1,0 +1,643 @@
+import Database from "better-sqlite3";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+import type {
+  AgentProvider,
+  ProviderEvent,
+  ProviderRunInput
+} from "../src/provider.js";
+import type {
+  PreparedIssueWorkspace,
+  PrepareIssueWorkspaceInput
+} from "../src/workspace.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-dispatch-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("daemon dispatch", () => {
+  it("claims one eligible issue and persists a completed fake-provider run", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "8-dispatch-an-end-to-end-run-through-a-test-provider"
+    );
+    await mkdir(workspacePath, { recursive: true });
+    await writeValidProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready", "priority:high"],
+          number: 8,
+          title: "Dispatch an end-to-end run through a test provider"
+        })
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const providerInputs: ProviderRunInput[] = [];
+    const codexProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (
+        input: ProviderRunInput
+      ): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        providerInputs.push(input);
+        yield {
+          normalized: {
+            sessionId: "fake-session-8",
+            type: "session_started"
+          },
+          raw: {
+            id: "fake-session-8",
+            kind: "session"
+          }
+        };
+        yield {
+          normalized: {
+            message: "completed fake issue 8",
+            type: "message"
+          },
+          raw: {
+            kind: "assistant_message",
+            text: "completed fake issue 8"
+          }
+        };
+        yield {
+          normalized: {
+            exitCode: 0,
+            type: "process_exit"
+          },
+          raw: {
+            code: 0,
+            kind: "exit"
+          }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+    const preparedWorkspace: PreparedIssueWorkspace = {
+      branchName:
+        "sym/symphonika/8-dispatch-an-end-to-end-run-through-a-test-provider",
+      branchRef:
+        "refs/heads/sym/symphonika/8-dispatch-an-end-to-end-run-through-a-test-provider",
+      cachePath: path.join(
+        root,
+        ".symphonika",
+        "workspaces",
+        "symphonika",
+        ".cache",
+        "repo.git"
+      ),
+      issueDirectoryName: "8-dispatch-an-end-to-end-run-through-a-test-provider",
+      reused: false,
+      workspacePath
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
+        void input;
+        return Promise.resolve(preparedWorkspace);
+      }
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: {
+        codex: codexProvider
+      },
+      createRunId: () => "run-issue-8",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "succeeded");
+      const run = firstRun(status);
+
+      expect(githubIssuesApi.addLabelsToIssue.mock.calls).toEqual([
+        [
+          {
+            issueNumber: 8,
+            labels: ["sym:claimed"],
+            owner: "pmatos",
+            repo: "symphonika",
+            token: "secret-token"
+          }
+        ],
+        [
+          {
+            issueNumber: 8,
+            labels: ["sym:running"],
+            owner: "pmatos",
+            repo: "symphonika",
+            token: "secret-token"
+          }
+        ]
+      ]);
+      expect(githubIssuesApi.removeLabelsFromIssue).toHaveBeenCalledWith({
+        issueNumber: 8,
+        labels: ["sym:running"],
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret-token"
+      });
+      const workspaceInput = firstPrepareIssueWorkspaceInput(prepareIssueWorkspace);
+      expect(workspaceInput.configDir).toBe(root);
+      expect(workspaceInput.issue).toEqual({
+        number: 8,
+        title: "Dispatch an end-to-end run through a test provider"
+      });
+      expect(workspaceInput.project.name).toBe("symphonika");
+      expect(codexProvider.validate).toHaveBeenCalledWith(
+        "codex --dangerously-bypass-approvals-and-sandbox app-server"
+      );
+      expect(providerInputs).toHaveLength(1);
+      expect(providerInputs[0]).toMatchObject({
+        issue: {
+          number: 8
+        },
+        promptPath: run.promptPath,
+        run: {
+          attempt: 1,
+          id: "run-issue-8"
+        },
+        workspacePath
+      });
+
+      expect(run).toMatchObject({
+        branchName:
+          "sym/symphonika/8-dispatch-an-end-to-end-run-through-a-test-provider",
+        issueNumber: 8,
+        normalizedLogPath: path.join(
+          root,
+          ".symphonika",
+          "logs",
+          "runs",
+          "run-issue-8",
+          "provider.normalized.jsonl"
+        ),
+        project: "symphonika",
+        promptPath: path.join(
+          root,
+          ".symphonika",
+          "logs",
+          "runs",
+          "run-issue-8",
+          "prompt.md"
+        ),
+        provider: "codex",
+        rawLogPath: path.join(
+          root,
+          ".symphonika",
+          "logs",
+          "runs",
+          "run-issue-8",
+          "provider.raw.jsonl"
+        ),
+        state: "succeeded",
+        workspacePath
+      });
+
+      expect(path.relative(workspacePath, run.promptPath)).toMatch(/^\.\./);
+      await expect(readFile(run.promptPath, "utf8")).resolves.toContain(
+        "Autonomous run instructions"
+      );
+      await expect(readFile(run.promptPath, "utf8")).resolves.toContain(
+        "Dispatch an end-to-end run through a test provider"
+      );
+      expect(readJsonl(await readFile(run.rawLogPath, "utf8"))).toEqual([
+        {
+          id: "fake-session-8",
+          kind: "session"
+        },
+        {
+          kind: "assistant_message",
+          text: "completed fake issue 8"
+        },
+        {
+          code: 0,
+          kind: "exit"
+        }
+      ]);
+      expect(readJsonl(await readFile(run.normalizedLogPath, "utf8"))).toEqual([
+        {
+          sessionId: "fake-session-8",
+          type: "session_started"
+        },
+        {
+          message: "completed fake issue 8",
+          type: "message"
+        },
+        {
+          exitCode: 0,
+          type: "process_exit"
+        }
+      ]);
+
+      const databasePath = path.join(root, ".symphonika", "symphonika.db");
+      const database = new Database(databasePath, { readonly: true });
+      try {
+        const storedRun = database.prepare("select * from runs").get();
+        expect(storedRun).toMatchObject({
+          branch_name:
+            "sym/symphonika/8-dispatch-an-end-to-end-run-through-a-test-provider",
+          id: "run-issue-8",
+          issue_number: 8,
+          normalized_log_path: run.normalizedLogPath,
+          project_name: "symphonika",
+          prompt_path: run.promptPath,
+          provider_command:
+            "codex --dangerously-bypass-approvals-and-sandbox app-server",
+          provider_name: "codex",
+          raw_log_path: run.rawLogPath,
+          state: "succeeded",
+          workspace_path: workspacePath
+        });
+        const transitions = database
+          .prepare("select state from run_state_transitions order by sequence")
+          .all()
+          .map((row) => stringColumn(row, "state"));
+        expect(transitions).toEqual([
+          "queued",
+          "preparing_workspace",
+          "running",
+          "succeeded"
+        ]);
+        const attempts = database.prepare("select * from attempts").all();
+        expect(attempts).toHaveLength(1);
+        expect(attempts[0]).toMatchObject({
+          attempt_number: 1,
+          normalized_log_path: run.normalizedLogPath,
+          prompt_path: run.promptPath,
+          provider_name: "codex",
+          raw_log_path: run.rawLogPath,
+          run_id: "run-issue-8",
+          state: "succeeded"
+        });
+        const eventTypes = database
+          .prepare("select type from provider_events order by sequence")
+          .all()
+          .map((row) => stringColumn(row, "type"));
+        expect(eventTypes).toEqual([
+          "session_started",
+          "message",
+          "process_exit"
+        ]);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("marks a fake-provider process failure and preserves logs for inspection", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "8-dispatch-an-end-to-end-run-through-a-test-provider"
+    );
+    await mkdir(workspacePath, { recursive: true });
+    await writeValidProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 8,
+          title: "Dispatch an end-to-end run through a test provider"
+        })
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: {
+            exitCode: 1,
+            type: "process_exit"
+          },
+          raw: {
+            code: 1,
+            kind: "exit"
+          }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+    const preparedWorkspace: PreparedIssueWorkspace = {
+      branchName:
+        "sym/symphonika/8-dispatch-an-end-to-end-run-through-a-test-provider",
+      branchRef:
+        "refs/heads/sym/symphonika/8-dispatch-an-end-to-end-run-through-a-test-provider",
+      cachePath: path.join(
+        root,
+        ".symphonika",
+        "workspaces",
+        "symphonika",
+        ".cache",
+        "repo.git"
+      ),
+      issueDirectoryName: "8-dispatch-an-end-to-end-run-through-a-test-provider",
+      reused: false,
+      workspacePath
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
+        void input;
+        return Promise.resolve(preparedWorkspace);
+      }
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: {
+        codex: codexProvider
+      },
+      createRunId: () => "run-issue-8-failed",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "failed");
+      const run = firstRun(status);
+
+      expect(githubIssuesApi.addLabelsToIssue.mock.calls).toEqual([
+        [
+          {
+            issueNumber: 8,
+            labels: ["sym:claimed"],
+            owner: "pmatos",
+            repo: "symphonika",
+            token: "secret-token"
+          }
+        ],
+        [
+          {
+            issueNumber: 8,
+            labels: ["sym:running"],
+            owner: "pmatos",
+            repo: "symphonika",
+            token: "secret-token"
+          }
+        ],
+        [
+          {
+            issueNumber: 8,
+            labels: ["sym:failed"],
+            owner: "pmatos",
+            repo: "symphonika",
+            token: "secret-token"
+          }
+        ]
+      ]);
+      expect(githubIssuesApi.removeLabelsFromIssue).toHaveBeenCalledWith({
+        issueNumber: 8,
+        labels: ["sym:running"],
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret-token"
+      });
+      expect(run).toMatchObject({
+        id: "run-issue-8-failed",
+        issueNumber: 8,
+        state: "failed"
+      });
+      expect(readJsonl(await readFile(run.rawLogPath, "utf8"))).toEqual([
+        {
+          code: 1,
+          kind: "exit"
+        }
+      ]);
+      expect(readJsonl(await readFile(run.normalizedLogPath, "utf8"))).toEqual([
+        {
+          exitCode: 1,
+          type: "process_exit"
+        }
+      ]);
+
+      const database = new Database(path.join(root, ".symphonika", "symphonika.db"), {
+        readonly: true
+      });
+      try {
+        const transitions = database
+          .prepare("select state from run_state_transitions order by sequence")
+          .all()
+          .map((row) => stringColumn(row, "state"));
+        expect(transitions).toEqual([
+          "queued",
+          "preparing_workspace",
+          "running",
+          "failed"
+        ]);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+});
+
+function issueFixture(overrides: {
+  labels: unknown[];
+  number: number;
+  title: string;
+}): {
+  body: string;
+  created_at: string;
+  html_url: string;
+  id: number;
+  labels: unknown[];
+  number: number;
+  state: string;
+  title: string;
+  updated_at: string;
+} {
+  return {
+    body: `${overrides.title} body.`,
+    created_at: "2026-04-20T10:00:00Z",
+    html_url: `https://github.com/pmatos/symphonika/issues/${overrides.number}`,
+    id: 5000 + overrides.number,
+    labels: overrides.labels,
+    number: overrides.number,
+    state: "open",
+    title: overrides.title,
+    updated_at: "2026-04-21T11:00:00Z"
+  };
+}
+
+async function writeValidProject(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels:",
+      '        "priority:critical": 0',
+      '        "priority:high": 1',
+      '        "priority:medium": 2',
+      '        "priority:low": 3',
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "WORKFLOW.md"),
+    [
+      "Work on #{{issue.number}}: {{issue.title}}.",
+      "Use {{workspace.path}} on {{branch.name}}.",
+      "Provider {{provider.name}} is running {{provider.command}}.",
+      ""
+    ].join("\n")
+  );
+}
+
+type StatusRun = {
+  branchName: string;
+  id: string;
+  issueNumber: number;
+  normalizedLogPath: string;
+  project: string;
+  promptPath: string;
+  provider: string;
+  rawLogPath: string;
+  state: string;
+  workspacePath: string;
+};
+
+type PrepareIssueWorkspaceSpy = {
+  mock: {
+    calls: Array<[PrepareIssueWorkspaceInput]>;
+  };
+};
+
+async function waitForRun(
+  url: string,
+  state: string,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<{ runs: StatusRun[] }> {
+  const timeoutMs = options.timeoutMs ?? 1_000;
+  const intervalMs = options.intervalMs ?? 10;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await fetch(`${url}/api/status`);
+    const body = (await response.json()) as { runs?: StatusRun[] };
+
+    if (body.runs?.some((run) => run.state === state)) {
+      return {
+        runs: body.runs
+      };
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`run did not reach ${state} before timeout`);
+}
+
+function readJsonl(contents: string): unknown[] {
+  return contents
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function firstRun(status: { runs: StatusRun[] }): StatusRun {
+  const run = status.runs[0];
+  if (run === undefined) {
+    throw new Error("expected at least one status run");
+  }
+
+  return run;
+}
+
+function firstPrepareIssueWorkspaceInput(
+  prepareIssueWorkspace: PrepareIssueWorkspaceSpy
+): PrepareIssueWorkspaceInput {
+  const call = prepareIssueWorkspace.mock.calls[0];
+  if (call === undefined) {
+    throw new Error("expected workspace preparation to be called");
+  }
+
+  return call[0];
+}
+
+function stringColumn(row: unknown, key: string): string {
+  if (typeof row === "object" && row !== null && key in row) {
+    const value = row[key as keyof typeof row];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  throw new Error(`expected string column ${key}`);
+}

--- a/tests/http-app.test.ts
+++ b/tests/http-app.test.ts
@@ -44,6 +44,7 @@ describe("HTTP app", () => {
         errors: [],
         projects: []
       },
+      runs: [],
       service: "symphonika",
       state: "idle",
       stateRoot: "/tmp/symphonika-state",


### PR DESCRIPTION
## Summary

Implements the issue #8 bootstrap dispatch slice with a fake/test provider path.

- Claims one eligible issue with `sym:claimed` and marks active work with `sym:running`.
- Prepares workspace metadata, renders prompt evidence, runs a normalized provider interface, and persists raw plus normalized provider events.
- Adds a SQLite-backed run store for runs, attempts, state transitions, provider event metadata, prompt paths, log paths, workspace paths, and provider metadata.
- Exposes completed run details through `/api/status`.
- Adds Octokit operational label writes for the GitHub issue tracker abstraction.

Closes #8.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`