### PR TITLE
[codex] Add Claude stream-json provider adapter

### DIFF
--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -1,47 +1,807 @@
+import {
+  spawn,
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams
+} from "node:child_process";
+
 import type {
   AgentProvider,
   ProviderEvent,
   ProviderRunInput
 } from "../provider.js";
 
-const UNAVAILABLE_MESSAGE =
-  "Claude provider adapter is not implemented yet; track issue #10";
+type JsonObject = Record<string, unknown>;
+
+type ActiveClaudeRun = {
+  cancelled: boolean;
+  child: ChildProcessWithoutNullStreams;
+  sessionId?: string;
+};
+
+type ProcessQueueItem =
+  | {
+      kind: "exit";
+      exitCode: number | null;
+      signal: NodeJS.Signals | null;
+    }
+  | {
+      error: Error;
+      kind: "error";
+    }
+  | {
+      kind: "malformed";
+      line: string;
+      message: string;
+    }
+  | {
+      kind: "message";
+      raw: unknown;
+    };
+
+type ProcessQueue = {
+  next: () => Promise<ProcessQueueItem>;
+};
 
 export function createClaudeProvider(): AgentProvider {
+  const activeRuns = new Map<string, ActiveClaudeRun>();
+
   return {
-    cancel: () => Promise.resolve(),
+    cancel: (runId) => {
+      const activeRun = activeRuns.get(runId);
+      if (activeRun === undefined) {
+        return Promise.resolve();
+      }
+
+      activeRun.cancelled = true;
+      shutdownProcess(activeRun.child);
+      return Promise.resolve();
+    },
     name: "claude",
     runAttempt: async function* (
       input: ProviderRunInput
     ): AsyncGenerator<ProviderEvent> {
-      await Promise.resolve();
-      yield {
+      const command = parseCommand(input.provider.command);
+      const child = spawn(command.executable, command.args, {
+        cwd: input.workspacePath,
+        env: process.env,
+        stdio: ["pipe", "pipe", "pipe"]
+      });
+      const activeRun: ActiveClaudeRun = {
+        cancelled: false,
+        child
+      };
+      activeRuns.set(input.run.id, activeRun);
+      child.stderr.resume();
+      const queue = createProcessQueue(child);
+
+      try {
+        writeClaudeInput(child, input.prompt);
+        child.stdin.end();
+
+        while (true) {
+          const events = providerEventsFromQueueItem(
+            await queue.next(),
+            activeRun
+          );
+          for (const event of events) {
+            yield event;
+            const type = event.normalized?.type;
+
+            if (type === "process_exit") {
+              return;
+            }
+
+            if (isTerminalFailure(type)) {
+              shutdownProcess(child);
+            }
+          }
+        }
+      } finally {
+        activeRuns.delete(input.run.id);
+      }
+    },
+    validate: async (command) => {
+      const parsed = parseCommand(command);
+      validateClaudeProtocolFlags(parsed.args);
+      await validateClaudeStreamJsonCommand(parsed);
+    }
+  };
+}
+
+function providerEventsFromQueueItem(
+  item: ProcessQueueItem,
+  activeRun: ActiveClaudeRun
+): ProviderEvent[] {
+  switch (item.kind) {
+    case "error":
+      return [
+        {
+          normalized: {
+            message: item.error.message,
+            type: "turn_failed"
+          },
+          raw: {
+            kind: "process_error",
+            message: item.error.message
+          }
+        }
+      ];
+    case "exit":
+      return [
+        {
+          normalized: {
+            cancelled: activeRun.cancelled,
+            exitCode: item.exitCode,
+            signal: item.signal,
+            type: "process_exit"
+          },
+          raw: {
+            cancelled: activeRun.cancelled,
+            exitCode: item.exitCode,
+            kind: "process_exit",
+            signal: item.signal
+          }
+        }
+      ];
+    case "malformed":
+      return [
+        {
+          normalized: {
+            line: item.line,
+            message: item.message,
+            type: "malformed_event"
+          },
+          raw: {
+            kind: "malformed_json",
+            line: item.line,
+            message: item.message
+          }
+        }
+      ];
+    case "message":
+      return mapClaudeStreamJsonMessage(item.raw, activeRun);
+  }
+}
+
+function mapClaudeStreamJsonMessage(
+  raw: unknown,
+  activeRun: ActiveClaudeRun
+): ProviderEvent[] {
+  const type = stringField(raw, "type");
+
+  if (type === "system") {
+    return mapSystemMessage(raw, activeRun);
+  }
+
+  if (type === "assistant") {
+    return mapAssistantMessage(raw, activeRun);
+  }
+
+  if (type === "result") {
+    return mapResultMessage(raw, activeRun);
+  }
+
+  if (type === "stream_event") {
+    return mapStreamEvent(raw, activeRun);
+  }
+
+  if (isInputRequiredType(type)) {
+    return [
+      {
         normalized: {
-          message: UNAVAILABLE_MESSAGE,
-          provider: input.provider.name,
+          input: objectField(raw, "input"),
+          message:
+            stringField(raw, "message") ?? "Claude provider requested input",
+          sessionId: stringField(raw, "session_id") ?? activeRun.sessionId,
+          type: "input_required"
+        },
+        raw
+      }
+    ];
+  }
+
+  if (type === "rate_limit") {
+    return [
+      {
+        normalized: {
+          rateLimits: objectField(raw, "rate_limits") ?? objectField(raw, "rateLimits"),
+          type: "rate_limit_updated"
+        },
+        raw
+      }
+    ];
+  }
+
+  if (type === "error") {
+    return [
+      {
+        normalized: {
+          message:
+            stringField(raw, "message") ??
+            stringField(objectField(raw, "error"), "message") ??
+            "Claude provider error",
+          sessionId: stringField(raw, "session_id") ?? activeRun.sessionId,
           type: "turn_failed"
         },
-        raw: {
-          kind: "provider_unavailable",
-          message: UNAVAILABLE_MESSAGE,
-          provider: input.provider.name
-        }
-      };
-      yield {
+        raw
+      }
+    ];
+  }
+
+  return [
+    {
+      raw
+    }
+  ];
+}
+
+function mapSystemMessage(
+  raw: unknown,
+  activeRun: ActiveClaudeRun
+): ProviderEvent[] {
+  if (stringField(raw, "subtype") !== "init") {
+    return [
+      {
+        raw
+      }
+    ];
+  }
+
+  const sessionId = stringField(raw, "session_id");
+  if (sessionId !== undefined) {
+    activeRun.sessionId = sessionId;
+  }
+
+  return [
+    {
+      normalized: {
+        cwd: stringField(raw, "cwd"),
+        model: stringField(raw, "model"),
+        permissionMode: stringField(raw, "permissionMode"),
+        sessionId,
+        type: "session_started"
+      },
+      raw
+    }
+  ];
+}
+
+function mapAssistantMessage(
+  raw: unknown,
+  activeRun: ActiveClaudeRun
+): ProviderEvent[] {
+  const message = objectField(raw, "message");
+  const sessionId = stringField(raw, "session_id") ?? activeRun.sessionId;
+  const events: ProviderEvent[] = [];
+
+  for (const block of arrayField(message, "content")) {
+    const blockType = stringField(block, "type");
+    if (blockType === "text") {
+      events.push({
         normalized: {
-          cancelled: false,
-          exitCode: null,
-          signal: null,
-          type: "process_exit"
+          message: stringField(block, "text") ?? "",
+          sessionId,
+          type: "message"
         },
-        raw: {
-          cancelled: false,
-          exitCode: null,
-          kind: "process_exit",
-          signal: null
+        raw
+      });
+      continue;
+    }
+
+    if (blockType === "tool_use") {
+      const toolName = stringField(block, "name");
+      const toolInput = objectField(block, "input");
+      if (isInputRequiredTool(toolName)) {
+        events.push({
+          normalized: {
+            input: toolInput,
+            sessionId,
+            toolCallId: stringField(block, "id"),
+            toolName,
+            type: "input_required"
+          },
+          raw
+        });
+        continue;
+      }
+
+      events.push({
+        normalized: {
+          input: toolInput,
+          sessionId,
+          toolCallId: stringField(block, "id"),
+          toolName,
+          type: "tool_call"
+        },
+        raw
+      });
+    }
+  }
+
+  const usage = objectField(message, "usage");
+  if (usage !== undefined) {
+    events.push({
+      normalized: {
+        sessionId,
+        tokenUsage: usage,
+        type: "usage_updated"
+      },
+      raw
+    });
+  }
+
+  if (events.length === 0) {
+    return [
+      {
+        raw
+      }
+    ];
+  }
+
+  return events;
+}
+
+function mapResultMessage(
+  raw: unknown,
+  activeRun: ActiveClaudeRun
+): ProviderEvent[] {
+  const sessionId = stringField(raw, "session_id") ?? activeRun.sessionId;
+  const subtype = stringField(raw, "subtype");
+  const isError = booleanField(raw, "is_error");
+
+  if (subtype === "success" && isError !== true) {
+    return [
+      {
+        normalized: {
+          durationMs: numberField(raw, "duration_ms"),
+          numTurns: numberField(raw, "num_turns"),
+          result: stringField(raw, "result"),
+          sessionId,
+          totalCostUsd: numberField(raw, "total_cost_usd"),
+          type: "turn_completed"
+        },
+        raw
+      }
+    ];
+  }
+
+  return [
+    {
+      normalized: {
+        durationMs: numberField(raw, "duration_ms"),
+        message:
+          stringField(raw, "result") ??
+          `Claude provider result ended with ${subtype ?? "unknown"} status`,
+        numTurns: numberField(raw, "num_turns"),
+        sessionId,
+        subtype,
+        type: "turn_failed"
+      },
+      raw
+    }
+  ];
+}
+
+function mapStreamEvent(
+  raw: unknown,
+  activeRun: ActiveClaudeRun
+): ProviderEvent[] {
+  const event = objectField(raw, "event");
+  const eventType = stringField(event, "type");
+  const sessionId = stringField(raw, "session_id") ?? activeRun.sessionId;
+
+  if (eventType === "content_block_delta") {
+    const delta = objectField(event, "delta");
+    if (stringField(delta, "type") === "text_delta") {
+      return [
+        {
+          normalized: {
+            message: stringField(delta, "text") ?? "",
+            sessionId,
+            type: "message"
+          },
+          raw
         }
-      };
-    },
-    validate: () => Promise.reject(new Error(UNAVAILABLE_MESSAGE))
+      ];
+    }
+  }
+
+  if (eventType === "content_block_start") {
+    const contentBlock = objectField(event, "content_block");
+    if (stringField(contentBlock, "type") === "tool_use") {
+      return [
+        {
+          normalized: {
+            input: objectField(contentBlock, "input"),
+            sessionId,
+            toolCallId: stringField(contentBlock, "id"),
+            toolName: stringField(contentBlock, "name"),
+            type: "tool_call"
+          },
+          raw
+        }
+      ];
+    }
+  }
+
+  return [
+    {
+      raw
+    }
+  ];
+}
+
+function isInputRequiredType(type: string | undefined): boolean {
+  return (
+    type === "input_required" ||
+    type === "permission_request" ||
+    type === "tool_permission_request" ||
+    type === "user_input_request"
+  );
+}
+
+function isInputRequiredTool(toolName: string | undefined): boolean {
+  return toolName === "AskUserQuestion";
+}
+
+function isTerminalFailure(type: string | undefined): boolean {
+  return (
+    type === "input_required" ||
+    type === "malformed_event" ||
+    type === "turn_failed"
+  );
+}
+
+function createProcessQueue(child: ChildProcessWithoutNullStreams): ProcessQueue {
+  const pending: ProcessQueueItem[] = [];
+  let waiting: ((item: ProcessQueueItem) => void) | undefined;
+  let stdoutBuffer = "";
+
+  const push = (item: ProcessQueueItem): void => {
+    if (waiting !== undefined) {
+      const resolve = waiting;
+      waiting = undefined;
+      resolve(item);
+      return;
+    }
+
+    pending.push(item);
   };
+
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdoutBuffer += chunk;
+    let newlineIndex = stdoutBuffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = stdoutBuffer.slice(0, newlineIndex).trimEnd();
+      stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+      pushLine(line, push);
+      newlineIndex = stdoutBuffer.indexOf("\n");
+    }
+  });
+  child.stdout.on("end", () => {
+    if (stdoutBuffer.length > 0) {
+      pushLine(stdoutBuffer.trimEnd(), push);
+      stdoutBuffer = "";
+    }
+  });
+  child.once("error", (error) => {
+    push({
+      error,
+      kind: "error"
+    });
+  });
+  child.once("close", (exitCode, signal) => {
+    push({
+      exitCode,
+      kind: "exit",
+      signal
+    });
+  });
+
+  return {
+    next: () => {
+      const item = pending.shift();
+      if (item !== undefined) {
+        return Promise.resolve(item);
+      }
+
+      return new Promise<ProcessQueueItem>((resolve) => {
+        waiting = resolve;
+      });
+    }
+  };
+}
+
+function pushLine(
+  line: string,
+  push: (item: ProcessQueueItem) => void
+): void {
+  if (line.trim().length === 0) {
+    return;
+  }
+
+  try {
+    push({
+      kind: "message",
+      raw: JSON.parse(line) as unknown
+    });
+  } catch (error) {
+    push({
+      kind: "malformed",
+      line,
+      message: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function writeClaudeInput(
+  child: ChildProcessWithoutNullStreams,
+  prompt: string
+): void {
+  child.stdin.write(
+    `${JSON.stringify({
+      message: {
+        content: [
+          {
+            text: prompt,
+            type: "text"
+          }
+        ],
+        role: "user"
+      },
+      type: "user"
+    })}\n`
+  );
+}
+
+function terminateProcess(child: ChildProcess): void {
+  if (child.killed || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+}
+
+function shutdownProcess(child: ChildProcessWithoutNullStreams): void {
+  if (!child.stdin.destroyed && child.stdin.writable) {
+    child.stdin.end();
+  }
+
+  const timer = setTimeout(() => {
+    terminateProcess(child);
+  }, 250);
+  timer.unref();
+}
+
+async function validateClaudeStreamJsonCommand(command: {
+  args: string[];
+  executable: string;
+}): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command.executable, [...command.args, "--help"], {
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let output = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      terminateProcess(child);
+      reject(new Error("Claude provider command validation timed out"));
+    }, 5_000);
+
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      callback();
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      output += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      output += chunk;
+    });
+    child.once("error", (error) => {
+      settle(() => {
+        reject(
+          new Error(
+            `Claude provider command executable not available: ${command.executable}: ${error.message}`
+          )
+        );
+      });
+    });
+    child.once("close", (exitCode) => {
+      settle(() => {
+        if (exitCode !== 0) {
+          reject(
+            new Error(
+              `Claude provider command validation failed with exit code ${exitCode ?? "unknown"}`
+            )
+          );
+          return;
+        }
+
+        if (!/stream-json/.test(output)) {
+          reject(
+            new Error(
+              "Claude provider command help output does not mention stream-json"
+            )
+          );
+          return;
+        }
+
+        resolve();
+      });
+    });
+  });
+}
+
+function validateClaudeProtocolFlags(args: string[]): void {
+  if (!args.includes("-p") && !args.includes("--print")) {
+    throw new Error("Claude provider command must include -p or --print");
+  }
+
+  if (!hasOptionValue(args, "--input-format", "stream-json")) {
+    throw new Error(
+      "Claude provider command must include --input-format stream-json"
+    );
+  }
+
+  if (!hasOptionValue(args, "--output-format", "stream-json")) {
+    throw new Error(
+      "Claude provider command must include --output-format stream-json"
+    );
+  }
+
+  if (
+    !args.includes("--dangerously-skip-permissions") &&
+    !hasOptionValue(args, "--permission-mode", "bypassPermissions")
+  ) {
+    throw new Error(
+      "Claude provider command must run with full permissions using --dangerously-skip-permissions or --permission-mode bypassPermissions"
+    );
+  }
+}
+
+function hasOptionValue(
+  args: string[],
+  option: string,
+  expectedValue: string
+): boolean {
+  return args.some((arg, index) => {
+    if (arg === option) {
+      return args[index + 1] === expectedValue;
+    }
+
+    return arg === `${option}=${expectedValue}`;
+  });
+}
+
+function parseCommand(command: string): { args: string[]; executable: string } {
+  const parts = splitCommand(command);
+  const executable = parts[0];
+  if (executable === undefined) {
+    throw new Error("Claude provider command is empty");
+  }
+
+  return {
+    args: parts.slice(1),
+    executable
+  };
+}
+
+function splitCommand(command: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  let escaping = false;
+
+  for (const character of command.trim()) {
+    if (escaping) {
+      current += character;
+      escaping = false;
+      continue;
+    }
+
+    if (character === "\\") {
+      escaping = true;
+      continue;
+    }
+
+    if (quote !== undefined) {
+      if (character === quote) {
+        quote = undefined;
+      } else {
+        current += character;
+      }
+      continue;
+    }
+
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+
+    if (/\s/.test(character)) {
+      if (current.length > 0) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += character;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+
+  if (quote !== undefined) {
+    throw new Error("Claude provider command has an unterminated quote");
+  }
+
+  if (current.length > 0) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function arrayField(value: unknown, key: string): unknown[] {
+  const valueAtKey = field(value, key);
+  return Array.isArray(valueAtKey) ? valueAtKey : [];
+}
+
+function objectField(value: unknown, key: string): JsonObject | undefined {
+  const valueAtKey = field(value, key);
+  if (typeof valueAtKey === "object" && valueAtKey !== null) {
+    return valueAtKey as JsonObject;
+  }
+
+  return undefined;
+}
+
+function field(value: unknown, key: string): unknown {
+  if (typeof value === "object" && value !== null && key in value) {
+    return value[key as keyof typeof value];
+  }
+
+  return undefined;
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const valueAtKey = field(value, key);
+  if (typeof valueAtKey === "string") {
+    return valueAtKey;
+  }
+
+  return undefined;
+}
+
+function numberField(value: unknown, key: string): number | undefined {
+  const valueAtKey = field(value, key);
+  if (typeof valueAtKey === "number") {
+    return valueAtKey;
+  }
+
+  return undefined;
+}
+
+function booleanField(value: unknown, key: string): boolean | undefined {
+  const valueAtKey = field(value, key);
+  if (typeof valueAtKey === "boolean") {
+    return valueAtKey;
+  }
+
+  return undefined;
 }

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -712,17 +712,17 @@ function splitCommand(command: string): string[] {
       continue;
     }
 
-    if (character === "\\") {
-      escaping = true;
-      continue;
-    }
-
     if (quote !== undefined) {
       if (character === quote) {
         quote = undefined;
       } else {
         current += character;
       }
+      continue;
+    }
+
+    if (character === "\\") {
+      escaping = true;
       continue;
     }
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -704,8 +704,10 @@ function splitCommand(command: string): string[] {
   let current = "";
   let quote: "'" | '"' | undefined;
   let escaping = false;
+  const trimmedCommand = command.trim();
 
-  for (const character of command.trim()) {
+  for (let index = 0; index < trimmedCommand.length; index += 1) {
+    const character = trimmedCommand[index] ?? "";
     if (escaping) {
       current += character;
       escaping = false;
@@ -722,7 +724,16 @@ function splitCommand(command: string): string[] {
     }
 
     if (character === "\\") {
-      escaping = true;
+      const nextCharacter = trimmedCommand[index + 1];
+      if (
+        nextCharacter === "'" ||
+        nextCharacter === '"' ||
+        (nextCharacter !== undefined && /\s/.test(nextCharacter))
+      ) {
+        escaping = true;
+      } else {
+        current += character;
+      }
       continue;
     }
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -715,6 +715,17 @@ function splitCommand(command: string): string[] {
     }
 
     if (quote !== undefined) {
+      if (character === "\\") {
+        const nextCharacter = trimmedCommand[index + 1];
+        if (nextCharacter === quote || nextCharacter === "\\") {
+          current += nextCharacter;
+          index += 1;
+        } else {
+          current += character;
+        }
+        continue;
+      }
+
       if (character === quote) {
         quote = undefined;
       } else {

--- a/tests/claude-provider.test.ts
+++ b/tests/claude-provider.test.ts
@@ -411,6 +411,20 @@ describe("Claude stream-json provider", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("preserves escaped quotes inside quoted command arguments", async () => {
+    const root = await makeTempRoot();
+    const fakeClaudePath = path.join(root, "fake-claude-argv.mjs");
+    const settingsJson = '{"permissions":{"allow":["Read"]}}';
+    await writeFakeClaudeArgvValidator(fakeClaudePath, settingsJson);
+    const provider = createClaudeProvider();
+
+    await expect(
+      provider.validate(
+        `${process.execPath} ${fakeClaudePath} --settings "${settingsJson.replaceAll('"', '\\"')}" -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`
+      )
+    ).resolves.toBeUndefined();
+  });
+
   it("rejects Claude commands that do not speak stream-json", async () => {
     const provider = createClaudeProvider();
 
@@ -557,6 +571,30 @@ async function writeFakeClaudeHelpExecutable(filePath: string): Promise<void> {
     "utf8"
   );
   await chmod(filePath, 0o755);
+}
+
+async function writeFakeClaudeArgvValidator(
+  filePath: string,
+  expectedSettings: string
+): Promise<void> {
+  await writeFile(
+    filePath,
+    [
+      "const expectedSettings = " + JSON.stringify(expectedSettings) + ";",
+      "const settingsIndex = process.argv.indexOf('--settings');",
+      "if (settingsIndex < 0 || process.argv[settingsIndex + 1] !== expectedSettings) {",
+      "  process.stderr.write(`settings mismatch: ${JSON.stringify(process.argv)}\\n`);",
+      "  process.exit(1);",
+      "}",
+      "if (process.argv.includes('--help')) {",
+      "  process.stdout.write('Usage: fake-claude -p --input-format stream-json --output-format stream-json\\n');",
+      "  process.exit(0);",
+      "}",
+      "process.exit(0);",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
 }
 
 function readJsonl(contents: string): unknown[] {

--- a/tests/claude-provider.test.ts
+++ b/tests/claude-provider.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -374,6 +381,21 @@ describe("Claude stream-json provider", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("preserves backslashes inside quoted command executables", async () => {
+    const root = await makeTempRoot();
+    const fakeClaudeDir = path.join(root, "fake\\claude dir");
+    await mkdir(fakeClaudeDir, { recursive: true });
+    const fakeClaudePath = path.join(fakeClaudeDir, "fake\\claude");
+    await writeFakeClaudeHelpExecutable(fakeClaudePath);
+    const provider = createClaudeProvider();
+
+    await expect(
+      provider.validate(
+        `"${fakeClaudePath}" -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`
+      )
+    ).resolves.toBeUndefined();
+  });
+
   it("rejects Claude commands that do not speak stream-json", async () => {
     const provider = createClaudeProvider();
 
@@ -506,6 +528,20 @@ async function writeFakeClaudeStreamJson(
   );
 
   process.env.SYMPHONIKA_FAKE_CLAUDE_TRANSCRIPT = transcriptPath;
+}
+
+async function writeFakeClaudeHelpExecutable(filePath: string): Promise<void> {
+  await writeFile(
+    filePath,
+    [
+      "#!/bin/sh",
+      "printf '%s\\n' 'Usage: fake-claude -p --input-format stream-json --output-format stream-json'",
+      "exit 0",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+  await chmod(filePath, 0o755);
 }
 
 function readJsonl(contents: string): unknown[] {

--- a/tests/claude-provider.test.ts
+++ b/tests/claude-provider.test.ts
@@ -1,0 +1,524 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createClaudeProvider } from "../src/providers/claude.js";
+import type { ProviderEvent, ProviderRunInput } from "../src/provider.js";
+
+const tempRoots: string[] = [];
+const originalFakeClaudeTranscript =
+  process.env.SYMPHONIKA_FAKE_CLAUDE_TRANSCRIPT;
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-claude-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  if (originalFakeClaudeTranscript === undefined) {
+    delete process.env.SYMPHONIKA_FAKE_CLAUDE_TRANSCRIPT;
+  } else {
+    process.env.SYMPHONIKA_FAKE_CLAUDE_TRANSCRIPT =
+      originalFakeClaudeTranscript;
+  }
+
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("Claude stream-json provider", () => {
+  it("launches the configured command in the workspace and maps a completed turn", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeClaudePath = path.join(root, "fake-claude.mjs");
+    await writeFakeClaudeStreamJson(fakeClaudePath, transcriptPath);
+    const provider = createClaudeProvider();
+
+    const events = await collectProviderEvents(
+      provider.runAttempt({
+        ...providerInputFixture(),
+        provider: {
+          command: `${process.execPath} ${fakeClaudePath} -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`,
+          name: "claude"
+        },
+        workspacePath
+      })
+    );
+
+    const requests = readJsonl(await readFile(transcriptPath, "utf8"));
+    expect(requests).toEqual([
+      {
+        message: {
+          content: [
+            {
+              text: "Implement issue #10.",
+              type: "text"
+            }
+          ],
+          role: "user"
+        },
+        type: "user"
+      }
+    ]);
+    expect(events.map((event) => event.raw)).toEqual([
+      {
+        cwd: workspacePath,
+        model: "claude-sonnet-4-6",
+        permissionMode: "bypassPermissions",
+        session_id: "session-10",
+        subtype: "init",
+        tools: ["Read", "Bash"],
+        type: "system"
+      },
+      {
+        message: {
+          content: [
+            {
+              text: "done",
+              type: "text"
+            }
+          ],
+          id: "msg_10",
+          role: "assistant",
+          type: "message",
+          usage: {
+            input_tokens: 11,
+            output_tokens: 7
+          }
+        },
+        session_id: "session-10",
+        type: "assistant"
+      },
+      {
+        message: {
+          content: [
+            {
+              text: "done",
+              type: "text"
+            }
+          ],
+          id: "msg_10",
+          role: "assistant",
+          type: "message",
+          usage: {
+            input_tokens: 11,
+            output_tokens: 7
+          }
+        },
+        session_id: "session-10",
+        type: "assistant"
+      },
+      {
+        duration_api_ms: 90,
+        duration_ms: 123,
+        is_error: false,
+        num_turns: 1,
+        result: "done",
+        session_id: "session-10",
+        subtype: "success",
+        total_cost_usd: 0.01,
+        type: "result"
+      },
+      {
+        cancelled: false,
+        exitCode: 0,
+        kind: "process_exit",
+        signal: null
+      }
+    ]);
+    const normalizedEvents = events
+      .map((event) => event.normalized)
+      .filter(Boolean);
+    expect(normalizedEvents).toEqual([
+      {
+        cwd: workspacePath,
+        model: "claude-sonnet-4-6",
+        permissionMode: "bypassPermissions",
+        sessionId: "session-10",
+        type: "session_started"
+      },
+      {
+        message: "done",
+        sessionId: "session-10",
+        type: "message"
+      },
+      {
+        sessionId: "session-10",
+        tokenUsage: {
+          input_tokens: 11,
+          output_tokens: 7
+        },
+        type: "usage_updated"
+      },
+      {
+        durationMs: 123,
+        numTurns: 1,
+        result: "done",
+        sessionId: "session-10",
+        totalCostUsd: 0.01,
+        type: "turn_completed"
+      },
+      {
+        cancelled: false,
+        exitCode: 0,
+        signal: null,
+        type: "process_exit"
+      }
+    ]);
+  });
+
+  it("maps AskUserQuestion tool use to input_required and stops the process", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeClaudePath = path.join(root, "fake-claude.mjs");
+    await writeFakeClaudeStreamJson(fakeClaudePath, transcriptPath);
+    const provider = createClaudeProvider();
+
+    const events = await collectProviderEvents(
+      provider.runAttempt({
+        ...providerInputFixture(),
+        provider: {
+          command: `${process.execPath} ${fakeClaudePath} --scenario=input-required -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`,
+          name: "claude"
+        },
+        workspacePath
+      })
+    );
+
+    const normalizedEvents = events
+      .map((event) => event.normalized)
+      .filter(Boolean);
+    expect(normalizedEvents.slice(0, 2)).toEqual([
+      {
+        cwd: workspacePath,
+        model: "claude-sonnet-4-6",
+        permissionMode: "bypassPermissions",
+        sessionId: "session-10",
+        type: "session_started"
+      },
+      {
+        input: {
+          questions: [
+            {
+              header: "Choice",
+              options: [
+                {
+                  description: "Use the default implementation",
+                  label: "Default"
+                }
+              ],
+              question: "Which approach?"
+            }
+          ]
+        },
+        sessionId: "session-10",
+        toolCallId: "toolu_question",
+        toolName: "AskUserQuestion",
+        type: "input_required"
+      }
+    ]);
+    expect(normalizedEvents[2]).toMatchObject({
+      cancelled: false,
+      type: "process_exit"
+    });
+  });
+
+  it("maps malformed stream-json output to malformed_event and stops the process", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeClaudePath = path.join(root, "fake-claude.mjs");
+    await writeFakeClaudeStreamJson(fakeClaudePath, transcriptPath);
+    const provider = createClaudeProvider();
+
+    const events = await collectProviderEvents(
+      provider.runAttempt({
+        ...providerInputFixture(),
+        provider: {
+          command: `${process.execPath} ${fakeClaudePath} --scenario=malformed -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`,
+          name: "claude"
+        },
+        workspacePath
+      })
+    );
+
+    const normalizedEvents = events
+      .map((event) => event.normalized)
+      .filter(Boolean);
+    expect(normalizedEvents.slice(0, 2)).toMatchObject([
+      {
+        cwd: workspacePath,
+        sessionId: "session-10",
+        type: "session_started"
+      },
+      {
+        line: "{bad json",
+        type: "malformed_event"
+      }
+    ]);
+    expect(String(objectField(normalizedEvents[1], "message"))).toContain(
+      "JSON"
+    );
+    expect(normalizedEvents[2]).toMatchObject({
+      cancelled: false,
+      type: "process_exit"
+    });
+  });
+
+  it("maps Claude error results to turn_failed", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeClaudePath = path.join(root, "fake-claude.mjs");
+    await writeFakeClaudeStreamJson(fakeClaudePath, transcriptPath);
+    const provider = createClaudeProvider();
+
+    const events = await collectProviderEvents(
+      provider.runAttempt({
+        ...providerInputFixture(),
+        provider: {
+          command: `${process.execPath} ${fakeClaudePath} --scenario=error -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`,
+          name: "claude"
+        },
+        workspacePath
+      })
+    );
+
+    expect(events.map((event) => event.normalized).filter(Boolean)).toEqual([
+      {
+        cwd: workspacePath,
+        model: "claude-sonnet-4-6",
+        permissionMode: "bypassPermissions",
+        sessionId: "session-10",
+        type: "session_started"
+      },
+      {
+        durationMs: 50,
+        message: "model exploded politely",
+        numTurns: 1,
+        sessionId: "session-10",
+        subtype: "error_during_execution",
+        type: "turn_failed"
+      },
+      {
+        cancelled: false,
+        exitCode: 0,
+        signal: null,
+        type: "process_exit"
+      }
+    ]);
+  });
+
+  it("stops the stream-json process on cancellation", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeClaudePath = path.join(root, "fake-claude.mjs");
+    await writeFakeClaudeStreamJson(fakeClaudePath, transcriptPath);
+    const provider = createClaudeProvider();
+    const iterable = provider.runAttempt({
+      ...providerInputFixture(),
+      provider: {
+        command: `${process.execPath} ${fakeClaudePath} --scenario=wait -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`,
+        name: "claude"
+      },
+      workspacePath
+    });
+    const iterator = iterable[Symbol.asyncIterator]();
+
+    const initialEvent = await nextProviderEvent(iterator);
+    await provider.cancel("run-issue-10");
+    const events = [initialEvent, ...(await collectIteratorEvents(iterator))];
+
+    const normalizedEvents = events
+      .map((event) => event.normalized)
+      .filter(Boolean);
+    expect(normalizedEvents[0]).toEqual(
+      {
+        cwd: workspacePath,
+        model: "claude-sonnet-4-6",
+        permissionMode: "bypassPermissions",
+        sessionId: "session-10",
+        type: "session_started"
+      }
+    );
+    expect(normalizedEvents[1]).toMatchObject({
+      cancelled: true,
+      type: "process_exit"
+    });
+  });
+
+  it("validates the configured full-permission stream-json command", async () => {
+    const root = await makeTempRoot();
+    const transcriptPath = path.join(root, "requests.jsonl");
+    const fakeClaudePath = path.join(root, "fake-claude.mjs");
+    await writeFakeClaudeStreamJson(fakeClaudePath, transcriptPath);
+    const provider = createClaudeProvider();
+
+    await expect(
+      provider.validate(
+        `${process.execPath} ${fakeClaudePath} -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects Claude commands that do not speak stream-json", async () => {
+    const provider = createClaudeProvider();
+
+    await expect(
+      provider.validate("claude -p --dangerously-skip-permissions")
+    ).rejects.toThrow("--input-format stream-json");
+  });
+});
+
+async function collectProviderEvents(
+  iterable: AsyncIterable<ProviderEvent>
+): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+async function collectIteratorEvents(
+  iterator: AsyncIterator<ProviderEvent>
+): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+  while (true) {
+    const result = await iterator.next();
+    if (result.done === true) {
+      return events;
+    }
+
+    events.push(result.value);
+  }
+}
+
+async function nextProviderEvent(
+  iterator: AsyncIterator<ProviderEvent>
+): Promise<ProviderEvent> {
+  const result = await iterator.next();
+  if (result.done === true) {
+    throw new Error("expected provider event");
+  }
+
+  return result.value;
+}
+
+function providerInputFixture(): ProviderRunInput {
+  return {
+    branchName: "sym/symphonika/10-add-claude-stream-json-provider-adapter",
+    issue: {
+      body: "Issue body",
+      created_at: "2026-04-20T10:00:00Z",
+      id: 5010,
+      labels: ["agent-ready"],
+      number: 10,
+      priority: 99,
+      state: "open",
+      title: "Add Claude stream-json provider adapter",
+      updated_at: "2026-04-21T11:00:00Z",
+      url: "https://github.com/pmatos/symphonika/issues/10"
+    },
+    prompt: "Implement issue #10.",
+    promptPath: "/tmp/prompt.md",
+    provider: {
+      command:
+        "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json",
+      name: "claude"
+    },
+    run: {
+      attempt: 1,
+      id: "run-issue-10"
+    },
+    workspacePath: "/tmp/workspace"
+  };
+}
+
+async function writeFakeClaudeStreamJson(
+  filePath: string,
+  transcriptPath: string
+): Promise<void> {
+  await writeFile(
+    filePath,
+    [
+      "import { appendFile } from 'node:fs/promises';",
+      "import readline from 'node:readline';",
+      "",
+      "const scenarioArg = process.argv.find((arg) => arg.startsWith('--scenario='));",
+      "const scenario = scenarioArg ? scenarioArg.slice('--scenario='.length) : 'success';",
+      "",
+      "if (process.argv.includes('--help')) {",
+      "  process.stdout.write('Usage: fake-claude -p --input-format stream-json --output-format stream-json\\n');",
+      "  process.exit(0);",
+      "}",
+      "",
+      "const transcriptPath = process.env.SYMPHONIKA_FAKE_CLAUDE_TRANSCRIPT;",
+      "const rl = readline.createInterface({ input: process.stdin });",
+      "function send(message) {",
+      "  process.stdout.write(`${JSON.stringify(message)}\\n`);",
+      "}",
+      "async function record(message) {",
+      "  if (transcriptPath) {",
+      "    await appendFile(transcriptPath, `${JSON.stringify(message)}\\n`, 'utf8');",
+      "  }",
+      "}",
+      "",
+      "for await (const line of rl) {",
+      "  const message = JSON.parse(line);",
+      "  await record(message);",
+      "  send({ type: 'system', subtype: 'init', session_id: 'session-10', cwd: process.cwd(), tools: ['Read', 'Bash'], model: 'claude-sonnet-4-6', permissionMode: 'bypassPermissions' });",
+      "  if (scenario === 'input-required') {",
+      "    send({ type: 'assistant', session_id: 'session-10', message: { id: 'msg_question', type: 'message', role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_question', name: 'AskUserQuestion', input: { questions: [{ header: 'Choice', question: 'Which approach?', options: [{ label: 'Default', description: 'Use the default implementation' }] }] } }] } });",
+      "    await new Promise(() => {});",
+      "  }",
+      "  if (scenario === 'malformed') {",
+      "    process.stdout.write('{bad json\\n');",
+      "    await new Promise(() => {});",
+      "  }",
+      "  if (scenario === 'error') {",
+      "    send({ type: 'result', subtype: 'error_during_execution', duration_ms: 50, duration_api_ms: 40, is_error: true, num_turns: 1, result: 'model exploded politely', session_id: 'session-10', total_cost_usd: 0.01 });",
+      "    process.exit(0);",
+      "  }",
+      "  if (scenario === 'wait') {",
+      "    await new Promise(() => {});",
+      "  }",
+      "  send({ type: 'assistant', session_id: 'session-10', message: { id: 'msg_10', type: 'message', role: 'assistant', content: [{ type: 'text', text: 'done' }], usage: { input_tokens: 11, output_tokens: 7 } } });",
+      "  send({ type: 'result', subtype: 'success', duration_ms: 123, duration_api_ms: 90, is_error: false, num_turns: 1, result: 'done', session_id: 'session-10', total_cost_usd: 0.01 });",
+      "  process.exit(0);",
+      "}",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+
+  process.env.SYMPHONIKA_FAKE_CLAUDE_TRANSCRIPT = transcriptPath;
+}
+
+function readJsonl(contents: string): unknown[] {
+  return contents
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function objectField(value: unknown, key: string): unknown {
+  if (typeof value === "object" && value !== null && key in value) {
+    return value[key as keyof typeof value];
+  }
+
+  return undefined;
+}

--- a/tests/claude-provider.test.ts
+++ b/tests/claude-provider.test.ts
@@ -396,6 +396,21 @@ describe("Claude stream-json provider", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("preserves backslashes inside unquoted command executables", async () => {
+    const root = await makeTempRoot();
+    const fakeClaudeDir = path.join(root, "fake\\claude");
+    await mkdir(fakeClaudeDir, { recursive: true });
+    const fakeClaudePath = path.join(fakeClaudeDir, "claude\\bin");
+    await writeFakeClaudeHelpExecutable(fakeClaudePath);
+    const provider = createClaudeProvider();
+
+    await expect(
+      provider.validate(
+        `${fakeClaudePath} -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`
+      )
+    ).resolves.toBeUndefined();
+  });
+
   it("rejects Claude commands that do not speak stream-json", async () => {
     const provider = createClaudeProvider();
 

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -212,11 +212,14 @@ describe("doctor", () => {
     });
   });
 
-  it("keeps Claude visible in the default registry but rejects it until issue #10 lands", async () => {
+  it("accepts Claude from the default registry now that its adapter is implemented", async () => {
     const root = await makeTempRoot();
     const configPath = path.join(root, "symphonika.yml");
+    const fakeClaudePath = path.join(root, "fake-claude.mjs");
+    await writeFakeClaudeHelp(fakeClaudePath);
     await writeValidConfig(configPath, {
-      agentProvider: "claude"
+      agentProvider: "claude",
+      claudeCommand: `${process.execPath} ${fakeClaudePath} -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json`
     });
     await writeFile(
       path.join(root, "WORKFLOW.md"),
@@ -230,12 +233,10 @@ describe("doctor", () => {
     });
 
     expect(DEFAULT_AGENT_PROVIDERS.claude?.name).toBe("claude");
-    expect(report.ok).toBe(false);
-    expect(report.errors).toContain(
-      "projects.symphonika.providers.claude.command is invalid: Claude provider adapter is not implemented yet; track issue #10"
-    );
+    expect(report.errors).toEqual([]);
+    expect(report.ok).toBe(true);
     expect(report.projects[0]).toMatchObject({
-      validForDispatch: false
+      validForDispatch: true
     });
   });
 
@@ -359,6 +360,8 @@ async function writeValidConfig(
   configPath: string,
   overrides: {
     agentProvider?: string;
+    claudeCommand?: string;
+    codexCommand?: string;
     token?: string;
     trackerKind?: string;
     workflowPath?: string;
@@ -375,9 +378,9 @@ async function writeValidConfig(
       "  interval_ms: 30000",
       "providers:",
       "  codex:",
-      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      `    command: "${overrides.codexCommand ?? "codex --dangerously-bypass-approvals-and-sandbox app-server"}"`,
       "  claude:",
-      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      `    command: "${overrides.claudeCommand ?? "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"}"`,
       "projects:",
       "  - name: symphonika",
       "    disabled: false",
@@ -408,5 +411,20 @@ async function writeValidConfig(
       `    workflow: ${overrides.workflowPath ?? "./WORKFLOW.md"}`,
       ""
     ].join("\n")
+  );
+}
+
+async function writeFakeClaudeHelp(filePath: string): Promise<void> {
+  await writeFile(
+    filePath,
+    [
+      "if (process.argv.includes('--help')) {",
+      "  process.stdout.write('Usage: fake-claude -p --input-format stream-json --output-format stream-json\\n');",
+      "  process.exit(0);",
+      "}",
+      "process.exit(0);",
+      ""
+    ].join("\n"),
+    "utf8"
   );
 }


### PR DESCRIPTION
## Summary

- replace the placeholder Claude provider with a real stream-json subprocess adapter
- map Claude system, assistant, usage, result, malformed, input-required, and process-exit evidence into normalized provider events
- add fake-subprocess provider tests and update doctor coverage so Claude validates without requiring a real Claude binary by default

## Why

Issue #10 requires Symphonika to support Claude as a first-class provider behind the normalized provider interface, matching the bootstrap requirement for both Codex and Claude providers.

Closes #10

## Validation

- npm test
- npm run typecheck
- npm run lint
- npm run build
- npm test -- tests/claude-provider.test.ts tests/doctor.test.ts