### PR TITLE
[codex] add Codex JSON-RPC provider adapter

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -16,6 +16,7 @@ import {
   replaceIssuePollStatus
 } from "./issue-polling.js";
 import type { AgentProviderRegistry } from "./provider.js";
+import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
 import { openRunStore } from "./run-store.js";
 import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
@@ -65,6 +66,7 @@ export async function startDaemon(
   const runStore = openRunStore({
     stateRoot: state.stateRoot
   });
+  const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;
   const dispatchRuntime = {
     dispatching: false
   };
@@ -95,7 +97,7 @@ export async function startDaemon(
     if (
       !state.configExists ||
       dispatchRuntime.dispatching ||
-      !hasRegisteredProviders(options.agentProviders)
+      !hasRegisteredProviders(agentProviders)
     ) {
       return;
     }
@@ -103,7 +105,7 @@ export async function startDaemon(
     dispatchRuntime.dispatching = true;
     try {
       await dispatchOneEligibleIssue({
-        agentProviders: options.agentProviders,
+        agentProviders,
         configDir: state.configDir,
         configPath: state.configPath,
         githubIssuesApi: options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API,

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -392,7 +392,9 @@ async function runProviderAttempt(input: {
       runStore: input.runStore,
       sequence
     });
-    finalState = terminalStateAfterEvent(finalState, event.normalized);
+    if (event.normalized !== undefined) {
+      finalState = terminalStateAfterEvent(finalState, event.normalized);
+    }
   }
 
   return finalState;
@@ -409,8 +411,14 @@ async function persistProviderEvent(input: {
 }): Promise<void> {
   await Promise.all([
     appendJsonl(input.rawLogPath, input.event.raw),
-    appendJsonl(input.normalizedLogPath, input.event.normalized)
+    ...(input.event.normalized === undefined
+      ? []
+      : [appendJsonl(input.normalizedLogPath, input.event.normalized)])
   ]);
+  if (input.event.normalized === undefined) {
+    return;
+  }
+
   input.runStore.recordProviderEvent({
     attemptId: input.attemptId,
     normalized: input.event.normalized,
@@ -445,7 +453,11 @@ function terminalStateAfterEvent(
 
 function processExitFailed(event: NormalizedProviderEvent): boolean {
   const exitCode = event.exitCode;
-  return typeof exitCode === "number" && exitCode !== 0;
+  if (typeof exitCode === "number" && exitCode !== 0) {
+    return true;
+  }
+
+  return typeof event.signal === "string" && event.cancelled !== true;
 }
 
 async function appendJsonl(filePath: string, value: unknown): Promise<void> {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -447,7 +447,12 @@ async function validateProject(
     validForDispatch = false;
   }
   const providerAdapter = agentProviders[project.agent.provider];
-  if (providerAdapter !== undefined) {
+  if (providerAdapter === undefined) {
+    errors.push(
+      `projects.${project.name}.agent.provider references ${project.agent.provider}, but no adapter is registered`
+    );
+    validForDispatch = false;
+  } else {
     try {
       await providerAdapter.validate(provider.command);
     } catch (error) {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,11 +5,14 @@ import { parse } from "yaml";
 import { z } from "zod";
 
 import { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
+import type { AgentProviderRegistry } from "./provider.js";
+import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
 import { validateWorkflowContract } from "./workflow.js";
 
 export { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
 
 export type DoctorOptions = {
+  agentProviders?: AgentProviderRegistry;
   configPath?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
@@ -199,6 +202,7 @@ export async function runDoctor(
   const configPath = path.resolve(cwd, options.configPath ?? "symphonika.yml");
   const env = options.env ?? process.env;
   const githubApi = options.githubApi ?? DEFAULT_GITHUB_API;
+  const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;
   const errors: string[] = [];
   const projects: DoctorProjectReport[] = [];
   const rawConfig = await readConfig(configPath, errors);
@@ -216,6 +220,7 @@ export async function runDoctor(
     const validation = await validateProject(
       project,
       parsedConfig,
+      agentProviders,
       env,
       errors,
       githubApi
@@ -427,6 +432,7 @@ function parseServiceConfig(
 async function validateProject(
   project: ProjectConfig,
   config: ServiceConfig,
+  agentProviders: AgentProviderRegistry,
   env: NodeJS.ProcessEnv,
   errors: string[],
   githubApi: GitHubApi | undefined
@@ -439,6 +445,17 @@ async function validateProject(
       `projects.${project.name}.agent.provider references ${project.agent.provider}, but its command is empty`
     );
     validForDispatch = false;
+  }
+  const providerAdapter = agentProviders[project.agent.provider];
+  if (providerAdapter !== undefined) {
+    try {
+      await providerAdapter.validate(provider.command);
+    } catch (error) {
+      errors.push(
+        `projects.${project.name}.providers.${project.agent.provider}.command is invalid: ${errorMessage(error)}`
+      );
+      validForDispatch = false;
+    }
   }
 
   const token = resolveEnvBackedValue(project.tracker.token, env);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -20,7 +20,7 @@ export type NormalizedProviderEvent = {
 };
 
 export type ProviderEvent = {
-  normalized: NormalizedProviderEvent;
+  normalized?: NormalizedProviderEvent;
   raw: unknown;
 };
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -1,0 +1,47 @@
+import type {
+  AgentProvider,
+  ProviderEvent,
+  ProviderRunInput
+} from "../provider.js";
+
+const UNAVAILABLE_MESSAGE =
+  "Claude provider adapter is not implemented yet; track issue #10";
+
+export function createClaudeProvider(): AgentProvider {
+  return {
+    cancel: () => Promise.resolve(),
+    name: "claude",
+    runAttempt: async function* (
+      input: ProviderRunInput
+    ): AsyncGenerator<ProviderEvent> {
+      await Promise.resolve();
+      yield {
+        normalized: {
+          message: UNAVAILABLE_MESSAGE,
+          provider: input.provider.name,
+          type: "turn_failed"
+        },
+        raw: {
+          kind: "provider_unavailable",
+          message: UNAVAILABLE_MESSAGE,
+          provider: input.provider.name
+        }
+      };
+      yield {
+        normalized: {
+          cancelled: false,
+          exitCode: null,
+          signal: null,
+          type: "process_exit"
+        },
+        raw: {
+          cancelled: false,
+          exitCode: null,
+          kind: "process_exit",
+          signal: null
+        }
+      };
+    },
+    validate: () => Promise.reject(new Error(UNAVAILABLE_MESSAGE))
+  };
+}

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -1,0 +1,787 @@
+import {
+  spawn,
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams
+} from "node:child_process";
+
+import type {
+  AgentProvider,
+  ProviderEvent,
+  ProviderRunInput
+} from "../provider.js";
+import { VERSION } from "../version.js";
+
+type JsonObject = Record<string, unknown>;
+
+type ActiveCodexRun = {
+  cancelled: boolean;
+  child: ChildProcessWithoutNullStreams;
+  nextRequestId: number;
+  threadId?: string;
+  turnId?: string;
+};
+
+type ProcessQueueItem =
+  | {
+      kind: "exit";
+      exitCode: number | null;
+      signal: NodeJS.Signals | null;
+    }
+  | {
+      error: Error;
+      kind: "error";
+    }
+  | {
+      kind: "malformed";
+      line: string;
+      message: string;
+    }
+  | {
+      kind: "message";
+      raw: unknown;
+    };
+
+type ProcessQueue = {
+  next: () => Promise<ProcessQueueItem>;
+};
+
+type ResponseReadResult = {
+  events: ProviderEvent[];
+  stopped: boolean;
+};
+
+export function createCodexProvider(): AgentProvider {
+  const activeRuns = new Map<string, ActiveCodexRun>();
+
+  return {
+    cancel: (runId) => {
+      const activeRun = activeRuns.get(runId);
+      if (activeRun === undefined) {
+        return Promise.resolve();
+      }
+
+      activeRun.cancelled = true;
+      if (activeRun.threadId !== undefined && activeRun.turnId !== undefined) {
+        writeJson(activeRun.child, {
+          id: activeRun.nextRequestId,
+          method: "turn/interrupt",
+          params: {
+            threadId: activeRun.threadId,
+            turnId: activeRun.turnId
+          }
+        });
+        activeRun.nextRequestId += 1;
+      }
+      shutdownProcess(activeRun.child);
+      return Promise.resolve();
+    },
+    name: "codex",
+    runAttempt: async function* (
+      input: ProviderRunInput
+    ): AsyncGenerator<ProviderEvent> {
+      const command = parseCommand(input.provider.command);
+      const child = spawn(command.executable, command.args, {
+        cwd: input.workspacePath,
+        env: process.env,
+        stdio: ["pipe", "pipe", "pipe"]
+      });
+      const activeRun: ActiveCodexRun = {
+        cancelled: false,
+        child,
+        nextRequestId: 4
+      };
+      activeRuns.set(input.run.id, activeRun);
+      child.stderr.resume();
+      const queue = createProcessQueue(child);
+
+      try {
+        writeJson(child, {
+          id: 1,
+          method: "initialize",
+          params: {
+            capabilities: {
+              experimentalApi: true
+            },
+            clientInfo: {
+              name: "symphonika",
+              title: "Symphonika",
+              version: VERSION
+            }
+          }
+        });
+        const initialized = await readUntilResponse(queue, 1, activeRun, (raw) => ({
+          raw
+        }));
+        yield* initialized.events;
+        if (initialized.stopped) {
+          return;
+        }
+
+        writeJson(child, {
+          method: "initialized"
+        });
+        writeJson(child, {
+          id: 2,
+          method: "thread/start",
+          params: {
+            approvalPolicy: "never",
+            cwd: input.workspacePath,
+            experimentalRawEvents: false,
+            permissionProfile: {
+              type: "disabled"
+            },
+            persistExtendedHistory: true
+          }
+        });
+        const threadStarted = await readUntilResponse(
+          queue,
+          2,
+          activeRun,
+          (raw) => {
+            const result = objectField(raw, "result");
+            const thread = objectField(result, "thread");
+            const threadId = stringField(thread, "id");
+            if (threadId !== undefined) {
+              activeRun.threadId = threadId;
+            }
+
+            if (threadId === undefined) {
+              return {
+                raw
+              };
+            }
+
+            return {
+              normalized: {
+                cwd: stringField(result, "cwd") ?? input.workspacePath,
+                sessionId: threadId,
+                threadId,
+                type: "session_started"
+              },
+              raw
+            };
+          }
+        );
+        yield* threadStarted.events;
+        if (threadStarted.stopped) {
+          return;
+        }
+
+        const threadId = activeRun.threadId;
+        if (threadId === undefined) {
+          yield protocolFailure("thread/start response did not include thread.id");
+          shutdownProcess(child);
+          yield* await drainUntilExit(queue, activeRun);
+          return;
+        }
+
+        writeJson(child, {
+          id: 3,
+          method: "turn/start",
+          params: {
+            input: [
+              {
+                text: input.prompt,
+                text_elements: [],
+                type: "text"
+              }
+            ],
+            threadId
+          }
+        });
+        const turnStarted = await readUntilResponse(queue, 3, activeRun, (raw) => {
+          const result = objectField(raw, "result");
+          const turn = objectField(result, "turn");
+          const turnId = stringField(turn, "id");
+          if (turnId !== undefined) {
+            activeRun.turnId = turnId;
+          }
+
+          return {
+            raw
+          };
+        });
+        yield* turnStarted.events;
+        if (turnStarted.stopped) {
+          return;
+        }
+
+        while (true) {
+          const event = providerEventFromQueueItem(await queue.next(), activeRun);
+          yield event;
+          const type = event.normalized?.type;
+
+          if (type === "process_exit") {
+            return;
+          }
+
+          if (
+            type === "input_required" ||
+            type === "malformed_event" ||
+            type === "turn_completed" ||
+            type === "turn_failed"
+          ) {
+            shutdownProcess(child);
+          }
+        }
+      } finally {
+        activeRuns.delete(input.run.id);
+      }
+    },
+    validate: async (command) => {
+      const parsed = parseCommand(command);
+      if (!parsed.args.includes("app-server")) {
+        throw new Error(
+          "Codex provider command must include the app-server subcommand"
+        );
+      }
+
+      await validateCodexAppServerCommand(parsed);
+    }
+  };
+}
+
+async function readUntilResponse(
+  queue: ProcessQueue,
+  requestId: number,
+  activeRun: ActiveCodexRun,
+  mapResponse: (raw: unknown) => ProviderEvent
+): Promise<ResponseReadResult> {
+  const events: ProviderEvent[] = [];
+
+  while (true) {
+    const item = await queue.next();
+    if (item.kind === "message" && responseId(item.raw) === requestId) {
+      if (objectField(item.raw, "error") !== undefined) {
+        events.push(jsonRpcErrorEvent(item.raw));
+        shutdownProcess(activeRun.child);
+        events.push(...(await drainUntilExit(queue, activeRun)));
+        return {
+          events,
+          stopped: true
+        };
+      }
+
+      events.push(mapResponse(item.raw));
+      return {
+        events,
+        stopped: false
+      };
+    }
+
+    const event = providerEventFromQueueItem(item, activeRun);
+    events.push(event);
+    if (event.normalized?.type === "process_exit") {
+      return {
+        events,
+        stopped: true
+      };
+    }
+    if (isTerminalFailure(event.normalized?.type)) {
+      shutdownProcess(activeRun.child);
+      events.push(...(await drainUntilExit(queue, activeRun)));
+      return {
+        events,
+        stopped: true
+      };
+    }
+  }
+}
+
+async function drainUntilExit(
+  queue: ProcessQueue,
+  activeRun: ActiveCodexRun
+): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+
+  while (true) {
+    const event = providerEventFromQueueItem(await queue.next(), activeRun);
+    events.push(event);
+    if (event.normalized?.type === "process_exit") {
+      return events;
+    }
+  }
+}
+
+function providerEventFromQueueItem(
+  item: ProcessQueueItem,
+  activeRun: ActiveCodexRun
+): ProviderEvent {
+  switch (item.kind) {
+    case "error":
+      return {
+        normalized: {
+          message: item.error.message,
+          type: "turn_failed"
+        },
+        raw: {
+          kind: "process_error",
+          message: item.error.message
+        }
+      };
+    case "exit":
+      return {
+        normalized: {
+          cancelled: activeRun.cancelled,
+          exitCode: item.exitCode,
+          signal: item.signal,
+          type: "process_exit"
+        },
+        raw: {
+          cancelled: activeRun.cancelled,
+          exitCode: item.exitCode,
+          kind: "process_exit",
+          signal: item.signal
+        }
+      };
+    case "malformed":
+      return {
+        normalized: {
+          line: item.line,
+          message: item.message,
+          type: "malformed_event"
+        },
+        raw: {
+          kind: "malformed_json",
+          line: item.line,
+          message: item.message
+        }
+      };
+    case "message":
+      return mapCodexJsonRpcMessage(item.raw, activeRun);
+  }
+}
+
+function mapCodexJsonRpcMessage(
+  raw: unknown,
+  activeRun: ActiveCodexRun
+): ProviderEvent {
+  const method = stringField(raw, "method");
+  if (method === undefined) {
+    if (objectField(raw, "error") !== undefined) {
+      return jsonRpcErrorEvent(raw);
+    }
+
+    return {
+      raw
+    };
+  }
+
+  if (isInputRequiredMethod(method)) {
+    return {
+      normalized: {
+        method,
+        params: objectField(raw, "params"),
+        requestId: responseId(raw),
+        type: "input_required"
+      },
+      raw
+    };
+  }
+
+  const params = objectField(raw, "params");
+  if (method === "item/agentMessage/delta") {
+    return {
+      normalized: {
+        message: stringField(params, "delta") ?? "",
+        threadId: stringField(params, "threadId"),
+        turnId: stringField(params, "turnId"),
+        type: "message"
+      },
+      raw
+    };
+  }
+
+  if (method === "thread/tokenUsage/updated") {
+    return {
+      normalized: {
+        threadId: stringField(params, "threadId"),
+        tokenUsage: objectField(params, "tokenUsage"),
+        turnId: stringField(params, "turnId"),
+        type: "usage_updated"
+      },
+      raw
+    };
+  }
+
+  if (method === "account/rateLimits/updated") {
+    return {
+      normalized: {
+        rateLimits: objectField(params, "rateLimits"),
+        type: "rate_limit_updated"
+      },
+      raw
+    };
+  }
+
+  if (method === "turn/completed") {
+    const turn = objectField(params, "turn");
+    const status = stringField(turn, "status");
+    const turnId = stringField(turn, "id") ?? activeRun.turnId;
+    const threadId = stringField(params, "threadId") ?? activeRun.threadId;
+
+    if (status === "completed") {
+      return {
+        normalized: {
+          status,
+          threadId,
+          turnId,
+          type: "turn_completed"
+        },
+        raw
+      };
+    }
+
+    return {
+      normalized: {
+        message:
+          stringField(objectField(turn, "error"), "message") ??
+          `turn completed with status ${status ?? "unknown"}`,
+        status,
+        threadId,
+        turnId,
+        type: "turn_failed"
+      },
+      raw
+    };
+  }
+
+  if (method === "error") {
+    const error = objectField(params, "error");
+    return {
+      normalized: {
+        message: stringField(error, "message") ?? "Codex provider error",
+        threadId: stringField(params, "threadId") ?? activeRun.threadId,
+        turnId: stringField(params, "turnId") ?? activeRun.turnId,
+        type: "turn_failed"
+      },
+      raw
+    };
+  }
+
+  return {
+    raw
+  };
+}
+
+function jsonRpcErrorEvent(raw: unknown): ProviderEvent {
+  const error = objectField(raw, "error");
+  return {
+    normalized: {
+      message: stringField(error, "message") ?? "Codex JSON-RPC error",
+      type: "turn_failed"
+    },
+    raw
+  };
+}
+
+function protocolFailure(message: string): ProviderEvent {
+  return {
+    normalized: {
+      message,
+      type: "malformed_event"
+    },
+    raw: {
+      kind: "protocol_error",
+      message
+    }
+  };
+}
+
+function isInputRequiredMethod(method: string): boolean {
+  return (
+    method === "item/tool/requestUserInput" ||
+    method === "mcpServer/elicitation/request" ||
+    method.endsWith("/requestApproval")
+  );
+}
+
+function isTerminalFailure(type: string | undefined): boolean {
+  return (
+    type === "input_required" ||
+    type === "malformed_event" ||
+    type === "turn_failed"
+  );
+}
+
+function createProcessQueue(child: ChildProcessWithoutNullStreams): ProcessQueue {
+  const pending: ProcessQueueItem[] = [];
+  let waiting: ((item: ProcessQueueItem) => void) | undefined;
+  let stdoutBuffer = "";
+
+  const push = (item: ProcessQueueItem): void => {
+    if (waiting !== undefined) {
+      const resolve = waiting;
+      waiting = undefined;
+      resolve(item);
+      return;
+    }
+
+    pending.push(item);
+  };
+
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdoutBuffer += chunk;
+    let newlineIndex = stdoutBuffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = stdoutBuffer.slice(0, newlineIndex).trimEnd();
+      stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+      pushLine(line, push);
+      newlineIndex = stdoutBuffer.indexOf("\n");
+    }
+  });
+  child.stdout.on("end", () => {
+    if (stdoutBuffer.length > 0) {
+      pushLine(stdoutBuffer.trimEnd(), push);
+      stdoutBuffer = "";
+    }
+  });
+  child.once("error", (error) => {
+    push({
+      error,
+      kind: "error"
+    });
+  });
+  child.once("close", (exitCode, signal) => {
+    push({
+      exitCode,
+      kind: "exit",
+      signal
+    });
+  });
+
+  return {
+    next: () => {
+      const item = pending.shift();
+      if (item !== undefined) {
+        return Promise.resolve(item);
+      }
+
+      return new Promise<ProcessQueueItem>((resolve) => {
+        waiting = resolve;
+      });
+    }
+  };
+}
+
+function pushLine(
+  line: string,
+  push: (item: ProcessQueueItem) => void
+): void {
+  if (line.trim().length === 0) {
+    return;
+  }
+
+  try {
+    push({
+      kind: "message",
+      raw: JSON.parse(line) as unknown
+    });
+  } catch (error) {
+    push({
+      kind: "malformed",
+      line,
+      message: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function writeJson(
+  child: ChildProcessWithoutNullStreams,
+  value: JsonObject
+): void {
+  child.stdin.write(`${JSON.stringify(value)}\n`);
+}
+
+function terminateProcess(child: ChildProcess): void {
+  if (child.killed || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+}
+
+function shutdownProcess(child: ChildProcessWithoutNullStreams): void {
+  if (!child.stdin.destroyed && child.stdin.writable) {
+    child.stdin.end();
+  }
+
+  const timer = setTimeout(() => {
+    terminateProcess(child);
+  }, 250);
+  timer.unref();
+}
+
+async function validateCodexAppServerCommand(command: {
+  args: string[];
+  executable: string;
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command.executable, [...command.args, "--help"], {
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let output = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      terminateProcess(child);
+      reject(new Error("Codex provider command validation timed out"));
+    }, 5_000);
+
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      callback();
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      output += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      output += chunk;
+    });
+    child.once("error", (error) => {
+      settle(() => {
+        reject(
+          new Error(
+            `Codex provider command executable not available: ${command.executable}: ${error.message}`
+          )
+        );
+      });
+    });
+    child.once("close", (exitCode) => {
+      settle(() => {
+        if (exitCode !== 0) {
+          reject(
+            new Error(
+              `Codex provider command validation failed with exit code ${exitCode ?? "unknown"}`
+            )
+          );
+          return;
+        }
+
+        if (!/app-server/.test(output)) {
+          reject(
+            new Error(
+              "Codex provider command help output does not look like app-server"
+            )
+          );
+          return;
+        }
+
+        resolve();
+      });
+    });
+  });
+}
+
+function parseCommand(command: string): { args: string[]; executable: string } {
+  const parts = splitCommand(command);
+  const executable = parts[0];
+  if (executable === undefined) {
+    throw new Error("Codex provider command is empty");
+  }
+
+  return {
+    args: parts.slice(1),
+    executable
+  };
+}
+
+function splitCommand(command: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  let escaping = false;
+
+  for (const character of command.trim()) {
+    if (escaping) {
+      current += character;
+      escaping = false;
+      continue;
+    }
+
+    if (character === "\\") {
+      escaping = true;
+      continue;
+    }
+
+    if (quote !== undefined) {
+      if (character === quote) {
+        quote = undefined;
+      } else {
+        current += character;
+      }
+      continue;
+    }
+
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+
+    if (/\s/.test(character)) {
+      if (current.length > 0) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += character;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+
+  if (quote !== undefined) {
+    throw new Error("Codex provider command has an unterminated quote");
+  }
+
+  if (current.length > 0) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function responseId(value: unknown): string | number | undefined {
+  const id = field(value, "id");
+  return typeof id === "string" || typeof id === "number" ? id : undefined;
+}
+
+function objectField(value: unknown, key: string): JsonObject | undefined {
+  const valueAtKey = field(value, key);
+  if (typeof valueAtKey === "object" && valueAtKey !== null) {
+    return valueAtKey as JsonObject;
+  }
+
+  return undefined;
+}
+
+function field(value: unknown, key: string): unknown {
+  if (typeof value === "object" && value !== null && key in value) {
+    return value[key as keyof typeof value];
+  }
+
+  return undefined;
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const valueAtKey = field(value, key);
+  if (typeof valueAtKey === "string") {
+    return valueAtKey;
+  }
+
+  return undefined;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,8 @@
 import type { AgentProviderRegistry } from "../provider.js";
+import { createClaudeProvider } from "./claude.js";
 import { createCodexProvider } from "./codex.js";
 
 export const DEFAULT_AGENT_PROVIDERS: AgentProviderRegistry = {
+  claude: createClaudeProvider(),
   codex: createCodexProvider()
 };

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,6 @@
+import type { AgentProviderRegistry } from "../provider.js";
+import { createCodexProvider } from "./codex.js";
+
+export const DEFAULT_AGENT_PROVIDERS: AgentProviderRegistry = {
+  codex: createCodexProvider()
+};

--- a/tests/codex-provider.test.ts
+++ b/tests/codex-provider.test.ts
@@ -1,0 +1,582 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createCodexProvider } from "../src/providers/codex.js";
+import type { ProviderEvent, ProviderRunInput } from "../src/provider.js";
+
+const tempRoots: string[] = [];
+const originalFakeCodexTranscript = process.env.SYMPHONIKA_FAKE_CODEX_TRANSCRIPT;
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-codex-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  if (originalFakeCodexTranscript === undefined) {
+    delete process.env.SYMPHONIKA_FAKE_CODEX_TRANSCRIPT;
+  } else {
+    process.env.SYMPHONIKA_FAKE_CODEX_TRANSCRIPT = originalFakeCodexTranscript;
+  }
+
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("Codex JSON-RPC provider", () => {
+  it("launches the configured app-server in the workspace and maps a completed turn", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeServerPath = path.join(root, "fake-codex-app-server.mjs");
+    await writeFakeCodexAppServer(fakeServerPath, transcriptPath);
+    const provider = createCodexProvider();
+
+    const events = await collectProviderEvents(
+      provider.runAttempt({
+        ...providerInputFixture(),
+        provider: {
+          command: `${process.execPath} ${fakeServerPath} app-server`,
+          name: "codex"
+        },
+        workspacePath
+      })
+    );
+
+    const requests = readJsonl(await readFile(transcriptPath, "utf8"));
+    expect(requests.map((request) => objectField(request, "method"))).toEqual([
+      "initialize",
+      "initialized",
+      "thread/start",
+      "turn/start"
+    ]);
+    expect(requests[2]).toMatchObject({
+      method: "thread/start",
+      params: {
+        approvalPolicy: "never",
+        cwd: workspacePath,
+        experimentalRawEvents: false,
+        permissionProfile: {
+          type: "disabled"
+        }
+      }
+    });
+    expect(requests[3]).toMatchObject({
+      method: "turn/start",
+      params: {
+        input: [
+          {
+            text: "Implement issue #9.",
+            text_elements: [],
+            type: "text"
+          }
+        ],
+        threadId: "thread-9"
+      }
+    });
+
+    expect(events.map((event) => event.raw)).toEqual([
+      {
+        id: 1,
+        result: {
+          codexHome: "/tmp/fake-codex-home",
+          platformFamily: "unix",
+          platformOs: "linux",
+          userAgent: "fake-codex-app-server"
+        }
+      },
+      {
+        id: 2,
+        result: {
+          cwd: workspacePath,
+          thread: {
+            id: "thread-9"
+          }
+        }
+      },
+      {
+        id: 3,
+        result: {
+          turn: {
+            id: "turn-9",
+            status: "inProgress"
+          }
+        }
+      },
+      {
+        method: "item/agentMessage/delta",
+        params: {
+          delta: "done",
+          itemId: "item-1",
+          threadId: "thread-9",
+          turnId: "turn-9"
+        }
+      },
+      {
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-9",
+          tokenUsage: {
+            inputTokens: 11,
+            outputTokens: 7,
+            totalTokens: 18
+          },
+          turnId: "turn-9"
+        }
+      },
+      {
+        method: "account/rateLimits/updated",
+        params: {
+          rateLimits: {
+            primary: {
+              remaining: 42,
+              resetAt: 1777470000
+            }
+          }
+        }
+      },
+      {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-9",
+          turn: {
+            id: "turn-9",
+            status: "completed"
+          }
+        }
+      },
+      {
+        cancelled: false,
+        exitCode: 0,
+        kind: "process_exit",
+        signal: null
+      }
+    ]);
+    const normalizedEvents = events
+      .map((event) => event.normalized)
+      .filter(Boolean);
+    expect(normalizedEvents).toMatchObject([
+      {
+        cwd: workspacePath,
+        sessionId: "thread-9",
+        threadId: "thread-9",
+        type: "session_started"
+      },
+      {
+        message: "done",
+        threadId: "thread-9",
+        turnId: "turn-9",
+        type: "message"
+      },
+      {
+        threadId: "thread-9",
+        tokenUsage: {
+          inputTokens: 11,
+          outputTokens: 7,
+          totalTokens: 18
+        },
+        turnId: "turn-9",
+        type: "usage_updated"
+      },
+      {
+        rateLimits: {
+          primary: {
+            remaining: 42,
+            resetAt: 1777470000
+          }
+        },
+        type: "rate_limit_updated"
+      },
+      {
+        status: "completed",
+        threadId: "thread-9",
+        turnId: "turn-9",
+        type: "turn_completed"
+      },
+      {
+        cancelled: false,
+        exitCode: 0,
+        signal: null,
+        type: "process_exit"
+      }
+    ]);
+  });
+
+  it("maps app-server input requests to input_required and stops the process", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeServerPath = path.join(root, "fake-codex-app-server.mjs");
+    await writeFakeCodexAppServer(fakeServerPath, transcriptPath);
+    const provider = createCodexProvider();
+
+    const events = await collectProviderEvents(
+      provider.runAttempt({
+        ...providerInputFixture(),
+        provider: {
+          command: `${process.execPath} ${fakeServerPath} --scenario=input-required app-server`,
+          name: "codex"
+        },
+        workspacePath
+      })
+    );
+
+    const normalizedEvents = events
+      .map((event) => event.normalized)
+      .filter(Boolean);
+    expect(normalizedEvents).toMatchObject([
+      {
+        cwd: workspacePath,
+        sessionId: "thread-9",
+        threadId: "thread-9",
+        type: "session_started"
+      },
+      {
+        method: "item/tool/requestUserInput",
+        params: {
+          itemId: "item-input",
+          questions: [
+            {
+              header: "Choice",
+              id: "choice",
+              options: [],
+              question: "Need operator input?"
+            }
+          ],
+          threadId: "thread-9",
+          turnId: "turn-9"
+        },
+        requestId: "input-1",
+        type: "input_required"
+      },
+      {
+        cancelled: false,
+        exitCode: 0,
+        signal: null,
+        type: "process_exit"
+      }
+    ]);
+  });
+
+  it("maps malformed app-server output to malformed_event and stops the process", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeServerPath = path.join(root, "fake-codex-app-server.mjs");
+    await writeFakeCodexAppServer(fakeServerPath, transcriptPath);
+    const provider = createCodexProvider();
+
+    const events = await collectProviderEvents(
+      provider.runAttempt({
+        ...providerInputFixture(),
+        provider: {
+          command: `${process.execPath} ${fakeServerPath} --scenario=malformed app-server`,
+          name: "codex"
+        },
+        workspacePath
+      })
+    );
+
+    const normalizedEvents = events
+      .map((event) => event.normalized)
+      .filter(Boolean);
+    expect(normalizedEvents).toMatchObject([
+      {
+        cwd: workspacePath,
+        sessionId: "thread-9",
+        threadId: "thread-9",
+        type: "session_started"
+      },
+      {
+        line: "{bad json",
+        type: "malformed_event"
+      },
+      {
+        cancelled: false,
+        exitCode: 0,
+        signal: null,
+        type: "process_exit"
+      }
+    ]);
+    expect(String(objectField(normalizedEvents[1], "message"))).toContain("JSON");
+  });
+
+  it("maps app-server error notifications to turn_failed and stops the process", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeServerPath = path.join(root, "fake-codex-app-server.mjs");
+    await writeFakeCodexAppServer(fakeServerPath, transcriptPath);
+    const provider = createCodexProvider();
+
+    const events = await collectProviderEvents(
+      provider.runAttempt({
+        ...providerInputFixture(),
+        provider: {
+          command: `${process.execPath} ${fakeServerPath} --scenario=error app-server`,
+          name: "codex"
+        },
+        workspacePath
+      })
+    );
+
+    expect(events.map((event) => event.normalized).filter(Boolean)).toEqual([
+      {
+        cwd: workspacePath,
+        sessionId: "thread-9",
+        threadId: "thread-9",
+        type: "session_started"
+      },
+      {
+        message: "model exploded politely",
+        threadId: "thread-9",
+        turnId: "turn-9",
+        type: "turn_failed"
+      },
+      {
+        cancelled: false,
+        exitCode: 0,
+        signal: null,
+        type: "process_exit"
+      }
+    ]);
+  });
+
+  it("interrupts and stops the app-server process on cancellation", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeServerPath = path.join(root, "fake-codex-app-server.mjs");
+    await writeFakeCodexAppServer(fakeServerPath, transcriptPath);
+    const provider = createCodexProvider();
+    const iterable = provider.runAttempt({
+      ...providerInputFixture(),
+      provider: {
+        command: `${process.execPath} ${fakeServerPath} --scenario=wait app-server`,
+        name: "codex"
+      },
+      workspacePath
+    });
+    const iterator = iterable[Symbol.asyncIterator]();
+
+    const initialEvents = [
+      await nextProviderEvent(iterator),
+      await nextProviderEvent(iterator),
+      await nextProviderEvent(iterator)
+    ];
+    await provider.cancel("run-issue-9");
+    const remainingEvents = await collectIteratorEvents(iterator);
+    const events = [...initialEvents, ...remainingEvents];
+
+    const requests = readJsonl(await readFile(transcriptPath, "utf8"));
+    expect(requests.map((request) => objectField(request, "method"))).toEqual([
+      "initialize",
+      "initialized",
+      "thread/start",
+      "turn/start",
+      "turn/interrupt"
+    ]);
+    expect(events.map((event) => event.normalized).filter(Boolean)).toEqual([
+      {
+        cwd: workspacePath,
+        sessionId: "thread-9",
+        threadId: "thread-9",
+        type: "session_started"
+      },
+      {
+        cancelled: true,
+        exitCode: 0,
+        signal: null,
+        type: "process_exit"
+      }
+    ]);
+  });
+});
+
+async function collectProviderEvents(
+  iterable: AsyncIterable<ProviderEvent>
+): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+async function collectIteratorEvents(
+  iterator: AsyncIterator<ProviderEvent>
+): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+  while (true) {
+    const result = await iterator.next();
+    if (result.done === true) {
+      return events;
+    }
+
+    events.push(result.value);
+  }
+}
+
+async function nextProviderEvent(
+  iterator: AsyncIterator<ProviderEvent>
+): Promise<ProviderEvent> {
+  const result = await iterator.next();
+  if (result.done === true) {
+    throw new Error("expected provider event");
+  }
+
+  return result.value;
+}
+
+function providerInputFixture(): ProviderRunInput {
+  return {
+    branchName: "sym/symphonika/9-add-codex-json-rpc-provider-adapter",
+    issue: {
+      body: "Issue body",
+      created_at: "2026-04-20T10:00:00Z",
+      id: 5009,
+      labels: ["agent-ready"],
+      number: 9,
+      priority: 99,
+      state: "open",
+      title: "Add Codex JSON-RPC provider adapter",
+      updated_at: "2026-04-21T11:00:00Z",
+      url: "https://github.com/pmatos/symphonika/issues/9"
+    },
+    prompt: "Implement issue #9.",
+    promptPath: "/tmp/prompt.md",
+    provider: {
+      command: "codex --dangerously-bypass-approvals-and-sandbox app-server",
+      name: "codex"
+    },
+    run: {
+      attempt: 1,
+      id: "run-issue-9"
+    },
+    workspacePath: "/tmp/workspace"
+  };
+}
+
+async function writeFakeCodexAppServer(
+  filePath: string,
+  transcriptPath: string
+): Promise<void> {
+  await writeFile(
+    filePath,
+    [
+      "import { appendFile } from 'node:fs/promises';",
+      "import readline from 'node:readline';",
+      "",
+      "const scenarioArg = process.argv.find((arg) => arg.startsWith('--scenario='));",
+      "const scenario = scenarioArg ? scenarioArg.slice('--scenario='.length) : 'success';",
+      "",
+      "if (process.argv.includes('--help')) {",
+      "  process.stdout.write('Usage: fake-codex app-server --listen <URL>\\n');",
+      "  process.exit(0);",
+      "}",
+      "",
+      "const transcriptPath = process.env.SYMPHONIKA_FAKE_CODEX_TRANSCRIPT;",
+      "const rl = readline.createInterface({ input: process.stdin });",
+      "function send(message) {",
+      "  process.stdout.write(`${JSON.stringify(message)}\\n`);",
+      "}",
+      "async function record(message) {",
+      "  if (transcriptPath) {",
+      "    await appendFile(transcriptPath, `${JSON.stringify(message)}\\n`, 'utf8');",
+      "  }",
+      "}",
+      "",
+      "for await (const line of rl) {",
+      "  const message = JSON.parse(line);",
+      "  await record(message);",
+      "  if (message.method === 'initialize') {",
+      "    send({",
+      "      id: message.id,",
+      "      result: {",
+      "        codexHome: '/tmp/fake-codex-home',",
+      "        platformFamily: 'unix',",
+      "        platformOs: 'linux',",
+      "        userAgent: 'fake-codex-app-server'",
+      "      }",
+      "    });",
+      "  }",
+      "  if (message.method === 'thread/start') {",
+      "    send({",
+      "      id: message.id,",
+      "      result: {",
+      "        cwd: process.cwd(),",
+      "        thread: {",
+      "          id: 'thread-9'",
+      "        }",
+      "      }",
+      "    });",
+      "  }",
+      "  if (message.method === 'turn/start') {",
+      "    send({",
+      "      id: message.id,",
+      "      result: {",
+      "        turn: {",
+      "          id: 'turn-9',",
+      "          status: 'inProgress'",
+      "        }",
+      "      }",
+      "    });",
+      "    if (scenario === 'input-required') {",
+      "      send({ method: 'item/tool/requestUserInput', id: 'input-1', params: { threadId: 'thread-9', turnId: 'turn-9', itemId: 'item-input', questions: [{ header: 'Choice', id: 'choice', question: 'Need operator input?', options: [] }] } });",
+      "      continue;",
+      "    }",
+      "    if (scenario === 'malformed') {",
+      "      process.stdout.write('{bad json\\n');",
+      "      continue;",
+      "    }",
+      "    if (scenario === 'error') {",
+      "      send({ method: 'error', params: { threadId: 'thread-9', turnId: 'turn-9', error: { message: 'model exploded politely', codexErrorInfo: null, additionalDetails: null }, willRetry: false } });",
+      "      continue;",
+      "    }",
+      "    if (scenario === 'wait') {",
+      "      continue;",
+      "    }",
+      "    send({ method: 'item/agentMessage/delta', params: { threadId: 'thread-9', turnId: 'turn-9', itemId: 'item-1', delta: 'done' } });",
+      "    send({ method: 'thread/tokenUsage/updated', params: { threadId: 'thread-9', turnId: 'turn-9', tokenUsage: { inputTokens: 11, outputTokens: 7, totalTokens: 18 } } });",
+      "    send({ method: 'account/rateLimits/updated', params: { rateLimits: { primary: { remaining: 42, resetAt: 1777470000 } } } });",
+      "    send({ method: 'turn/completed', params: { threadId: 'thread-9', turn: { id: 'turn-9', status: 'completed' } } });",
+      "    process.exit(0);",
+      "  }",
+      "  if (message.method === 'turn/interrupt') {",
+      "    send({ id: message.id, result: {} });",
+      "    process.exit(0);",
+      "  }",
+      "}",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+
+  process.env.SYMPHONIKA_FAKE_CODEX_TRANSCRIPT = transcriptPath;
+}
+
+function readJsonl(contents: string): unknown[] {
+  return contents
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function objectField(value: unknown, key: string): unknown {
+  if (typeof value === "object" && value !== null && key in value) {
+    return value[key as keyof typeof value];
+  }
+
+  return undefined;
+}

--- a/tests/doctor-github.test.ts
+++ b/tests/doctor-github.test.ts
@@ -8,6 +8,7 @@ import {
   runInitProject,
   type GitHubApi
 } from "../src/doctor.js";
+import type { AgentProviderRegistry } from "../src/provider.js";
 
 const tempRoots: string[] = [];
 
@@ -42,6 +43,7 @@ describe("GitHub Project validation", () => {
     };
 
     const report = await runDoctor({
+      agentProviders: fakeAgentProviders(),
       configPath: "symphonika.yml",
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
@@ -73,6 +75,7 @@ describe("GitHub Project validation", () => {
     };
 
     const report = await runDoctor({
+      agentProviders: fakeAgentProviders(),
       configPath: "symphonika.yml",
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
@@ -101,6 +104,7 @@ describe("GitHub Project validation", () => {
     };
 
     const report = await runDoctor({
+      agentProviders: fakeAgentProviders(),
       configPath: "symphonika.yml",
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
@@ -128,6 +132,7 @@ describe("GitHub Project validation", () => {
     };
 
     const report = await runDoctor({
+      agentProviders: fakeAgentProviders(),
       configPath: "symphonika.yml",
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
@@ -144,6 +149,20 @@ describe("GitHub Project validation", () => {
     });
   });
 });
+
+function fakeAgentProviders(): AgentProviderRegistry {
+  return {
+    codex: {
+      cancel: () => Promise.resolve(),
+      name: "codex",
+      runAttempt: async function* () {
+        await Promise.resolve();
+        yield* [];
+      },
+      validate: () => Promise.resolve()
+    }
+  };
+}
 
 describe("GitHub Project initialization", () => {
   it("warns about the target repository and labels without mutating unless confirmed", async () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -10,6 +10,7 @@ import {
   type GitHubApi
 } from "../src/doctor.js";
 import type { AgentProviderRegistry } from "../src/provider.js";
+import { DEFAULT_AGENT_PROVIDERS } from "../src/providers/index.js";
 
 const tempRoots: string[] = [];
 const originalGithubToken = process.env.GITHUB_TOKEN;
@@ -178,6 +179,60 @@ describe("doctor", () => {
     expect(report.ok).toBe(false);
     expect(report.errors).toContain(
       "projects.symphonika.providers.codex.command is invalid: codex app-server missing"
+    );
+    expect(report.projects[0]).toMatchObject({
+      validForDispatch: false
+    });
+  });
+
+  it("reports missing provider adapters as invalid for dispatch", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath, {
+      agentProvider: "claude"
+    });
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}} for {{project.name}}.\n"
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const report = await runDoctor({
+      agentProviders: fakeAgentProviders(),
+      configPath,
+      githubApi: successfulGitHubApi()
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "projects.symphonika.agent.provider references claude, but no adapter is registered"
+    );
+    expect(report.projects[0]).toMatchObject({
+      validForDispatch: false
+    });
+  });
+
+  it("keeps Claude visible in the default registry but rejects it until issue #10 lands", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath, {
+      agentProvider: "claude"
+    });
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}} for {{project.name}}.\n"
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const report = await runDoctor({
+      configPath,
+      githubApi: successfulGitHubApi()
+    });
+
+    expect(DEFAULT_AGENT_PROVIDERS.claude?.name).toBe("claude");
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "projects.symphonika.providers.claude.command is invalid: Claude provider adapter is not implemented yet; track issue #10"
     );
     expect(report.projects[0]).toMatchObject({
       validForDispatch: false

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -9,6 +9,7 @@ import {
   runDoctor,
   type GitHubApi
 } from "../src/doctor.js";
+import type { AgentProviderRegistry } from "../src/provider.js";
 
 const tempRoots: string[] = [];
 const originalGithubToken = process.env.GITHUB_TOKEN;
@@ -148,6 +149,41 @@ describe("doctor", () => {
     expect(output.stderr).toContain("$SYMPHONIKA_MISSING_TOKEN");
   });
 
+  it("reports Codex provider command validation errors", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath);
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}} for {{project.name}}.\n"
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const report = await runDoctor({
+      agentProviders: {
+        codex: {
+          cancel: () => Promise.resolve(),
+          name: "codex",
+          runAttempt: async function* () {
+            await Promise.resolve();
+            yield* [];
+          },
+          validate: () => Promise.reject(new Error("codex app-server missing"))
+        }
+      },
+      configPath,
+      githubApi: successfulGitHubApi()
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "projects.symphonika.providers.codex.command is invalid: codex app-server missing"
+    );
+    expect(report.projects[0]).toMatchObject({
+      validForDispatch: false
+    });
+  });
+
   it("accepts workflow front matter for prompt-adjacent policy", async () => {
     const root = await makeTempRoot();
     const configPath = path.join(root, "symphonika.yml");
@@ -218,6 +254,7 @@ async function runDoctorCommand(
     runDoctor: (options) =>
       runDoctor({
         ...options,
+        agentProviders: fakeAgentProviders(),
         githubApi
       })
   });
@@ -239,6 +276,20 @@ async function runDoctorCommand(
   ]);
 
   return output;
+}
+
+function fakeAgentProviders(): AgentProviderRegistry {
+  return {
+    codex: {
+      cancel: () => Promise.resolve(),
+      name: "codex",
+      runAttempt: async function* () {
+        await Promise.resolve();
+        yield* [];
+      },
+      validate: () => Promise.resolve()
+    }
+  };
 }
 
 function successfulGitHubApi(): GitHubApi {


### PR DESCRIPTION
## What changed

- Add a Codex JSON-RPC app-server provider adapter with workspace-cwd launch, handshake, turn start, cancellation, and normalized event mapping.
- Persist raw-only provider messages safely while only recording normalized metadata for normalized events.
- Wire the default Codex provider into daemon dispatch and doctor validation, with tests using fake app-server subprocess streams.

## Why

Issue #9 requires Symphonika to run Codex through the normalized provider interface without requiring a real Codex binary in tests.

## Validation

- npm test
- npm run typecheck
- npm run lint