### PR TITLE
Implement run lifecycle controls (closes #11)

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -138,8 +138,12 @@ export async function startDaemon(
       activeRuns.scheduleDelayed({
         delayMs: item.delayMs,
         fire: async () => {
-          await dispatchMutex.acquire();
+          // Register the entire fire callback in inflightDispatches BEFORE
+          // awaiting the mutex, so a shutdown that races with a freshly-fired
+          // timer (while another dispatch still holds the mutex) cannot snapshot
+          // the set early and miss this work.
           const promise = (async () => {
+            await dispatchMutex.acquire();
             try {
               await item.fire();
             } catch (error) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -86,8 +86,11 @@ export async function startDaemon(
   const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
   const env = options.env ?? process.env;
   const activeRuns = new ActiveRunRegistry();
+  const dispatchMutex = createAsyncMutex();
   const dispatchRuntime = {
-    dispatching: false
+    get dispatching(): boolean {
+      return dispatchMutex.held;
+    }
   };
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let polling = false;
@@ -134,23 +137,23 @@ export async function startDaemon(
     schedule: (item: ScheduledWorkInput) => {
       activeRuns.scheduleDelayed({
         delayMs: item.delayMs,
-        fire: () =>
-          new Promise<void>((resolve) => {
-            enqueueScheduledWork(async () => {
-              if (dispatchRuntime.dispatching) {
-                // re-defer if mutex is held; rare for retry/continuation chains.
-              }
-              dispatchRuntime.dispatching = true;
-              try {
-                await item.fire();
-              } catch (error) {
-                logger.error({ err: error }, "symphonika scheduled work failed");
-              } finally {
-                dispatchRuntime.dispatching = false;
-                resolve();
-              }
-            });
-          }),
+        fire: async () => {
+          await dispatchMutex.acquire();
+          const promise = (async () => {
+            try {
+              await item.fire();
+            } catch (error) {
+              logger.error({ err: error }, "symphonika scheduled work failed");
+            } finally {
+              dispatchMutex.release();
+            }
+          })();
+          inflightDispatches.add(promise);
+          void promise.finally(() => {
+            inflightDispatches.delete(promise);
+          });
+          await promise;
+        },
         kind: item.kind,
         runId: item.runId
       });
@@ -211,34 +214,24 @@ export async function startDaemon(
       logger.error({ err: error }, "symphonika reconcile failed");
     }
   };
-  const dispatchEligibleIssue = async (): Promise<void> => {
-    if (
-      !state.configExists ||
-      dispatchRuntime.dispatching ||
-      !hasRegisteredProviders(agentProviders)
-    ) {
-      return;
-    }
-
-    dispatchRuntime.dispatching = true;
-    try {
-      await runController.dispatchOneFresh(issuePollStatus);
-    } catch (error) {
-      issuePollStatus.errors.push(errorMessage(error));
-      logger.error({ err: error }, "symphonika dispatch failed");
-    } finally {
-      dispatchRuntime.dispatching = false;
-    }
-  };
   const launchDispatch = (): void => {
     if (
       !state.configExists ||
-      dispatchRuntime.dispatching ||
-      !hasRegisteredProviders(agentProviders)
+      !hasRegisteredProviders(agentProviders) ||
+      !dispatchMutex.tryAcquire()
     ) {
       return;
     }
-    const promise = dispatchEligibleIssue();
+    const promise = (async () => {
+      try {
+        await runController.dispatchOneFresh(issuePollStatus);
+      } catch (error) {
+        issuePollStatus.errors.push(errorMessage(error));
+        logger.error({ err: error }, "symphonika dispatch failed");
+      } finally {
+        dispatchMutex.release();
+      }
+    })();
     inflightDispatches.add(promise);
     void promise.finally(() => {
       inflightDispatches.delete(promise);
@@ -488,4 +481,45 @@ function defaultProvidersConfig(): RunControllerProvidersConfig {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type AsyncMutex = {
+  acquire: () => Promise<void>;
+  readonly held: boolean;
+  release: () => void;
+  tryAcquire: () => boolean;
+};
+
+function createAsyncMutex(): AsyncMutex {
+  const waiters: Array<() => void> = [];
+  let locked = false;
+  return {
+    acquire(): Promise<void> {
+      if (!locked) {
+        locked = true;
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) => {
+        waiters.push(resolve);
+      });
+    },
+    get held(): boolean {
+      return locked;
+    },
+    release(): void {
+      const next = waiters.shift();
+      if (next !== undefined) {
+        next();
+        return;
+      }
+      locked = false;
+    },
+    tryAcquire(): boolean {
+      if (locked) {
+        return false;
+      }
+      locked = true;
+      return true;
+    }
+  };
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,20 +1,35 @@
+import { readFile } from "node:fs/promises";
+
 import { serve, type ServerType } from "@hono/node-server";
 import type { Logger } from "pino";
 import pino from "pino";
+import { parse } from "yaml";
 
-import { dispatchOneEligibleIssue } from "./dispatch.js";
 import { createHttpApp } from "./http/app.js";
 import type {
   GitHubIssuesApi,
-  PollConfiguredGitHubIssuesOptions
+  PollConfiguredGitHubIssuesOptions,
+  PollingProjectConfig
 } from "./issue-polling.js";
 import {
   DEFAULT_GITHUB_ISSUES_API,
   emptyIssuePollStatus,
+  loadPollingProjectsByName,
   pollConfiguredGitHubIssues,
   readConfiguredPollingIntervalMs,
   replaceIssuePollStatus
 } from "./issue-polling.js";
+import { ActiveRunRegistry } from "./lifecycle/active-runs.js";
+import type {
+  LifecyclePolicy,
+  ScheduledWorkInput
+} from "./lifecycle/active-runs.js";
+import { reconcileActiveRuns } from "./lifecycle/reconcile.js";
+import {
+  RunController,
+  type RunControllerProjectConfig,
+  type RunControllerProvidersConfig
+} from "./lifecycle/run-controller.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
 import { openRunStore } from "./run-store.js";
@@ -33,6 +48,7 @@ export type StartDaemonOptions = {
   env?: NodeJS.ProcessEnv;
   githubIssuesApi?: GitHubIssuesApi;
   host?: string;
+  lifecyclePolicy?: LifecyclePolicy;
   logger?: Logger;
   port?: number;
   prepareIssueWorkspace?: (
@@ -67,12 +83,90 @@ export async function startDaemon(
     stateRoot: state.stateRoot
   });
   const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;
+  const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
+  const env = options.env ?? process.env;
+  const activeRuns = new ActiveRunRegistry();
   const dispatchRuntime = {
     dispatching: false
   };
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let polling = false;
   let scheduledWork = Promise.resolve();
+  const inflightDispatches = new Set<Promise<void>>();
+  const projectsLoader = async (): Promise<
+    Map<string, RunControllerProjectConfig>
+  > => {
+    if (!state.configExists) {
+      return new Map();
+    }
+    const map = await loadPollingProjectsByName(state.configPath);
+    const enriched = new Map<string, RunControllerProjectConfig>();
+    const richDetails = await loadRichProjects(state.configPath);
+    for (const [name, project] of map) {
+      const detail = richDetails.get(name);
+      if (detail === undefined) {
+        continue;
+      }
+      enriched.set(name, {
+        ...project,
+        workflow: detail.workflow,
+        workspace: detail.workspace
+      });
+    }
+    return enriched;
+  };
+  const providersLoader = async (): Promise<RunControllerProvidersConfig> => {
+    return loadProvidersConfig(state.configPath);
+  };
+  const enqueueScheduledWork = (work: () => Promise<void>): void => {
+    scheduledWork = scheduledWork.then(work, work);
+    void scheduledWork;
+  };
+  const runController = new RunController({
+    activeRuns,
+    agentProviders,
+    configDir: state.configDir,
+    githubIssuesApi,
+    logger,
+    projectsLoader,
+    providersLoader,
+    runStore,
+    schedule: (item: ScheduledWorkInput) => {
+      activeRuns.scheduleDelayed({
+        delayMs: item.delayMs,
+        fire: () =>
+          new Promise<void>((resolve) => {
+            enqueueScheduledWork(async () => {
+              if (dispatchRuntime.dispatching) {
+                // re-defer if mutex is held; rare for retry/continuation chains.
+              }
+              dispatchRuntime.dispatching = true;
+              try {
+                await item.fire();
+              } catch (error) {
+                logger.error({ err: error }, "symphonika scheduled work failed");
+              } finally {
+                dispatchRuntime.dispatching = false;
+                resolve();
+              }
+            });
+          }),
+        kind: item.kind,
+        runId: item.runId
+      });
+    },
+    stateRoot: state.stateRoot,
+    ...(options.createRunId === undefined
+      ? {}
+      : { createRunId: options.createRunId }),
+    ...(options.env === undefined ? {} : { env: options.env }),
+    ...(options.lifecyclePolicy === undefined
+      ? {}
+      : { lifecyclePolicy: options.lifecyclePolicy }),
+    ...(options.prepareIssueWorkspace === undefined
+      ? {}
+      : { prepareIssueWorkspace: options.prepareIssueWorkspace })
+  });
   const refreshIssuePollStatus = async (): Promise<void> => {
     if (!state.configExists || polling) {
       return;
@@ -93,6 +187,30 @@ export async function startDaemon(
       polling = false;
     }
   };
+  const reconcile = async (): Promise<void> => {
+    if (!state.configExists) {
+      return;
+    }
+    let projects: Map<string, PollingProjectConfig>;
+    try {
+      projects = await loadPollingProjectsByName(state.configPath);
+    } catch {
+      return;
+    }
+    try {
+      await reconcileActiveRuns({
+        activeRuns,
+        env,
+        githubIssuesApi,
+        logger,
+        pollStatus: issuePollStatus,
+        projects,
+        runStore
+      });
+    } catch (error) {
+      logger.error({ err: error }, "symphonika reconcile failed");
+    }
+  };
   const dispatchEligibleIssue = async (): Promise<void> => {
     if (
       !state.configExists ||
@@ -104,22 +222,7 @@ export async function startDaemon(
 
     dispatchRuntime.dispatching = true;
     try {
-      await dispatchOneEligibleIssue({
-        agentProviders,
-        configDir: state.configDir,
-        configPath: state.configPath,
-        githubIssuesApi: options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API,
-        issuePollStatus,
-        runStore,
-        stateRoot: state.stateRoot,
-        ...(options.createRunId === undefined
-          ? {}
-          : { createRunId: options.createRunId }),
-        ...(options.env === undefined ? {} : { env: options.env }),
-        ...(options.prepareIssueWorkspace === undefined
-          ? {}
-          : { prepareIssueWorkspace: options.prepareIssueWorkspace })
-      });
+      await runController.dispatchOneFresh(issuePollStatus);
     } catch (error) {
       issuePollStatus.errors.push(errorMessage(error));
       logger.error({ err: error }, "symphonika dispatch failed");
@@ -127,24 +230,46 @@ export async function startDaemon(
       dispatchRuntime.dispatching = false;
     }
   };
-  const refreshAndDispatch = async (): Promise<void> => {
-    await refreshIssuePollStatus();
-    await dispatchEligibleIssue();
+  const launchDispatch = (): void => {
+    if (
+      !state.configExists ||
+      dispatchRuntime.dispatching ||
+      !hasRegisteredProviders(agentProviders)
+    ) {
+      return;
+    }
+    const promise = dispatchEligibleIssue();
+    inflightDispatches.add(promise);
+    void promise.finally(() => {
+      inflightDispatches.delete(promise);
+    });
   };
-  const scheduleRefreshAndDispatch = (): void => {
-    scheduledWork = scheduledWork.then(refreshAndDispatch, refreshAndDispatch);
-    void scheduledWork;
+  const tick = async (): Promise<void> => {
+    await refreshIssuePollStatus();
+    await reconcile();
+    launchDispatch();
+  };
+  const scheduleTick = (): void => {
+    enqueueScheduledWork(tick);
   };
 
+  let intervalMs: number | undefined;
   if (state.configExists) {
     await refreshIssuePollStatus();
-    const intervalMs = await readConfiguredPollingIntervalMs(state.configPath);
-    pollTimer = setInterval(scheduleRefreshAndDispatch, intervalMs);
-    pollTimer.unref?.();
+    intervalMs = await readConfiguredPollingIntervalMs(state.configPath);
   }
   const app = createHttpApp({
     dispatchRuntime,
+    getActiveRuns: () =>
+      activeRuns.list().map((entry) => ({
+        cancelReason: entry.cancelReason ?? null,
+        cancelRequested: entry.cancelRequested,
+        issueNumber: entry.issueNumber,
+        projectName: entry.projectName,
+        runId: entry.runId
+      })),
     getRuns: () => runStore.listRuns(),
+    getScheduled: () => activeRuns.peekDelayed(),
     issuePollStatus,
     stateRoot: state.stateRoot,
     version: VERSION
@@ -158,7 +283,15 @@ export async function startDaemon(
   await waitForListening(server);
   const port = resolveListeningPort(server, requestedPort);
   const url = `http://${host}:${port}`;
-  const dispatchPromise = dispatchEligibleIssue();
+  if (state.configExists) {
+    if (issuePollStatus.candidateIssues.length > 0) {
+      launchDispatch();
+    }
+    if (intervalMs !== undefined) {
+      pollTimer = setInterval(scheduleTick, intervalMs);
+      pollTimer.unref?.();
+    }
+  }
 
   logger.info(
     {
@@ -179,10 +312,9 @@ export async function startDaemon(
       if (pollTimer !== undefined) {
         clearInterval(pollTimer);
       }
-      if (dispatchPromise !== undefined) {
-        await dispatchPromise;
-      }
+      activeRuns.cancelAll();
       await scheduledWork;
+      await Promise.allSettled(Array.from(inflightDispatches));
       await stopServer(server, logger);
       runStore.close();
     }
@@ -248,4 +380,112 @@ function hasRegisteredProviders(
   providers: AgentProviderRegistry | undefined
 ): providers is AgentProviderRegistry {
   return providers !== undefined && Object.values(providers).some(Boolean);
+}
+
+type RichProjectDetail = {
+  workflow: string;
+  workspace: {
+    git: {
+      base_branch: string;
+      remote: string;
+    };
+    root: string;
+  };
+};
+
+async function loadRichProjects(
+  configPath: string
+): Promise<Map<string, RichProjectDetail>> {
+  const map = new Map<string, RichProjectDetail>();
+  let raw: unknown;
+  try {
+    raw = parse(await readFile(configPath, "utf8")) ?? {};
+  } catch {
+    return map;
+  }
+  if (!isRecord(raw)) {
+    return map;
+  }
+  const projects = raw["projects"];
+  if (!Array.isArray(projects)) {
+    return map;
+  }
+  for (const project of projects) {
+    if (!isRecord(project)) {
+      continue;
+    }
+    const name = project["name"];
+    if (typeof name !== "string") {
+      continue;
+    }
+    const workflow = project["workflow"];
+    const workspace = project["workspace"];
+    if (typeof workflow !== "string" || !isRecord(workspace)) {
+      continue;
+    }
+    const root = workspace["root"];
+    const git = workspace["git"];
+    if (typeof root !== "string" || !isRecord(git)) {
+      continue;
+    }
+    const remote = git["remote"];
+    const baseBranch = git["base_branch"];
+    if (typeof remote !== "string" || typeof baseBranch !== "string") {
+      continue;
+    }
+    map.set(name, {
+      workflow,
+      workspace: {
+        git: {
+          base_branch: baseBranch,
+          remote
+        },
+        root
+      }
+    });
+  }
+  return map;
+}
+
+async function loadProvidersConfig(
+  configPath: string
+): Promise<RunControllerProvidersConfig> {
+  let raw: unknown;
+  try {
+    raw = parse(await readFile(configPath, "utf8")) ?? {};
+  } catch {
+    return defaultProvidersConfig();
+  }
+  if (!isRecord(raw)) {
+    return defaultProvidersConfig();
+  }
+  const providers = raw["providers"];
+  if (!isRecord(providers)) {
+    return defaultProvidersConfig();
+  }
+  return {
+    claude: { command: providerCommand(providers["claude"], defaultProvidersConfig().claude.command) },
+    codex: { command: providerCommand(providers["codex"], defaultProvidersConfig().codex.command) }
+  };
+}
+
+function providerCommand(input: unknown, fallback: string): string {
+  if (isRecord(input) && typeof input["command"] === "string") {
+    return input["command"];
+  }
+  return fallback;
+}
+
+function defaultProvidersConfig(): RunControllerProvidersConfig {
+  return {
+    claude: {
+      command:
+        "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"
+    },
+    codex: { command: "codex --dangerously-bypass-approvals-and-sandbox app-server" }
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -1,35 +1,24 @@
-import { randomUUID } from "node:crypto";
-import { appendFile, readFile, writeFile } from "node:fs/promises";
-import path from "node:path";
+import { readFile } from "node:fs/promises";
 import { parse } from "yaml";
 import { z } from "zod";
 
 import type {
   GitHubIssueLabelInput,
-  GitHubIssueRepositoryInput,
   GitHubIssuesApi,
-  IssuePollStatus,
-  IssueSnapshot,
-  ProjectIssueSnapshot
+  IssuePollStatus
 } from "./issue-polling.js";
-import type {
-  AgentProvider,
-  AgentProviderName,
-  AgentProviderRegistry,
-  NormalizedProviderEvent,
-  ProviderEvent
-} from "./provider.js";
-import type { RunState, RunStore } from "./run-store.js";
+import { ActiveRunRegistry } from "./lifecycle/active-runs.js";
+import {
+  RunController,
+  type RunControllerProjectConfig,
+  type RunControllerProvidersConfig
+} from "./lifecycle/run-controller.js";
+import type { AgentProviderRegistry } from "./provider.js";
+import type { RunStore } from "./run-store.js";
 import type {
   PreparedIssueWorkspace,
   PrepareIssueWorkspaceInput
 } from "./workspace.js";
-import { prepareIssueWorkspace as prepareRealIssueWorkspace } from "./workspace.js";
-import {
-  loadWorkflowContract,
-  persistRunEvidence,
-  renderAutonomousPrompt
-} from "./workflow.js";
 
 export type LabelWritingGitHubIssuesApi = GitHubIssuesApi & {
   addLabelsToIssue: (input: GitHubIssueLabelInput) => Promise<void>;
@@ -37,6 +26,7 @@ export type LabelWritingGitHubIssuesApi = GitHubIssuesApi & {
 };
 
 export type DispatchIssueOptions = {
+  activeRuns?: ActiveRunRegistry;
   agentProviders: AgentProviderRegistry;
   configDir: string;
   configPath: string;
@@ -61,9 +51,6 @@ export type DispatchIssueResult =
       runId: string;
     };
 
-type DispatchServiceConfig = z.infer<typeof dispatchServiceConfigSchema>;
-type DispatchProjectConfig = z.infer<typeof dispatchProjectSchema>;
-
 const providerNameSchema = z.enum(["codex", "claude"]);
 const providerCommandSchema = z
   .object({
@@ -81,6 +68,19 @@ const dispatchProjectSchema = z
         owner: z.string().trim().min(1),
         repo: z.string().trim().min(1),
         token: z.string().trim().min(1)
+      })
+      .passthrough(),
+    issue_filters: z
+      .object({
+        states: z.array(z.literal("open")).min(1),
+        labels_all: z.array(z.string().trim().min(1)),
+        labels_none: z.array(z.string().trim().min(1))
+      })
+      .passthrough(),
+    priority: z
+      .object({
+        labels: z.record(z.number().int().nonnegative()),
+        default: z.number().int().nonnegative()
       })
       .passthrough(),
     workspace: z
@@ -119,386 +119,48 @@ export async function dispatchOneEligibleIssue(
   options: DispatchIssueOptions
 ): Promise<DispatchIssueResult> {
   const config = await readDispatchConfig(options.configPath);
-  const target = dispatchTarget(config, options.issuePollStatus, options.agentProviders);
-
-  if (target === undefined) {
-    return {
-      dispatched: false,
-      reason: "no eligible issue has a registered provider"
-    };
-  }
-
-  if (!isLabelWritingGitHubIssuesApi(options.githubIssuesApi)) {
-    return {
-      dispatched: false,
-      reason: "GitHub tracker does not support operational label writes"
-    };
-  }
-
-  const token = resolveEnvBackedValue(
-    target.project.tracker.token,
-    options.env ?? process.env
-  );
-  if (token === undefined) {
-    return {
-      dispatched: false,
-      reason: `projects.${target.project.name}.tracker.token is not available`
-    };
-  }
-
-  const providerName = target.project.agent.provider;
-  const provider = target.provider;
-  const providerCommand = config.providers[providerName].command;
-  const runId = options.createRunId?.() ?? randomUUID();
-  const attemptId = `${runId}-attempt-1`;
-  const issue = target.candidate.issue;
-  const repository = {
-    owner: target.project.tracker.owner,
-    repo: target.project.tracker.repo,
-    token
+  const projectsLoader = (): Promise<
+    Map<string, RunControllerProjectConfig>
+  > => {
+    const map = new Map<string, RunControllerProjectConfig>();
+    for (const project of config.projects) {
+      map.set(project.name, project);
+    }
+    return Promise.resolve(map);
   };
-
-  let runCreated = false;
-  let attemptCreated = false;
-  let claimed = false;
-  let running = false;
-
-  try {
-    await options.githubIssuesApi.addLabelsToIssue({
-      ...repository,
-      issueNumber: issue.number,
-      labels: ["sym:claimed"]
+  const providersLoader = (): Promise<RunControllerProvidersConfig> =>
+    Promise.resolve({
+      claude: { command: config.providers.claude.command },
+      codex: { command: config.providers.codex.command }
     });
-    claimed = true;
-    options.runStore.createRun({
-      id: runId,
-      issue,
-      projectName: target.project.name,
-      providerCommand,
-      providerName
-    });
-    runCreated = true;
-    options.runStore.updateRunState(runId, "preparing_workspace");
-    const prepared = await (options.prepareIssueWorkspace ?? prepareRealIssueWorkspace)({
-      configDir: options.configDir,
-      issue: {
-        number: issue.number,
-        title: issue.title
-      },
-      project: target.project
-    });
-    const promptInput = await buildPromptInput({
-      configDir: options.configDir,
-      issue,
-      prepared,
-      project: target.project,
-      providerCommand,
-      providerName,
-      runId
-    });
-    const renderedPrompt = renderAutonomousPrompt(promptInput);
-    const evidence = await persistRunEvidence({
-      ...promptInput,
-      renderedPrompt,
-      stateRoot: options.stateRoot
-    });
-    const rawLogPath = path.join(
-      evidence.runEvidenceDirectory,
-      "provider.raw.jsonl"
-    );
-    const normalizedLogPath = path.join(
-      evidence.runEvidenceDirectory,
-      "provider.normalized.jsonl"
-    );
-
-    await Promise.all([
-      writeFile(rawLogPath, "", "utf8"),
-      writeFile(normalizedLogPath, "", "utf8")
-    ]);
-    const runEvidence = {
-      branchName: prepared.branchName,
-      branchRef: prepared.branchRef,
-      issueSnapshotPath: evidence.issueSnapshotPath,
-      metadataPath: evidence.metadataPath,
-      normalizedLogPath,
-      promptPath: evidence.promptPath,
-      rawLogPath,
-      workspacePath: prepared.workspacePath
-    };
-    options.runStore.updateRunEvidence(runId, runEvidence);
-
-    await provider.validate(providerCommand);
-    await options.githubIssuesApi.addLabelsToIssue({
-      ...repository,
-      issueNumber: issue.number,
-      labels: ["sym:running"]
-    });
-    running = true;
-    options.runStore.updateRunState(runId, "running");
-    options.runStore.createAttempt({
-      ...runEvidence,
-      attemptNumber: 1,
-      id: attemptId,
-      providerCommand,
-      providerName,
-      runId,
-      state: "running"
-    });
-    attemptCreated = true;
-    const finalState = await runProviderAttempt({
-      attemptId,
-      branchName: prepared.branchName,
-      issue,
-      normalizedLogPath,
-      prompt: renderedPrompt.prompt,
-      promptPath: evidence.promptPath,
-      provider,
-      providerCommand,
-      providerName,
-      rawLogPath,
-      runId,
-      runStore: options.runStore,
-      workspacePath: prepared.workspacePath
-    });
-
-    options.runStore.updateAttemptState(attemptId, finalState);
-    options.runStore.updateRunState(runId, finalState);
-    await options.githubIssuesApi.removeLabelsFromIssue({
-      ...repository,
-      issueNumber: issue.number,
-      labels: ["sym:running"]
-    });
-    if (finalState === "failed" || finalState === "input_required") {
-      await options.githubIssuesApi.addLabelsToIssue({
-        ...repository,
-        issueNumber: issue.number,
-        labels: ["sym:failed"]
-      });
-    }
-
-    return {
-      dispatched: true,
-      runId
-    };
-  } catch (error) {
-    if (attemptCreated) {
-      options.runStore.updateAttemptState(attemptId, "failed");
-    }
-    if (runCreated) {
-      options.runStore.updateRunState(runId, "failed");
-    }
-    if (running) {
-      await bestEffortRemoveRunningLabel(
-        options.githubIssuesApi,
-        repository,
-        issue.number
-      );
-    }
-    if (claimed) {
-      await bestEffortAddFailedLabel(
-        options.githubIssuesApi,
-        repository,
-        issue.number
-      );
-    }
-    throw error;
-  }
-}
-
-async function buildPromptInput(input: {
-  configDir: string;
-  issue: IssueSnapshot;
-  prepared: PreparedIssueWorkspace;
-  project: DispatchProjectConfig;
-  providerCommand: string;
-  providerName: AgentProviderName;
-  runId: string;
-}): Promise<Parameters<typeof renderAutonomousPrompt>[0]> {
-  const workflowPath = path.resolve(input.configDir, input.project.workflow);
-  const workflow = await loadWorkflowContract(workflowPath);
-  if (workflow.errors.length > 0) {
-    throw new Error(workflow.errors.join("\n"));
-  }
-
-  return {
-    branch: {
-      name: input.prepared.branchName,
-      ref: input.prepared.branchRef
-    },
-    issue: input.issue,
-    project: {
-      name: input.project.name
-    },
-    provider: {
-      command: input.providerCommand,
-      name: input.providerName
-    },
-    run: {
-      attempt: 1,
-      continuation: false,
-      id: input.runId
-    },
-    template: workflow.body,
-    workflowContentHash: workflow.contentHash,
-    workflowPath,
-    workspace: {
-      path: input.prepared.workspacePath,
-      previous_attempt: input.prepared.reused,
-      root: path.resolve(input.configDir, input.project.workspace.root)
-    }
+  const activeRuns = options.activeRuns ?? new ActiveRunRegistry();
+  const controllerOptions: ConstructorParameters<typeof RunController>[0] = {
+    activeRuns,
+    agentProviders: options.agentProviders,
+    configDir: options.configDir,
+    githubIssuesApi: options.githubIssuesApi,
+    projectsLoader,
+    providersLoader,
+    runStore: options.runStore,
+    schedule: () => undefined,
+    stateRoot: options.stateRoot
   };
-}
-
-async function runProviderAttempt(input: {
-  attemptId: string;
-  branchName: string;
-  issue: IssueSnapshot;
-  normalizedLogPath: string;
-  prompt: string;
-  promptPath: string;
-  provider: AgentProvider;
-  providerCommand: string;
-  providerName: AgentProviderName;
-  rawLogPath: string;
-  runId: string;
-  runStore: RunStore;
-  workspacePath: string;
-}): Promise<RunState> {
-  let finalState: RunState = "succeeded";
-  let sequence = 0;
-
-  for await (const event of input.provider.runAttempt({
-    branchName: input.branchName,
-    issue: input.issue,
-    prompt: input.prompt,
-    promptPath: input.promptPath,
-    provider: {
-      command: input.providerCommand,
-      name: input.providerName
-    },
-    run: {
-      attempt: 1,
-      id: input.runId
-    },
-    workspacePath: input.workspacePath
-  })) {
-    sequence += 1;
-    await persistProviderEvent({
-      attemptId: input.attemptId,
-      event,
-      normalizedLogPath: input.normalizedLogPath,
-      rawLogPath: input.rawLogPath,
-      runId: input.runId,
-      runStore: input.runStore,
-      sequence
-    });
-    if (event.normalized !== undefined) {
-      finalState = terminalStateAfterEvent(finalState, event.normalized);
-    }
+  if (options.createRunId !== undefined) {
+    controllerOptions.createRunId = options.createRunId;
   }
-
-  return finalState;
-}
-
-async function persistProviderEvent(input: {
-  attemptId: string;
-  event: ProviderEvent;
-  normalizedLogPath: string;
-  rawLogPath: string;
-  runId: string;
-  runStore: RunStore;
-  sequence: number;
-}): Promise<void> {
-  await Promise.all([
-    appendJsonl(input.rawLogPath, input.event.raw),
-    ...(input.event.normalized === undefined
-      ? []
-      : [appendJsonl(input.normalizedLogPath, input.event.normalized)])
-  ]);
-  if (input.event.normalized === undefined) {
-    return;
+  if (options.env !== undefined) {
+    controllerOptions.env = options.env;
   }
-
-  input.runStore.recordProviderEvent({
-    attemptId: input.attemptId,
-    normalized: input.event.normalized,
-    raw: input.event.raw,
-    runId: input.runId,
-    sequence: input.sequence
-  });
-}
-
-function terminalStateAfterEvent(
-  current: RunState,
-  event: NormalizedProviderEvent
-): RunState {
-  if (current === "input_required" || current === "failed") {
-    return current;
+  if (options.prepareIssueWorkspace !== undefined) {
+    controllerOptions.prepareIssueWorkspace = options.prepareIssueWorkspace;
   }
-
-  if (event.type === "input_required") {
-    return "input_required";
-  }
-
-  if (event.type === "turn_failed" || event.type === "malformed_event") {
-    return "failed";
-  }
-
-  if (event.type === "process_exit" && processExitFailed(event)) {
-    return "failed";
-  }
-
-  return current;
-}
-
-function processExitFailed(event: NormalizedProviderEvent): boolean {
-  const exitCode = event.exitCode;
-  if (typeof exitCode === "number" && exitCode !== 0) {
-    return true;
-  }
-
-  return typeof event.signal === "string" && event.cancelled !== true;
-}
-
-async function appendJsonl(filePath: string, value: unknown): Promise<void> {
-  await appendFile(filePath, `${JSON.stringify(value)}\n`, "utf8");
-}
-
-function dispatchTarget(
-  config: DispatchServiceConfig,
-  issuePollStatus: IssuePollStatus,
-  providers: AgentProviderRegistry
-):
-  | {
-      candidate: ProjectIssueSnapshot;
-      project: DispatchProjectConfig;
-      provider: AgentProvider;
-    }
-  | undefined {
-  for (const candidate of issuePollStatus.candidateIssues) {
-    const project = config.projects.find(
-      (entry) => entry.name === candidate.project && entry.disabled !== true
-    );
-    if (project === undefined) {
-      continue;
-    }
-
-    const provider = providers[project.agent.provider];
-    if (provider !== undefined) {
-      return {
-        candidate,
-        project,
-        provider
-      };
-    }
-  }
-
-  return undefined;
+  const controller = new RunController(controllerOptions);
+  return controller.dispatchOneFresh(options.issuePollStatus);
 }
 
 async function readDispatchConfig(
   configPath: string
-): Promise<DispatchServiceConfig> {
+): Promise<z.infer<typeof dispatchServiceConfigSchema>> {
   const contents = await readFile(configPath, "utf8");
   const parsed = dispatchServiceConfigSchema.safeParse(parse(contents) ?? {});
 
@@ -513,64 +175,4 @@ async function readDispatchConfig(
   }
 
   return parsed.data;
-}
-
-function isLabelWritingGitHubIssuesApi(
-  api: GitHubIssuesApi
-): api is LabelWritingGitHubIssuesApi {
-  const candidate = api as Partial<LabelWritingGitHubIssuesApi>;
-  return (
-    typeof candidate.addLabelsToIssue === "function" &&
-    typeof candidate.removeLabelsFromIssue === "function"
-  );
-}
-
-function resolveEnvBackedValue(
-  input: string,
-  env: NodeJS.ProcessEnv
-): string | undefined {
-  const variableName = envReferenceName(input);
-  if (variableName === undefined) {
-    return undefined;
-  }
-
-  const value = env[variableName];
-  return value === undefined || value.length === 0 ? undefined : value;
-}
-
-function envReferenceName(input: string): string | undefined {
-  const match = /^\$([A-Za-z_][A-Za-z0-9_]*)$/.exec(input);
-  return match?.[1];
-}
-
-async function bestEffortRemoveRunningLabel(
-  api: LabelWritingGitHubIssuesApi,
-  repository: GitHubIssueRepositoryInput,
-  issueNumber: number
-): Promise<void> {
-  try {
-    await api.removeLabelsFromIssue({
-      ...repository,
-      issueNumber,
-      labels: ["sym:running"]
-    });
-  } catch {
-    // Preserve the original failure; reconciliation will surface stale labels later.
-  }
-}
-
-async function bestEffortAddFailedLabel(
-  api: LabelWritingGitHubIssuesApi,
-  repository: GitHubIssueRepositoryInput,
-  issueNumber: number
-): Promise<void> {
-  try {
-    await api.addLabelsToIssue({
-      ...repository,
-      issueNumber,
-      labels: ["sym:failed"]
-    });
-  } catch {
-    // Preserve the original failure; the run store remains the durable failure record.
-  }
 }

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -79,7 +79,7 @@ const dispatchProjectSchema = z
       .passthrough(),
     priority: z
       .object({
-        labels: z.record(z.number().int().nonnegative()),
+        labels: z.record(z.string(), z.number().int().nonnegative()),
         default: z.number().int().nonnegative()
       })
       .passthrough(),

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -147,7 +147,7 @@ const projectSchema = z
       .passthrough(),
     priority: z
       .object({
-        labels: z.record(z.number().int().nonnegative()),
+        labels: z.record(z.string(), z.number().int().nonnegative()),
         default: z.number().int().nonnegative()
       })
       .passthrough(),

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -8,7 +8,19 @@ export type HttpAppOptions = {
   dispatchRuntime?: {
     dispatching: boolean;
   };
+  getActiveRuns?: () => Array<{
+    cancelReason: string | null;
+    cancelRequested: boolean;
+    issueNumber: number;
+    projectName: string;
+    runId: string;
+  }>;
   getRuns?: () => RunStatus[];
+  getScheduled?: () => Array<{
+    dueAt: number;
+    kind: "retry" | "continuation";
+    runId: string;
+  }>;
   issuePollStatus?: IssuePollStatus;
   stateRoot: string;
   version: string;
@@ -25,6 +37,8 @@ export function createHttpApp(options: HttpAppOptions): Hono {
     dispatching: false
   };
   const getRuns = options.getRuns ?? (() => []);
+  const getActiveRuns = options.getActiveRuns ?? (() => []);
+  const getScheduled = options.getScheduled ?? (() => []);
 
   app.get("/health", (context) =>
     context.json({
@@ -38,6 +52,7 @@ export function createHttpApp(options: HttpAppOptions): Hono {
 
   app.get("/api/status", (context) =>
     context.json({
+      active: getActiveRuns(),
       candidateIssues: issuePollStatus.candidateIssues,
       filteredIssues: issuePollStatus.filteredIssues,
       issuePolling: {
@@ -45,6 +60,7 @@ export function createHttpApp(options: HttpAppOptions): Hono {
         projects: issuePollStatus.projects
       },
       runs: getRuns(),
+      scheduled: getScheduled(),
       service: "symphonika",
       state: dispatchRuntime.dispatching ? "dispatching" : "idle",
       dispatching: dispatchRuntime.dispatching,

--- a/src/issue-polling.ts
+++ b/src/issue-polling.ts
@@ -114,7 +114,7 @@ const pollingProjectSchema = z
       .passthrough(),
     priority: z
       .object({
-        labels: z.record(z.number().int().nonnegative()),
+        labels: z.record(z.string(), z.number().int().nonnegative()),
         default: z.number().int().nonnegative()
       })
       .passthrough(),

--- a/src/issue-polling.ts
+++ b/src/issue-polling.ts
@@ -32,6 +32,9 @@ export type RawGitHubIssue = {
 
 export type GitHubIssuesApi = {
   addLabelsToIssue?: (input: GitHubIssueLabelInput) => Promise<void>;
+  getIssue?: (
+    input: GitHubIssueRepositoryInput & { issueNumber: number }
+  ) => Promise<RawGitHubIssue | null>;
   listOpenIssues: (
     input: GitHubIssueRepositoryInput
   ) => Promise<RawGitHubIssue[]>;
@@ -80,7 +83,7 @@ export type PollConfiguredGitHubIssuesOptions = {
   githubIssuesApi?: GitHubIssuesApi;
 };
 
-type PollingProjectConfig = z.infer<typeof pollingProjectSchema>;
+export type PollingProjectConfig = z.infer<typeof pollingProjectSchema>;
 type PollingServiceConfig = {
   polling?: {
     interval_ms?: number | undefined;
@@ -151,6 +154,25 @@ class OctokitGitHubIssuesApi implements GitHubIssuesApi {
       owner: input.owner,
       repo: input.repo
     });
+  }
+
+  async getIssue(
+    input: GitHubIssueRepositoryInput & { issueNumber: number }
+  ): Promise<RawGitHubIssue | null> {
+    const octokit = this.octokit(input.token);
+    try {
+      const response = await octokit.rest.issues.get({
+        issue_number: input.issueNumber,
+        owner: input.owner,
+        repo: input.repo
+      });
+      return response.data;
+    } catch (error) {
+      if (isOctokitNotFound(error)) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   async listOpenIssues(
@@ -421,6 +443,14 @@ function issueFilterReasons(
   issue: IssueSnapshot,
   project: PollingProjectConfig
 ): string[] {
+  return evaluateProjectEligibility(issue, project).reasons;
+}
+
+export function evaluateProjectEligibility(
+  issue: IssueSnapshot,
+  project: PollingProjectConfig,
+  options: { ignoreOperationalLabels?: boolean } = {}
+): { eligible: boolean; reasons: string[] } {
   const reasons: string[] = [];
   const labels = new Set(issue.labels);
 
@@ -440,13 +470,38 @@ function issueFilterReasons(
     }
   }
 
-  for (const operationalLabel of REQUIRED_OPERATIONAL_LABELS) {
-    if (labels.has(operationalLabel)) {
-      reasons.push(`has operational label ${operationalLabel}`);
+  if (options.ignoreOperationalLabels !== true) {
+    for (const operationalLabel of REQUIRED_OPERATIONAL_LABELS) {
+      if (labels.has(operationalLabel)) {
+        reasons.push(`has operational label ${operationalLabel}`);
+      }
     }
   }
 
-  return reasons;
+  return {
+    eligible: reasons.length === 0,
+    reasons
+  };
+}
+
+export async function loadPollingProjectsByName(
+  configPath: string
+): Promise<Map<string, PollingProjectConfig>> {
+  const errors: string[] = [];
+  const config = await readPollingConfig(configPath, errors);
+  if (config === undefined) {
+    throw new Error(
+      errors.length === 0
+        ? `failed to load polling config at ${configPath}`
+        : errors.join("\n")
+    );
+  }
+
+  const map = new Map<string, PollingProjectConfig>();
+  for (const project of config.projects) {
+    map.set(project.name, project);
+  }
+  return map;
 }
 
 function compareProjectIssues(
@@ -498,4 +553,13 @@ function errorMessage(error: unknown): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isOctokitNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error as { status?: unknown }).status === 404
+  );
 }

--- a/src/lifecycle/active-runs.ts
+++ b/src/lifecycle/active-runs.ts
@@ -1,0 +1,166 @@
+import type { AgentProvider } from "../provider.js";
+import type { CancelReason } from "../run-store.js";
+
+export const CANCEL_REASONS = {
+  CLOSED_ISSUE: "closed_issue",
+  ELIGIBILITY_LOSS: "eligibility_loss",
+  OPERATOR: "operator"
+} as const satisfies Record<string, CancelReason>;
+
+export const LIFECYCLE_POLICY: LifecyclePolicy = {
+  continuation: {
+    cap: 3,
+    delayMs: 1_000
+  },
+  retry: {
+    cap: 3,
+    delaysMs: [10_000, 30_000, 120_000],
+    maxBackoffMs: 300_000
+  }
+};
+
+export type LifecyclePolicy = {
+  continuation: {
+    cap: number;
+    delayMs: number;
+  };
+  retry: {
+    cap: number;
+    delaysMs: number[];
+    maxBackoffMs: number;
+  };
+};
+
+export function computeRetryDelayMs(
+  retryCount: number,
+  policy: LifecyclePolicy = LIFECYCLE_POLICY
+): number {
+  const slot = policy.retry.delaysMs[retryCount - 1];
+  if (slot === undefined) {
+    return policy.retry.maxBackoffMs;
+  }
+  return Math.min(slot, policy.retry.maxBackoffMs);
+}
+
+export type ActiveRunEntry = {
+  cancel: () => Promise<void>;
+  cancelReason?: CancelReason;
+  cancelRequested: boolean;
+  issueNumber: number;
+  projectName: string;
+  provider?: AgentProvider;
+  runId: string;
+};
+
+export type RegisterInput = {
+  cancel: () => Promise<void>;
+  issueNumber: number;
+  projectName: string;
+  provider?: AgentProvider;
+  runId: string;
+};
+
+export type ScheduledWorkKind = "retry" | "continuation";
+
+export type ScheduledWorkInput = {
+  delayMs: number;
+  fire: () => Promise<void>;
+  kind: ScheduledWorkKind;
+  runId: string;
+};
+
+type ScheduledItem = {
+  dueAt: number;
+  kind: ScheduledWorkKind;
+  runId: string;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+export class ActiveRunRegistry {
+  private readonly entries = new Map<string, ActiveRunEntry>();
+  private readonly issueLocks = new Set<string>();
+  private readonly scheduled = new Set<ScheduledItem>();
+
+  register(input: RegisterInput): void {
+    const entry: ActiveRunEntry = {
+      cancel: input.cancel,
+      cancelRequested: false,
+      issueNumber: input.issueNumber,
+      projectName: input.projectName,
+      runId: input.runId
+    };
+    if (input.provider !== undefined) {
+      entry.provider = input.provider;
+    }
+    this.entries.set(input.runId, entry);
+    this.issueLocks.add(issueLockKey(input.projectName, input.issueNumber));
+  }
+
+  unregister(runId: string): ActiveRunEntry | undefined {
+    const entry = this.entries.get(runId);
+    if (entry === undefined) {
+      return undefined;
+    }
+    this.entries.delete(runId);
+    this.issueLocks.delete(issueLockKey(entry.projectName, entry.issueNumber));
+    return entry;
+  }
+
+  get(runId: string): ActiveRunEntry | undefined {
+    return this.entries.get(runId);
+  }
+
+  list(): ActiveRunEntry[] {
+    return Array.from(this.entries.values());
+  }
+
+  isIssueInFlight(projectName: string, issueNumber: number): boolean {
+    return this.issueLocks.has(issueLockKey(projectName, issueNumber));
+  }
+
+  async requestCancel(runId: string, reason: CancelReason): Promise<void> {
+    const entry = this.entries.get(runId);
+    if (entry === undefined || entry.cancelRequested) {
+      return;
+    }
+    entry.cancelRequested = true;
+    entry.cancelReason = reason;
+    await entry.cancel();
+  }
+
+  scheduleDelayed(input: ScheduledWorkInput): void {
+    const dueAt = Date.now() + input.delayMs;
+    const item: ScheduledItem = {
+      dueAt,
+      kind: input.kind,
+      runId: input.runId,
+      timeout: setTimeout(() => {
+        this.scheduled.delete(item);
+        input.fire().catch(() => {
+          /* caller is responsible for surfacing scheduled-work failures */
+        });
+      }, input.delayMs)
+    };
+    item.timeout.unref?.();
+    this.scheduled.add(item);
+  }
+
+  peekDelayed(): { runId: string; kind: ScheduledWorkKind; dueAt: number }[] {
+    return Array.from(this.scheduled, (item) => ({
+      dueAt: item.dueAt,
+      kind: item.kind,
+      runId: item.runId
+    }));
+  }
+
+  cancelAll(): void {
+    for (const item of this.scheduled) {
+      clearTimeout(item.timeout);
+    }
+    this.scheduled.clear();
+  }
+}
+
+function issueLockKey(projectName: string, issueNumber: number): string {
+  return `${projectName}#${issueNumber}`;
+}

--- a/src/lifecycle/classify-failure.ts
+++ b/src/lifecycle/classify-failure.ts
@@ -1,0 +1,158 @@
+import type { NormalizedProviderEvent } from "../provider.js";
+import type { FailureClassification } from "../run-store.js";
+import { WorkspacePreparationError } from "../workspace.js";
+
+export type ClassifyFailureInput = {
+  cancelRequested: boolean;
+  error?: unknown;
+  events: NormalizedProviderEvent[];
+};
+
+export type ClassifiedTerminal = {
+  classification?: FailureClassification;
+  kind: "success" | "failed" | "cancelled" | "input_required";
+  reason: string;
+};
+
+export function classifyFailure(input: ClassifyFailureInput): ClassifiedTerminal {
+  if (input.cancelRequested) {
+    return {
+      kind: "cancelled",
+      reason: "cancelled"
+    };
+  }
+
+  if (input.error !== undefined) {
+    return classifyError(input.error);
+  }
+
+  const inputRequired = input.events.find((event) => event.type === "input_required");
+  if (inputRequired !== undefined) {
+    return {
+      classification: "input_required",
+      kind: "input_required",
+      reason: extractMessage(inputRequired) ?? "provider requested input"
+    };
+  }
+
+  const malformed = input.events.find((event) => event.type === "malformed_event");
+  if (malformed !== undefined) {
+    return {
+      classification: "deterministic",
+      kind: "failed",
+      reason: "malformed_provider_event"
+    };
+  }
+
+  const turnFailed = input.events.find((event) => event.type === "turn_failed");
+  if (turnFailed !== undefined) {
+    return {
+      classification: "transient",
+      kind: "failed",
+      reason: extractMessage(turnFailed) ?? "turn_failed"
+    };
+  }
+
+  const exit = input.events.find((event) => event.type === "process_exit");
+  if (exit === undefined) {
+    return {
+      classification: "transient",
+      kind: "failed",
+      reason: "no_process_exit_event"
+    };
+  }
+
+  if (exit.cancelled === true) {
+    return {
+      kind: "cancelled",
+      reason: "provider_cancelled"
+    };
+  }
+
+  const exitCode = numberField(exit, "exitCode");
+  if (exitCode === 0) {
+    return {
+      kind: "success",
+      reason: ""
+    };
+  }
+
+  return {
+    classification: "transient",
+    kind: "failed",
+    reason:
+      exitCode === undefined
+        ? `process_exit_signal_${stringField(exit, "signal") ?? "unknown"}`
+        : `process_exit_${exitCode}`
+  };
+}
+
+function classifyError(error: unknown): ClassifiedTerminal {
+  if (error instanceof WorkspacePreparationError) {
+    return {
+      classification: "deterministic",
+      kind: "failed",
+      reason: `workspace_${error.code}`
+    };
+  }
+
+  const message = errorMessage(error);
+  if (
+    /workflow|prompt|unknown variable|render|workflow contract|workflow template/i.test(
+      message
+    )
+  ) {
+    return {
+      classification: "deterministic",
+      kind: "failed",
+      reason: `render_error: ${message}`
+    };
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: string }).code === "ENOENT"
+  ) {
+    return {
+      classification: "deterministic",
+      kind: "failed",
+      reason: `binary_missing: ${message}`
+    };
+  }
+
+  return {
+    classification: "transient",
+    kind: "failed",
+    reason: message
+  };
+}
+
+function extractMessage(event: NormalizedProviderEvent): string | undefined {
+  return stringField(event, "message");
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  if (typeof value === "object" && value !== null && key in value) {
+    const inner = (value as Record<string, unknown>)[key];
+    if (typeof inner === "string") {
+      return inner;
+    }
+  }
+  return undefined;
+}
+
+function numberField(value: unknown, key: string): number | undefined {
+  if (typeof value === "object" && value !== null && key in value) {
+    const inner = (value as Record<string, unknown>)[key];
+    if (typeof inner === "number") {
+      return inner;
+    }
+  }
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/lifecycle/reconcile.ts
+++ b/src/lifecycle/reconcile.ts
@@ -1,0 +1,136 @@
+import type { Logger } from "pino";
+
+import {
+  evaluateProjectEligibility,
+  type GitHubIssuesApi,
+  type IssuePollStatus,
+  type IssueSnapshot,
+  type PollingProjectConfig,
+  type RawGitHubIssue
+} from "../issue-polling.js";
+import type { RunStore } from "../run-store.js";
+
+import { ActiveRunRegistry, CANCEL_REASONS } from "./active-runs.js";
+
+export type ReconcileInput = {
+  activeRuns: ActiveRunRegistry;
+  env: NodeJS.ProcessEnv;
+  githubIssuesApi: GitHubIssuesApi;
+  logger: Logger;
+  pollStatus: IssuePollStatus;
+  projects: Map<string, PollingProjectConfig>;
+  runStore: RunStore;
+};
+
+export async function reconcileActiveRuns(input: ReconcileInput): Promise<void> {
+  for (const entry of input.activeRuns.list()) {
+    if (entry.cancelRequested) {
+      continue;
+    }
+    const project = input.projects.get(entry.projectName);
+    if (project === undefined) {
+      continue;
+    }
+
+    const snapshot = findIssueSnapshot(input.pollStatus, entry.projectName, entry.issueNumber);
+    if (snapshot === undefined) {
+      await handleMissingFromPoll({
+        ...input,
+        entry,
+        project
+      });
+      continue;
+    }
+
+    if (snapshot.state !== "open") {
+      await markCancelled(input, entry.runId, CANCEL_REASONS.CLOSED_ISSUE);
+      continue;
+    }
+
+    const eligibility = evaluateProjectEligibility(snapshot, project, {
+      ignoreOperationalLabels: true
+    });
+    if (!eligibility.eligible) {
+      await markCancelled(input, entry.runId, CANCEL_REASONS.ELIGIBILITY_LOSS);
+    }
+  }
+}
+
+async function handleMissingFromPoll(input: ReconcileInput & {
+  entry: ReturnType<ActiveRunRegistry["list"]>[number];
+  project: PollingProjectConfig;
+}): Promise<void> {
+  const token = resolveToken(input.project.tracker.token, input.env);
+  if (token === undefined) {
+    input.logger.warn(
+      { project: input.project.name, runId: input.entry.runId },
+      "symphonika reconcile skipped: github token not available"
+    );
+    return;
+  }
+
+  const fetcher = input.githubIssuesApi.getIssue;
+  if (fetcher === undefined) {
+    input.logger.warn(
+      { runId: input.entry.runId },
+      "symphonika reconcile skipped: githubIssuesApi.getIssue not available"
+    );
+    return;
+  }
+
+  let raw: RawGitHubIssue | null;
+  try {
+    raw = await fetcher({
+      issueNumber: input.entry.issueNumber,
+      owner: input.project.tracker.owner,
+      repo: input.project.tracker.repo,
+      token
+    });
+  } catch (error) {
+    input.logger.warn(
+      { err: error, runId: input.entry.runId },
+      "symphonika reconcile getIssue failed"
+    );
+    return;
+  }
+
+  if (raw === null || raw.state === "closed") {
+    await markCancelled(input, input.entry.runId, CANCEL_REASONS.CLOSED_ISSUE);
+  }
+}
+
+async function markCancelled(
+  input: ReconcileInput,
+  runId: string,
+  reason: (typeof CANCEL_REASONS)[keyof typeof CANCEL_REASONS]
+): Promise<void> {
+  input.runStore.markCancelRequested(runId, reason);
+  await input.activeRuns.requestCancel(runId, reason);
+}
+
+function findIssueSnapshot(
+  pollStatus: IssuePollStatus,
+  projectName: string,
+  issueNumber: number
+): IssueSnapshot | undefined {
+  for (const candidate of pollStatus.candidateIssues) {
+    if (candidate.project === projectName && candidate.issue.number === issueNumber) {
+      return candidate.issue;
+    }
+  }
+  for (const filtered of pollStatus.filteredIssues) {
+    if (filtered.project === projectName && filtered.issue.number === issueNumber) {
+      return filtered.issue;
+    }
+  }
+  return undefined;
+}
+
+function resolveToken(reference: string, env: NodeJS.ProcessEnv): string | undefined {
+  const match = /^\$([A-Za-z_][A-Za-z0-9_]*)$/.exec(reference);
+  if (match === null) {
+    return undefined;
+  }
+  const value = env[match[1] ?? ""];
+  return value === undefined || value.length === 0 ? undefined : value;
+}

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -283,11 +283,49 @@ export class RunController {
       token
     };
 
+    // Re-validate eligibility before re-asserting sym:claimed and starting the
+    // attempt. During the [10s, 30s, 2m] retry backoff the issue may have been
+    // closed or lost required labels; reconcile cannot help here because a
+    // scheduled retry is not present in activeRuns.list() during the window.
+    const refreshed = await this.refreshIssue({
+      project,
+      issueNumber: payload.issue.number,
+      repository
+    });
+    if (refreshed === undefined) {
+      this.logger?.warn(
+        { runId: payload.runId, projectName: payload.projectName },
+        "symphonika retry dropped: issue refresh unavailable"
+      );
+      return;
+    }
+    if (refreshed === null || refreshed.state !== "open") {
+      await this.cancelScheduledLifecycleWork({
+        issueNumber: payload.issue.number,
+        reason: CANCEL_REASONS.CLOSED_ISSUE,
+        repository,
+        runId: payload.runId
+      });
+      return;
+    }
+    const eligibility = evaluateProjectEligibility(refreshed, project, {
+      ignoreOperationalLabels: true
+    });
+    if (!eligibility.eligible) {
+      await this.cancelScheduledLifecycleWork({
+        issueNumber: payload.issue.number,
+        reason: CANCEL_REASONS.ELIGIBILITY_LOSS,
+        repository,
+        runId: payload.runId
+      });
+      return;
+    }
+
     // Re-assert sym:claimed best-effort in case operator clear-stale ran between attempts.
     await this.bestEffort(() =>
       this.githubIssuesApi.addLabelsToIssue!({
         ...repository,
-        issueNumber: payload.issue.number,
+        issueNumber: refreshed.number,
         labels: ["sym:claimed"]
       })
     );
@@ -295,13 +333,31 @@ export class RunController {
     await this.runAttemptLifecycle({
       attemptNumber: payload.attemptNumber,
       isContinuation: this.runStore.isContinuationRun(payload.runId),
-      issue: payload.issue,
+      issue: refreshed,
       project,
       provider,
       providerCommand,
       providerName: project.agent.provider,
       repository,
       runId: payload.runId
+    });
+  }
+
+  private async cancelScheduledLifecycleWork(input: {
+    issueNumber: number;
+    reason: CancelReason;
+    repository: GitHubIssueRepositoryInput;
+    runId: string;
+  }): Promise<void> {
+    this.runStore.markCancelRequested(input.runId, input.reason);
+    this.runStore.recordTerminalReason(input.runId, input.reason);
+    this.runStore.updateRunState(input.runId, "cancelled");
+    await this.applyTerminalLabels({
+      cancelReason: input.reason,
+      issueNumber: input.issueNumber,
+      outcome: { kind: "cancelled", reason: input.reason },
+      repository: input.repository,
+      willRetry: false
     });
   }
 

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -1,0 +1,1002 @@
+import { randomUUID } from "node:crypto";
+import { appendFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { Logger } from "pino";
+
+import type {
+  GitHubIssueLabelInput,
+  GitHubIssueRepositoryInput,
+  GitHubIssuesApi,
+  IssuePollStatus,
+  IssueSnapshot,
+  PollingProjectConfig
+} from "../issue-polling.js";
+import { evaluateProjectEligibility } from "../issue-polling.js";
+import type {
+  AgentProvider,
+  AgentProviderName,
+  AgentProviderRegistry,
+  NormalizedProviderEvent,
+  ProviderEvent
+} from "../provider.js";
+import type { CancelReason, RunState, RunStore } from "../run-store.js";
+import type {
+  PreparedIssueWorkspace,
+  PrepareIssueWorkspaceInput
+} from "../workspace.js";
+import { prepareIssueWorkspace as defaultPrepareIssueWorkspace } from "../workspace.js";
+import {
+  loadWorkflowContract,
+  persistRunEvidence,
+  renderAutonomousPrompt
+} from "../workflow.js";
+
+import {
+  ActiveRunRegistry,
+  CANCEL_REASONS,
+  computeRetryDelayMs,
+  LIFECYCLE_POLICY,
+  type LifecyclePolicy
+} from "./active-runs.js";
+import { classifyFailure, type ClassifiedTerminal } from "./classify-failure.js";
+
+export type RunControllerProjectConfig = PollingProjectConfig & {
+  workflow: string;
+  workspace: {
+    git: {
+      base_branch: string;
+      remote: string;
+    };
+    root: string;
+  };
+};
+
+export type RunControllerProvidersConfig = {
+  codex: { command: string };
+  claude: { command: string };
+};
+
+export type ScheduleHandler = (input: {
+  delayMs: number;
+  fire: () => Promise<void>;
+  kind: "retry" | "continuation";
+  runId: string;
+}) => void;
+
+export type RunControllerOptions = {
+  activeRuns: ActiveRunRegistry;
+  agentProviders: AgentProviderRegistry;
+  configDir: string;
+  createRunId?: () => string;
+  env?: NodeJS.ProcessEnv;
+  githubIssuesApi: GitHubIssuesApi;
+  lifecyclePolicy?: LifecyclePolicy;
+  logger?: Logger;
+  prepareIssueWorkspace?: (
+    input: PrepareIssueWorkspaceInput
+  ) => Promise<PreparedIssueWorkspace>;
+  projectsLoader: () => Promise<Map<string, RunControllerProjectConfig>>;
+  providersLoader: () => Promise<RunControllerProvidersConfig>;
+  runStore: RunStore;
+  schedule: ScheduleHandler;
+  stateRoot: string;
+};
+
+export type DispatchOneFreshResult =
+  | { dispatched: false; reason: string }
+  | { dispatched: true; runId: string };
+
+type DispatchTarget = {
+  candidate: { issue: IssueSnapshot; project: string };
+  project: RunControllerProjectConfig;
+  provider: AgentProvider;
+};
+
+type LabelWritingGitHubIssuesApi = GitHubIssuesApi & {
+  addLabelsToIssue: (input: GitHubIssueLabelInput) => Promise<void>;
+  removeLabelsFromIssue: (input: GitHubIssueLabelInput) => Promise<void>;
+};
+
+type RunRuntime = {
+  attemptId: string;
+  attemptNumber: number;
+  events: NormalizedProviderEvent[];
+};
+
+type StartedAttempt = {
+  evidence: AttemptEvidence;
+  prepared: PreparedIssueWorkspace;
+  prompt: string;
+  promptPath: string;
+};
+
+type AttemptEvidence = {
+  branchName: string;
+  branchRef: string;
+  issueSnapshotPath: string;
+  metadataPath: string;
+  normalizedLogPath: string;
+  promptPath: string;
+  rawLogPath: string;
+  workspacePath: string;
+};
+
+type ApplyLabelsInput = {
+  cancelReason?: CancelReason;
+  issueNumber: number;
+  outcome: ClassifiedTerminal;
+  repository: GitHubIssueRepositoryInput;
+  willRetry: boolean;
+};
+
+type RetryPayload = {
+  attemptNumber: number;
+  issue: IssueSnapshot;
+  projectName: string;
+  runId: string;
+};
+
+type ContinuationPayload = {
+  issue: IssueSnapshot;
+  parentRunId: string;
+  projectName: string;
+};
+
+export class RunController {
+  private readonly activeRuns: ActiveRunRegistry;
+  private readonly agentProviders: AgentProviderRegistry;
+  private readonly configDir: string;
+  private readonly createRunId: () => string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly githubIssuesApi: GitHubIssuesApi;
+  private readonly lifecyclePolicy: LifecyclePolicy;
+  private readonly logger?: Logger;
+  private readonly prepareIssueWorkspace: (
+    input: PrepareIssueWorkspaceInput
+  ) => Promise<PreparedIssueWorkspace>;
+  private readonly projectsLoader: () => Promise<
+    Map<string, RunControllerProjectConfig>
+  >;
+  private readonly providersLoader: () => Promise<RunControllerProvidersConfig>;
+  private readonly runStore: RunStore;
+  private readonly schedule: ScheduleHandler;
+  private readonly stateRoot: string;
+
+  constructor(options: RunControllerOptions) {
+    this.activeRuns = options.activeRuns;
+    this.agentProviders = options.agentProviders;
+    this.configDir = options.configDir;
+    this.createRunId = options.createRunId ?? randomUUID;
+    this.env = options.env ?? process.env;
+    this.githubIssuesApi = options.githubIssuesApi;
+    this.lifecyclePolicy = options.lifecyclePolicy ?? LIFECYCLE_POLICY;
+    if (options.logger !== undefined) {
+      this.logger = options.logger;
+    }
+    this.prepareIssueWorkspace =
+      options.prepareIssueWorkspace ?? defaultPrepareIssueWorkspace;
+    this.projectsLoader = options.projectsLoader;
+    this.providersLoader = options.providersLoader;
+    this.runStore = options.runStore;
+    this.schedule = options.schedule;
+    this.stateRoot = options.stateRoot;
+  }
+
+  async dispatchOneFresh(
+    pollStatus: IssuePollStatus
+  ): Promise<DispatchOneFreshResult> {
+    // Snapshot candidates before any await so a concurrent poll cannot wipe them.
+    const candidates = pollStatus.candidateIssues.slice();
+    const projects = await this.projectsLoader();
+    const providersConfig = await this.providersLoader();
+    const target = this.pickTargetFromCandidates(candidates, projects);
+    if (target === undefined) {
+      return {
+        dispatched: false,
+        reason: "no eligible issue has a registered provider"
+      };
+    }
+
+    if (!isLabelWritingGitHubIssuesApi(this.githubIssuesApi)) {
+      return {
+        dispatched: false,
+        reason: "GitHub tracker does not support operational label writes"
+      };
+    }
+
+    const token = resolveTokenFromEnv(target.project.tracker.token, this.env);
+    if (token === undefined) {
+      return {
+        dispatched: false,
+        reason: `projects.${target.project.name}.tracker.token is not available`
+      };
+    }
+
+    const runId = this.createRunId();
+    const repository = {
+      owner: target.project.tracker.owner,
+      repo: target.project.tracker.repo,
+      token
+    };
+    const providerCommand =
+      providersConfig[target.project.agent.provider].command;
+
+    await this.runFreshLifecycle({
+      attemptNumber: 1,
+      isContinuation: false,
+      issue: target.candidate.issue,
+      parentRunId: null,
+      project: target.project,
+      provider: target.provider,
+      providerCommand,
+      providerName: target.project.agent.provider,
+      repository,
+      runId
+    });
+
+    return { dispatched: true, runId };
+  }
+
+  async executeRetry(payload: RetryPayload): Promise<void> {
+    const projects = await this.projectsLoader();
+    const project = projects.get(payload.projectName);
+    if (project === undefined || project.disabled === true) {
+      this.logger?.warn(
+        { projectName: payload.projectName, runId: payload.runId },
+        "symphonika retry dropped: project disabled or removed"
+      );
+      return;
+    }
+
+    const provider = this.agentProviders[project.agent.provider];
+    if (provider === undefined) {
+      this.logger?.warn(
+        { projectName: payload.projectName, runId: payload.runId },
+        "symphonika retry dropped: provider missing"
+      );
+      return;
+    }
+
+    const providersConfig = await this.providersLoader();
+    const providerCommand = providersConfig[project.agent.provider].command;
+
+    if (!isLabelWritingGitHubIssuesApi(this.githubIssuesApi)) {
+      this.logger?.warn(
+        { runId: payload.runId },
+        "symphonika retry dropped: github tracker missing label writes"
+      );
+      return;
+    }
+
+    const token = resolveTokenFromEnv(project.tracker.token, this.env);
+    if (token === undefined) {
+      this.logger?.warn(
+        { runId: payload.runId },
+        "symphonika retry dropped: token not available"
+      );
+      return;
+    }
+    const repository = {
+      owner: project.tracker.owner,
+      repo: project.tracker.repo,
+      token
+    };
+
+    // Re-assert sym:claimed best-effort in case operator clear-stale ran between attempts.
+    await this.bestEffort(() =>
+      this.githubIssuesApi.addLabelsToIssue!({
+        ...repository,
+        issueNumber: payload.issue.number,
+        labels: ["sym:claimed"]
+      })
+    );
+
+    await this.runAttemptLifecycle({
+      attemptNumber: payload.attemptNumber,
+      issue: payload.issue,
+      project,
+      provider,
+      providerCommand,
+      providerName: project.agent.provider,
+      repository,
+      runId: payload.runId
+    });
+  }
+
+  async executeContinuation(payload: ContinuationPayload): Promise<void> {
+    const projects = await this.projectsLoader();
+    const project = projects.get(payload.projectName);
+    if (project === undefined || project.disabled === true) {
+      this.logger?.warn(
+        { projectName: payload.projectName, parentRunId: payload.parentRunId },
+        "symphonika continuation dropped: project disabled or removed"
+      );
+      return;
+    }
+
+    const provider = this.agentProviders[project.agent.provider];
+    if (provider === undefined) {
+      return;
+    }
+
+    const providersConfig = await this.providersLoader();
+    const providerCommand = providersConfig[project.agent.provider].command;
+
+    if (!isLabelWritingGitHubIssuesApi(this.githubIssuesApi)) {
+      return;
+    }
+
+    const token = resolveTokenFromEnv(project.tracker.token, this.env);
+    if (token === undefined) {
+      return;
+    }
+    const repository = {
+      owner: project.tracker.owner,
+      repo: project.tracker.repo,
+      token
+    };
+
+    const runId = this.createRunId();
+    await this.runFreshLifecycle({
+      attemptNumber: 1,
+      isContinuation: true,
+      issue: payload.issue,
+      parentRunId: payload.parentRunId,
+      project,
+      provider,
+      providerCommand,
+      providerName: project.agent.provider,
+      repository,
+      runId
+    });
+  }
+
+  private pickTargetFromCandidates(
+    candidates: ReadonlyArray<{ issue: IssueSnapshot; project: string }>,
+    projects: Map<string, RunControllerProjectConfig>
+  ): DispatchTarget | undefined {
+    for (const candidate of candidates) {
+      const project = projects.get(candidate.project);
+      if (project === undefined || project.disabled === true) {
+        continue;
+      }
+      if (
+        this.activeRuns.isIssueInFlight(candidate.project, candidate.issue.number)
+      ) {
+        continue;
+      }
+      const provider = this.agentProviders[project.agent.provider];
+      if (provider === undefined) {
+        continue;
+      }
+      return { candidate, project, provider };
+    }
+    return undefined;
+  }
+
+  private async runFreshLifecycle(input: {
+    attemptNumber: number;
+    isContinuation: boolean;
+    issue: IssueSnapshot;
+    parentRunId: string | null;
+    project: RunControllerProjectConfig;
+    provider: AgentProvider;
+    providerCommand: string;
+    providerName: AgentProviderName;
+    repository: GitHubIssueRepositoryInput;
+    runId: string;
+  }): Promise<void> {
+    let claimed = false;
+    let runCreated = false;
+    try {
+      await (this.githubIssuesApi as LabelWritingGitHubIssuesApi).addLabelsToIssue({
+        ...input.repository,
+        issueNumber: input.issue.number,
+        labels: ["sym:claimed"]
+      });
+      claimed = true;
+      const createInput = {
+        id: input.runId,
+        issue: input.issue,
+        projectName: input.project.name,
+        providerCommand: input.providerCommand,
+        providerName: input.providerName
+      };
+      if (input.isContinuation && input.parentRunId !== null) {
+        this.runStore.createContinuationRun({
+          ...createInput,
+          parentRunId: input.parentRunId
+        });
+      } else {
+        this.runStore.createRun(createInput);
+      }
+      runCreated = true;
+      await this.runAttemptLifecycle({
+        attemptNumber: input.attemptNumber,
+        issue: input.issue,
+        project: input.project,
+        provider: input.provider,
+        providerCommand: input.providerCommand,
+        providerName: input.providerName,
+        repository: input.repository,
+        runId: input.runId
+      });
+    } catch (error) {
+      if (!runCreated && claimed) {
+        // Failure between claim and createRun (rare): still mark sym:failed best-effort.
+        await this.bestEffort(() =>
+          (this.githubIssuesApi as LabelWritingGitHubIssuesApi).addLabelsToIssue({
+            ...input.repository,
+            issueNumber: input.issue.number,
+            labels: ["sym:failed"]
+          })
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async runAttemptLifecycle(input: {
+    attemptNumber: number;
+    issue: IssueSnapshot;
+    project: RunControllerProjectConfig;
+    provider: AgentProvider;
+    providerCommand: string;
+    providerName: AgentProviderName;
+    repository: GitHubIssueRepositoryInput;
+    runId: string;
+  }): Promise<void> {
+    const attemptId = `${input.runId}-attempt-${input.attemptNumber}`;
+    const runtime: RunRuntime = {
+      attemptId,
+      attemptNumber: input.attemptNumber,
+      events: []
+    };
+    let attemptCreated = false;
+    let registered = false;
+    let started: StartedAttempt | undefined;
+    let caughtError: unknown;
+
+    this.runStore.updateRunState(input.runId, "preparing_workspace");
+
+    try {
+      started = await this.startAttempt({
+        attemptId,
+        attemptNumber: input.attemptNumber,
+        issue: input.issue,
+        project: input.project,
+        providerCommand: input.providerCommand,
+        providerName: input.providerName,
+        runId: input.runId
+      });
+      await input.provider.validate(input.providerCommand);
+      await (this.githubIssuesApi as LabelWritingGitHubIssuesApi).addLabelsToIssue({
+        ...input.repository,
+        issueNumber: input.issue.number,
+        labels: ["sym:running"]
+      });
+      this.runStore.updateRunState(input.runId, "running");
+      this.runStore.createAttempt({
+        ...started.evidence,
+        attemptNumber: input.attemptNumber,
+        id: attemptId,
+        providerCommand: input.providerCommand,
+        providerName: input.providerName,
+        runId: input.runId,
+        state: "running"
+      });
+      attemptCreated = true;
+      this.activeRuns.register({
+        cancel: () => input.provider.cancel(input.runId),
+        issueNumber: input.issue.number,
+        projectName: input.project.name,
+        provider: input.provider,
+        runId: input.runId
+      });
+      registered = true;
+
+      await this.iterateAttempt({
+        attemptId,
+        attemptNumber: input.attemptNumber,
+        evidence: started.evidence,
+        issue: input.issue,
+        prompt: started.prompt,
+        promptPath: started.promptPath,
+        provider: input.provider,
+        providerCommand: input.providerCommand,
+        providerName: input.providerName,
+        runId: input.runId,
+        runtime
+      });
+    } catch (error) {
+      caughtError = error;
+    } finally {
+      let cancelRequested = false;
+      let cancelReason: CancelReason | undefined;
+      if (registered) {
+        const removed = this.activeRuns.unregister(input.runId);
+        if (removed !== undefined) {
+          cancelRequested = removed.cancelRequested;
+          cancelReason = removed.cancelReason;
+        }
+      }
+      const terminal = classifyFailure({
+        cancelRequested,
+        ...(caughtError === undefined ? {} : { error: caughtError }),
+        events: runtime.events
+      });
+      const outcomeState = mapOutcomeToRunState(terminal);
+      if (attemptCreated) {
+        this.runStore.updateAttemptState(attemptId, outcomeState);
+      }
+      this.runStore.recordTerminalReason(
+        input.runId,
+        terminal.reason,
+        terminal.classification
+      );
+      this.runStore.updateRunState(input.runId, outcomeState);
+
+      const willRetry =
+        terminal.kind === "failed" &&
+        terminal.classification === "transient" &&
+        this.runStore.runRetryCount(input.runId) < this.lifecyclePolicy.retry.cap;
+
+      const labelInput: ApplyLabelsInput = {
+        issueNumber: input.issue.number,
+        outcome: terminal,
+        repository: input.repository,
+        willRetry
+      };
+      if (cancelReason !== undefined) {
+        labelInput.cancelReason = cancelReason;
+      }
+      await this.applyTerminalLabels(labelInput);
+
+      if (caughtError === undefined) {
+        await this.scheduleNext({
+          issue: input.issue,
+          outcome: terminal,
+          project: input.project,
+          repository: input.repository,
+          runId: input.runId,
+          runtimeAttemptNumber: input.attemptNumber
+        });
+      }
+    }
+
+    if (caughtError !== undefined) {
+      throw caughtError instanceof Error
+        ? caughtError
+        : new Error(typeof caughtError === "string" ? caughtError : "unknown error");
+    }
+  }
+
+  private async startAttempt(input: {
+    attemptId: string;
+    attemptNumber: number;
+    issue: IssueSnapshot;
+    project: RunControllerProjectConfig;
+    providerCommand: string;
+    providerName: AgentProviderName;
+    runId: string;
+  }): Promise<StartedAttempt> {
+    const prepared = await this.prepareIssueWorkspace({
+      configDir: this.configDir,
+      issue: {
+        number: input.issue.number,
+        title: input.issue.title
+      },
+      project: input.project
+    });
+
+    const workflowPath = path.resolve(this.configDir, input.project.workflow);
+    const workflow = await loadWorkflowContract(workflowPath);
+    if (workflow.errors.length > 0) {
+      throw new Error(workflow.errors.join("\n"));
+    }
+
+    const promptInput = {
+      branch: {
+        name: prepared.branchName,
+        ref: prepared.branchRef
+      },
+      issue: input.issue,
+      project: { name: input.project.name },
+      provider: {
+        command: input.providerCommand,
+        name: input.providerName
+      },
+      run: {
+        attempt: input.attemptNumber,
+        continuation: false,
+        id: input.runId
+      },
+      template: workflow.body,
+      workflowContentHash: workflow.contentHash,
+      workflowPath,
+      workspace: {
+        path: prepared.workspacePath,
+        previous_attempt: prepared.reused,
+        root: path.resolve(this.configDir, input.project.workspace.root)
+      }
+    };
+    const renderedPrompt = renderAutonomousPrompt(promptInput);
+    const evidence = await persistRunEvidence({
+      ...promptInput,
+      renderedPrompt,
+      stateRoot: this.stateRoot
+    });
+    const rawLogPath = path.join(
+      evidence.runEvidenceDirectory,
+      "provider.raw.jsonl"
+    );
+    const normalizedLogPath = path.join(
+      evidence.runEvidenceDirectory,
+      "provider.normalized.jsonl"
+    );
+    await Promise.all([
+      writeFile(rawLogPath, "", "utf8"),
+      writeFile(normalizedLogPath, "", "utf8")
+    ]);
+    const attemptEvidence: AttemptEvidence = {
+      branchName: prepared.branchName,
+      branchRef: prepared.branchRef,
+      issueSnapshotPath: evidence.issueSnapshotPath,
+      metadataPath: evidence.metadataPath,
+      normalizedLogPath,
+      promptPath: evidence.promptPath,
+      rawLogPath,
+      workspacePath: prepared.workspacePath
+    };
+    this.runStore.updateRunEvidence(input.runId, attemptEvidence);
+
+    return {
+      evidence: attemptEvidence,
+      prepared,
+      prompt: renderedPrompt.prompt,
+      promptPath: evidence.promptPath
+    };
+  }
+
+  private async iterateAttempt(input: {
+    attemptId: string;
+    attemptNumber: number;
+    evidence: AttemptEvidence;
+    issue: IssueSnapshot;
+    prompt: string;
+    promptPath: string;
+    provider: AgentProvider;
+    providerCommand: string;
+    providerName: AgentProviderName;
+    runId: string;
+    runtime: RunRuntime;
+  }): Promise<void> {
+    let sequence = 0;
+    for await (const event of input.provider.runAttempt({
+      branchName: input.evidence.branchName,
+      issue: input.issue,
+      prompt: input.prompt,
+      promptPath: input.promptPath,
+      provider: {
+        command: input.providerCommand,
+        name: input.providerName
+      },
+      run: {
+        attempt: input.attemptNumber,
+        id: input.runId
+      },
+      workspacePath: input.evidence.workspacePath
+    })) {
+      sequence += 1;
+      await this.persistProviderEvent({
+        attemptId: input.attemptId,
+        event,
+        normalizedLogPath: input.evidence.normalizedLogPath,
+        rawLogPath: input.evidence.rawLogPath,
+        runId: input.runId,
+        sequence
+      });
+      if (event.normalized !== undefined) {
+        input.runtime.events.push(event.normalized);
+      }
+    }
+  }
+
+  private async persistProviderEvent(input: {
+    attemptId: string;
+    event: ProviderEvent;
+    normalizedLogPath: string;
+    rawLogPath: string;
+    runId: string;
+    sequence: number;
+  }): Promise<void> {
+    await Promise.all([
+      appendJsonl(input.rawLogPath, input.event.raw),
+      ...(input.event.normalized === undefined
+        ? []
+        : [appendJsonl(input.normalizedLogPath, input.event.normalized)])
+    ]);
+    if (input.event.normalized === undefined) {
+      return;
+    }
+    this.runStore.recordProviderEvent({
+      attemptId: input.attemptId,
+      normalized: input.event.normalized,
+      raw: input.event.raw,
+      runId: input.runId,
+      sequence: input.sequence
+    });
+  }
+
+  private async applyTerminalLabels(input: ApplyLabelsInput): Promise<void> {
+    const api = this.githubIssuesApi as LabelWritingGitHubIssuesApi;
+    if (input.outcome.kind === "cancelled") {
+      const reason = input.cancelReason;
+      await this.bestEffort(() =>
+        api.removeLabelsFromIssue({
+          ...input.repository,
+          issueNumber: input.issueNumber,
+          labels: ["sym:running"]
+        })
+      );
+      if (reason === CANCEL_REASONS.CLOSED_ISSUE) {
+        await this.bestEffort(() =>
+          api.removeLabelsFromIssue({
+            ...input.repository,
+            issueNumber: input.issueNumber,
+            labels: ["sym:claimed"]
+          })
+        );
+        await this.bestEffort(() =>
+          api.removeLabelsFromIssue({
+            ...input.repository,
+            issueNumber: input.issueNumber,
+            labels: ["sym:failed"]
+          })
+        );
+      }
+      return;
+    }
+
+    await this.bestEffort(() =>
+      api.removeLabelsFromIssue({
+        ...input.repository,
+        issueNumber: input.issueNumber,
+        labels: ["sym:running"]
+      })
+    );
+
+    if (
+      input.outcome.kind === "input_required" ||
+      (input.outcome.kind === "failed" && !input.willRetry)
+    ) {
+      await this.bestEffort(() =>
+        api.addLabelsToIssue({
+          ...input.repository,
+          issueNumber: input.issueNumber,
+          labels: ["sym:failed"]
+        })
+      );
+    }
+  }
+
+  private async scheduleNext(input: {
+    issue: IssueSnapshot;
+    outcome: ClassifiedTerminal;
+    project: RunControllerProjectConfig;
+    repository: GitHubIssueRepositoryInput;
+    runId: string;
+    runtimeAttemptNumber: number;
+  }): Promise<void> {
+    if (input.outcome.kind === "cancelled" || input.outcome.kind === "input_required") {
+      return;
+    }
+
+    if (input.outcome.kind === "failed") {
+      if (input.outcome.classification !== "transient") {
+        return;
+      }
+      const currentRetries = this.runStore.runRetryCount(input.runId);
+      if (currentRetries >= this.lifecyclePolicy.retry.cap) {
+        return;
+      }
+      const next = this.runStore.incrementRetryCount(input.runId);
+      const delayMs = computeRetryDelayMs(next, this.lifecyclePolicy);
+      this.schedule({
+        delayMs,
+        fire: () =>
+          this.executeRetry({
+            attemptNumber: input.runtimeAttemptNumber + 1,
+            issue: input.issue,
+            projectName: input.project.name,
+            runId: input.runId
+          }),
+        kind: "retry",
+        runId: input.runId
+      });
+      return;
+    }
+
+    // success path: re-check eligibility, schedule continuation, enforce cap.
+    const refreshed = await this.refreshIssue({
+      project: input.project,
+      issueNumber: input.issue.number,
+      repository: input.repository
+    });
+    if (refreshed === undefined) {
+      return;
+    }
+    if (refreshed === null || refreshed.state !== "open") {
+      return;
+    }
+    const eligibility = evaluateProjectEligibility(refreshed, input.project, {
+      ignoreOperationalLabels: true
+    });
+    if (!eligibility.eligible) {
+      return;
+    }
+
+    const succeededContinuations = this.runStore.countSucceededContinuations(
+      input.project.name,
+      input.issue.number
+    );
+    if (succeededContinuations >= this.lifecyclePolicy.continuation.cap) {
+      const capId = this.createRunId();
+      this.runStore.createCapReachedFailureRun({
+        id: capId,
+        issue: refreshed,
+        parentRunId: input.runId,
+        projectName: input.project.name,
+        reason: "continuation cap reached"
+      });
+      await this.bestEffort(() =>
+        (this.githubIssuesApi as LabelWritingGitHubIssuesApi).addLabelsToIssue({
+          ...input.repository,
+          issueNumber: input.issue.number,
+          labels: ["sym:failed"]
+        })
+      );
+      return;
+    }
+
+    this.schedule({
+      delayMs: this.lifecyclePolicy.continuation.delayMs,
+      fire: () =>
+        this.executeContinuation({
+          issue: refreshed,
+          parentRunId: input.runId,
+          projectName: input.project.name
+        }),
+      kind: "continuation",
+      runId: input.runId
+    });
+  }
+
+  private async refreshIssue(input: {
+    project: RunControllerProjectConfig;
+    issueNumber: number;
+    repository: GitHubIssueRepositoryInput;
+  }): Promise<IssueSnapshot | null | undefined> {
+    const fetcher = this.githubIssuesApi.getIssue;
+    if (fetcher === undefined) {
+      return undefined;
+    }
+    let raw;
+    try {
+      raw = await fetcher({
+        issueNumber: input.issueNumber,
+        owner: input.repository.owner,
+        repo: input.repository.repo,
+        token: input.repository.token
+      });
+    } catch (error) {
+      this.logger?.warn(
+        { err: error },
+        "symphonika continuation refresh failed"
+      );
+      return undefined;
+    }
+    if (raw === null) {
+      return null;
+    }
+    return normalizeRawIssue(raw, input.project);
+  }
+
+  private async bestEffort(fn: () => Promise<void>): Promise<void> {
+    try {
+      await fn();
+    } catch {
+      // best-effort: swallow.
+    }
+  }
+}
+
+function mapOutcomeToRunState(outcome: ClassifiedTerminal): RunState {
+  switch (outcome.kind) {
+    case "success":
+      return "succeeded";
+    case "cancelled":
+      return "cancelled";
+    case "input_required":
+      return "input_required";
+    case "failed":
+    default:
+      return "failed";
+  }
+}
+
+function isLabelWritingGitHubIssuesApi(
+  api: GitHubIssuesApi
+): api is LabelWritingGitHubIssuesApi {
+  const candidate = api as Partial<LabelWritingGitHubIssuesApi>;
+  return (
+    typeof candidate.addLabelsToIssue === "function" &&
+    typeof candidate.removeLabelsFromIssue === "function"
+  );
+}
+
+function resolveTokenFromEnv(
+  reference: string,
+  env: NodeJS.ProcessEnv
+): string | undefined {
+  const match = /^\$([A-Za-z_][A-Za-z0-9_]*)$/.exec(reference);
+  if (match === null) {
+    return undefined;
+  }
+  const value = env[match[1] ?? ""];
+  return value === undefined || value.length === 0 ? undefined : value;
+}
+
+async function appendJsonl(filePath: string, value: unknown): Promise<void> {
+  await appendFile(filePath, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function normalizeRawIssue(
+  raw: import("../issue-polling.js").RawGitHubIssue,
+  project: RunControllerProjectConfig
+): IssueSnapshot {
+  const labels = normalizeLabels(raw.labels ?? []);
+  return {
+    body: raw.body ?? "",
+    created_at: raw.created_at ?? "",
+    id: raw.id ?? 0,
+    labels,
+    number: raw.number ?? 0,
+    priority: priorityForLabels(labels, project),
+    state: raw.state ?? "open",
+    title: raw.title ?? "",
+    updated_at: raw.updated_at ?? "",
+    url: raw.html_url ?? raw.url ?? ""
+  };
+}
+
+function normalizeLabels(labels: unknown[]): string[] {
+  const normalized: string[] = [];
+  for (const label of labels) {
+    if (typeof label === "string") {
+      normalized.push(label);
+      continue;
+    }
+    if (
+      typeof label === "object" &&
+      label !== null &&
+      "name" in label &&
+      typeof (label as { name?: unknown }).name === "string"
+    ) {
+      normalized.push((label as { name: string }).name);
+    }
+  }
+  return normalized;
+}
+
+function priorityForLabels(
+  labels: string[],
+  project: RunControllerProjectConfig
+): number {
+  const priorities = labels.flatMap((label) => {
+    const priority = project.priority.labels[label];
+    return priority === undefined ? [] : [priority];
+  });
+  return priorities.length === 0 ? project.priority.default : Math.min(...priorities);
+}

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -294,6 +294,7 @@ export class RunController {
 
     await this.runAttemptLifecycle({
       attemptNumber: payload.attemptNumber,
+      isContinuation: this.runStore.isContinuationRun(payload.runId),
       issue: payload.issue,
       project,
       provider,
@@ -414,6 +415,7 @@ export class RunController {
       runCreated = true;
       await this.runAttemptLifecycle({
         attemptNumber: input.attemptNumber,
+        isContinuation: input.isContinuation,
         issue: input.issue,
         project: input.project,
         provider: input.provider,
@@ -439,6 +441,7 @@ export class RunController {
 
   private async runAttemptLifecycle(input: {
     attemptNumber: number;
+    isContinuation: boolean;
     issue: IssueSnapshot;
     project: RunControllerProjectConfig;
     provider: AgentProvider;
@@ -464,6 +467,7 @@ export class RunController {
       started = await this.startAttempt({
         attemptId,
         attemptNumber: input.attemptNumber,
+        isContinuation: input.isContinuation,
         issue: input.issue,
         project: input.project,
         providerCommand: input.providerCommand,
@@ -574,6 +578,7 @@ export class RunController {
 
   private async startAttempt(input: {
     attemptId: string;
+    isContinuation: boolean;
     attemptNumber: number;
     issue: IssueSnapshot;
     project: RunControllerProjectConfig;
@@ -609,7 +614,7 @@ export class RunController {
       },
       run: {
         attempt: input.attemptNumber,
-        continuation: false,
+        continuation: input.isContinuation,
         id: input.runId
       },
       template: workflow.body,

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -557,7 +557,9 @@ export class RunController {
       }
       await this.applyTerminalLabels(labelInput);
 
-      if (caughtError === undefined) {
+      // scheduleNext also handles transient throws (kind=failed/transient with retry budget).
+      // It is a no-op for cancelled, deterministic, and input_required outcomes.
+      try {
         await this.scheduleNext({
           issue: input.issue,
           outcome: terminal,
@@ -566,6 +568,11 @@ export class RunController {
           runId: input.runId,
           runtimeAttemptNumber: input.attemptNumber
         });
+      } catch (scheduleError) {
+        this.logger?.error(
+          { err: scheduleError, runId: input.runId },
+          "symphonika scheduleNext failed"
+        );
       }
     }
 
@@ -632,13 +639,15 @@ export class RunController {
       renderedPrompt,
       stateRoot: this.stateRoot
     });
+    const attemptSuffix =
+      input.attemptNumber === 1 ? "" : `.attempt-${input.attemptNumber}`;
     const rawLogPath = path.join(
       evidence.runEvidenceDirectory,
-      "provider.raw.jsonl"
+      `provider.raw${attemptSuffix}.jsonl`
     );
     const normalizedLogPath = path.join(
       evidence.runEvidenceDirectory,
-      "provider.normalized.jsonl"
+      `provider.normalized${attemptSuffix}.jsonl`
     );
     await Promise.all([
       writeFile(rawLogPath, "", "utf8"),
@@ -839,6 +848,11 @@ export class RunController {
       ignoreOperationalLabels: true
     });
     if (!eligibility.eligible) {
+      return;
+    }
+
+    if (this.lifecyclePolicy.continuation.cap <= 0) {
+      // Continuations disabled; nothing to schedule and nothing to surface as cap-reached.
       return;
     }
 

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -16,9 +16,18 @@ export type RunState =
   | "cancelled"
   | "stale";
 
+export type FailureClassification = "transient" | "deterministic" | "input_required";
+
+export type CancelReason = "closed_issue" | "eligibility_loss" | "operator";
+
 export type RunStatus = {
   branchName: string;
+  cancelReason: CancelReason | null;
+  cancelRequested: boolean;
+  continuationParentRunId: string | null;
+  failureClassification: FailureClassification | null;
   id: string;
+  isContinuation: boolean;
   issueNumber: number;
   issueSnapshotPath: string;
   metadataPath: string;
@@ -27,7 +36,9 @@ export type RunStatus = {
   promptPath: string;
   provider: string;
   rawLogPath: string;
+  retryCount: number;
   state: RunState;
+  terminalReason: string | null;
   workspacePath: string;
 };
 
@@ -73,7 +84,12 @@ export type ProviderEventMetadataInput = {
 
 type RunRow = {
   branch_name: string | null;
+  cancel_reason: string | null;
+  cancel_requested: number;
+  continuation_parent_run_id: string | null;
+  failure_classification: string | null;
   id: string;
+  is_continuation: number;
   issue_number: number;
   issue_snapshot_path: string | null;
   metadata_path: string | null;
@@ -82,7 +98,9 @@ type RunRow = {
   prompt_path: string | null;
   provider_name: string | null;
   raw_log_path: string | null;
+  retry_count: number;
   state: RunState;
+  terminal_reason: string | null;
   workspace_path: string | null;
 };
 
@@ -99,32 +117,148 @@ export class RunStore {
   }
 
   createRun(input: CreateRunInput): void {
+    this.insertRunRow({
+      ...input,
+      isContinuation: false,
+      parentRunId: null,
+      providerCommand: input.providerCommand,
+      providerName: input.providerName,
+      state: "queued"
+    });
+  }
+
+  createContinuationRun(input: CreateRunInput & { parentRunId: string }): void {
+    this.insertRunRow({
+      ...input,
+      isContinuation: true,
+      parentRunId: input.parentRunId,
+      providerCommand: input.providerCommand,
+      providerName: input.providerName,
+      state: "queued"
+    });
+  }
+
+  createCapReachedFailureRun(input: {
+    id: string;
+    issue: IssueSnapshot;
+    parentRunId: string;
+    projectName: string;
+    reason: string;
+  }): void {
+    this.insertRunRow({
+      id: input.id,
+      isContinuation: true,
+      issue: input.issue,
+      parentRunId: input.parentRunId,
+      projectName: input.projectName,
+      providerCommand: null,
+      providerName: null,
+      state: "failed"
+    });
+    this.database
+      .prepare(
+        "update runs set terminal_reason = ?, failure_classification = 'deterministic', updated_at = ? where id = ?"
+      )
+      .run(input.reason, timestamp(), input.id);
+    this.updateRunState(input.id, "failed");
+  }
+
+  recordTerminalReason(
+    runId: string,
+    reason: string,
+    classification?: FailureClassification
+  ): void {
+    if (classification === undefined) {
+      this.database
+        .prepare("update runs set terminal_reason = ?, updated_at = ? where id = ?")
+        .run(reason, timestamp(), runId);
+      return;
+    }
+    this.database
+      .prepare(
+        "update runs set terminal_reason = ?, failure_classification = ?, updated_at = ? where id = ?"
+      )
+      .run(reason, classification, timestamp(), runId);
+  }
+
+  incrementRetryCount(runId: string): number {
+    const updated = this.database
+      .prepare(
+        "update runs set retry_count = retry_count + 1, updated_at = ? where id = ? returning retry_count"
+      )
+      .get(timestamp(), runId) as { retry_count: number } | undefined;
+    return updated?.retry_count ?? 0;
+  }
+
+  runRetryCount(runId: string): number {
+    const row = this.database
+      .prepare("select retry_count from runs where id = ?")
+      .get(runId) as { retry_count: number } | undefined;
+    return row?.retry_count ?? 0;
+  }
+
+  listActiveRunIds(): { runId: string; projectName: string; issueNumber: number }[] {
+    const rows = this.database
+      .prepare(
+        "select id, project_name, issue_number from runs where state in ('queued','preparing_workspace','running')"
+      )
+      .all() as { id: string; project_name: string; issue_number: number }[];
+    return rows.map((row) => ({
+      issueNumber: row.issue_number,
+      projectName: row.project_name,
+      runId: row.id
+    }));
+  }
+
+  private insertRunRow(input: {
+    id: string;
+    isContinuation: boolean;
+    issue: IssueSnapshot;
+    parentRunId: string | null;
+    projectName: string;
+    providerCommand: string | null;
+    providerName: AgentProviderName | null;
+    state: RunState;
+  }): void {
     const now = timestamp();
     this.database
       .prepare(
         [
           "insert into runs (",
           "id, project_name, issue_number, issue_title, state, issue_snapshot_json,",
-          "provider_name, provider_command, created_at, updated_at",
+          "provider_name, provider_command, is_continuation, continuation_parent_run_id,",
+          "created_at, updated_at",
           ") values (",
           "@id, @project_name, @issue_number, @issue_title, @state, @issue_snapshot_json,",
-          "@provider_name, @provider_command, @created_at, @updated_at",
+          "@provider_name, @provider_command, @is_continuation, @continuation_parent_run_id,",
+          "@created_at, @updated_at",
           ")"
         ].join(" ")
       )
       .run({
+        continuation_parent_run_id: input.parentRunId,
         created_at: now,
         id: input.id,
+        is_continuation: input.isContinuation ? 1 : 0,
         issue_number: input.issue.number,
         issue_snapshot_json: JSON.stringify(input.issue),
         issue_title: input.issue.title,
         project_name: input.projectName,
         provider_command: input.providerCommand,
         provider_name: input.providerName,
-        state: "queued",
+        state: input.state,
         updated_at: now
       });
-    this.recordRunTransition(input.id, "queued", now);
+    this.recordRunTransition(input.id, input.state, now);
+  }
+
+  countSucceededContinuations(projectName: string, issueNumber: number): number {
+    const row = this.database
+      .prepare(
+        "select count(*) as count from runs where project_name = ? and issue_number = ? and state = 'succeeded' and is_continuation = 1"
+      )
+      .get(projectName, issueNumber) as { count: number } | undefined;
+    return row?.count ?? 0;
   }
 
   updateRunState(runId: string, state: RunState): void {
@@ -234,26 +368,23 @@ export class RunStore {
         [
           "select id, project_name, issue_number, state, provider_name,",
           "workspace_path, branch_name, prompt_path, metadata_path,",
-          "issue_snapshot_path, raw_log_path, normalized_log_path",
+          "issue_snapshot_path, raw_log_path, normalized_log_path,",
+          "is_continuation, continuation_parent_run_id, retry_count,",
+          "failure_classification, terminal_reason, cancel_requested, cancel_reason",
           "from runs order by created_at desc, id desc"
         ].join(" ")
       )
       .all() as RunRow[];
 
-    return rows.map((row) => ({
-      branchName: row.branch_name ?? "",
-      id: row.id,
-      issueNumber: row.issue_number,
-      issueSnapshotPath: row.issue_snapshot_path ?? "",
-      metadataPath: row.metadata_path ?? "",
-      normalizedLogPath: row.normalized_log_path ?? "",
-      project: row.project_name,
-      promptPath: row.prompt_path ?? "",
-      provider: row.provider_name ?? "",
-      rawLogPath: row.raw_log_path ?? "",
-      state: row.state,
-      workspacePath: row.workspace_path ?? ""
-    }));
+    return rows.map((row) => mapRunRow(row));
+  }
+
+  markCancelRequested(runId: string, reason: CancelReason): void {
+    this.database
+      .prepare(
+        "update runs set cancel_requested = 1, cancel_reason = ?, updated_at = ? where id = ?"
+      )
+      .run(reason, timestamp(), runId);
   }
 
   private migrate(): void {
@@ -319,6 +450,35 @@ export class RunStore {
         foreign key (attempt_id) references attempts(id)
       );
     `);
+
+    const additions: Array<[string, string, string]> = [
+      ["runs", "is_continuation", "integer not null default 0"],
+      ["runs", "continuation_parent_run_id", "text"],
+      ["runs", "retry_count", "integer not null default 0"],
+      ["runs", "failure_classification", "text"],
+      ["runs", "terminal_reason", "text"],
+      ["runs", "cancel_requested", "integer not null default 0"],
+      ["runs", "cancel_reason", "text"],
+      ["attempts", "failure_classification", "text"]
+    ];
+
+    const apply = this.database.transaction(() => {
+      for (const [table, column, decl] of additions) {
+        this.ensureColumn(table, column, decl);
+      }
+    });
+    apply();
+  }
+
+  private ensureColumn(table: string, column: string, decl: string): void {
+    const existing = this.database
+      .prepare("select name from pragma_table_info(?)")
+      .all(table) as { name: string }[];
+    if (existing.some((row) => row.name === column)) {
+      return;
+    }
+
+    this.database.exec(`alter table ${table} add column ${column} ${decl};`);
   }
 
   private recordRunTransition(
@@ -356,4 +516,29 @@ function nextTransitionSequence(database: SqliteDatabase, runId: string): number
 
 function timestamp(): string {
   return new Date().toISOString();
+}
+
+function mapRunRow(row: RunRow): RunStatus {
+  return {
+    branchName: row.branch_name ?? "",
+    cancelReason: (row.cancel_reason as CancelReason | null) ?? null,
+    cancelRequested: row.cancel_requested === 1,
+    continuationParentRunId: row.continuation_parent_run_id ?? null,
+    failureClassification:
+      (row.failure_classification as FailureClassification | null) ?? null,
+    id: row.id,
+    isContinuation: row.is_continuation === 1,
+    issueNumber: row.issue_number,
+    issueSnapshotPath: row.issue_snapshot_path ?? "",
+    metadataPath: row.metadata_path ?? "",
+    normalizedLogPath: row.normalized_log_path ?? "",
+    project: row.project_name,
+    promptPath: row.prompt_path ?? "",
+    provider: row.provider_name ?? "",
+    rawLogPath: row.raw_log_path ?? "",
+    retryCount: row.retry_count ?? 0,
+    state: row.state,
+    terminalReason: row.terminal_reason ?? null,
+    workspacePath: row.workspace_path ?? ""
+  };
 }

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -197,6 +197,13 @@ export class RunStore {
     return row?.retry_count ?? 0;
   }
 
+  isContinuationRun(runId: string): boolean {
+    const row = this.database
+      .prepare("select is_continuation from runs where id = ?")
+      .get(runId) as { is_continuation: number } | undefined;
+    return row?.is_continuation === 1;
+  }
+
   listActiveRunIds(): { runId: string; projectName: string; issueNumber: number }[] {
     const rows = this.database
       .prepare(

--- a/tests/active-runs.test.ts
+++ b/tests/active-runs.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ActiveRunRegistry,
+  CANCEL_REASONS,
+  computeRetryDelayMs,
+  LIFECYCLE_POLICY
+} from "../src/lifecycle/active-runs.js";
+
+function entry(overrides: Partial<{ runId: string; cancel: () => Promise<void> }> = {}) {
+  return {
+    cancel: overrides.cancel ?? (() => Promise.resolve()),
+    issueNumber: 7,
+    projectName: "symphonika",
+    runId: overrides.runId ?? "run-a"
+  };
+}
+
+describe("ActiveRunRegistry", () => {
+  it("registers and looks up by runId", () => {
+    const registry = new ActiveRunRegistry();
+    registry.register(entry());
+
+    expect(registry.get("run-a")?.issueNumber).toBe(7);
+    expect(registry.list()).toHaveLength(1);
+  });
+
+  it("isIssueInFlight reports per-(project,issue) lock", () => {
+    const registry = new ActiveRunRegistry();
+    registry.register(entry({ runId: "run-a" }));
+
+    expect(registry.isIssueInFlight("symphonika", 7)).toBe(true);
+    expect(registry.isIssueInFlight("symphonika", 8)).toBe(false);
+
+    registry.unregister("run-a");
+    expect(registry.isIssueInFlight("symphonika", 7)).toBe(false);
+  });
+
+  it("requestCancel calls the entry cancel exactly once", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const registry = new ActiveRunRegistry();
+    registry.register(entry({ cancel, runId: "run-a" }));
+
+    await registry.requestCancel("run-a", CANCEL_REASONS.CLOSED_ISSUE);
+    await registry.requestCancel("run-a", CANCEL_REASONS.CLOSED_ISSUE);
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(registry.get("run-a")?.cancelRequested).toBe(true);
+    expect(registry.get("run-a")?.cancelReason).toBe("closed_issue");
+  });
+
+  it("scheduleDelayed fires after the requested delay and is reported by peekDelayed", async () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new ActiveRunRegistry();
+      const fire = vi.fn().mockResolvedValue(undefined);
+      registry.scheduleDelayed({
+        delayMs: 50,
+        fire,
+        kind: "retry",
+        runId: "run-a"
+      });
+
+      const peeked = registry.peekDelayed();
+      expect(peeked).toHaveLength(1);
+      expect(peeked[0]?.kind).toBe("retry");
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(fire).toHaveBeenCalledTimes(1);
+      expect(registry.peekDelayed()).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancelAll clears pending scheduled work", async () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new ActiveRunRegistry();
+      const fire = vi.fn().mockResolvedValue(undefined);
+      registry.scheduleDelayed({
+        delayMs: 50,
+        fire,
+        kind: "continuation",
+        runId: "run-a"
+      });
+      registry.cancelAll();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(fire).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("computeRetryDelayMs", () => {
+  it("returns the configured delay for each retry slot, then cap", () => {
+    expect(computeRetryDelayMs(1)).toBe(LIFECYCLE_POLICY.retry.delaysMs[0]);
+    expect(computeRetryDelayMs(2)).toBe(LIFECYCLE_POLICY.retry.delaysMs[1]);
+    expect(computeRetryDelayMs(3)).toBe(LIFECYCLE_POLICY.retry.delaysMs[2]);
+    expect(computeRetryDelayMs(99)).toBe(LIFECYCLE_POLICY.retry.maxBackoffMs);
+  });
+});

--- a/tests/classify-failure.test.ts
+++ b/tests/classify-failure.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyFailure } from "../src/lifecycle/classify-failure.js";
+import { WorkspacePreparationError } from "../src/workspace.js";
+
+describe("classifyFailure", () => {
+  it("classifies a clean process_exit code 0 as success", () => {
+    const result = classifyFailure({
+      cancelRequested: false,
+      events: [
+        { type: "session_started" },
+        { type: "process_exit", exitCode: 0 }
+      ]
+    });
+
+    expect(result.kind).toBe("success");
+  });
+
+  it("treats cancelRequested override as cancelled regardless of event flags", () => {
+    const result = classifyFailure({
+      cancelRequested: true,
+      events: [{ type: "process_exit", exitCode: 0 }]
+    });
+
+    expect(result.kind).toBe("cancelled");
+  });
+
+  it("classifies input_required terminally", () => {
+    const result = classifyFailure({
+      cancelRequested: false,
+      events: [{ type: "input_required" }]
+    });
+
+    expect(result.kind).toBe("input_required");
+    expect(result.classification).toBe("input_required");
+  });
+
+  it("classifies malformed_event as deterministic failure", () => {
+    const result = classifyFailure({
+      cancelRequested: false,
+      events: [
+        { type: "malformed_event", line: "{" },
+        { type: "process_exit", exitCode: 1 }
+      ]
+    });
+
+    expect(result.kind).toBe("failed");
+    expect(result.classification).toBe("deterministic");
+  });
+
+  it("classifies turn_failed as transient failure", () => {
+    const result = classifyFailure({
+      cancelRequested: false,
+      events: [
+        { type: "turn_failed", message: "boom" },
+        { type: "process_exit", exitCode: 1 }
+      ]
+    });
+
+    expect(result.kind).toBe("failed");
+    expect(result.classification).toBe("transient");
+  });
+
+  it("classifies non-zero process_exit as transient failure", () => {
+    const result = classifyFailure({
+      cancelRequested: false,
+      events: [{ type: "process_exit", exitCode: 1 }]
+    });
+
+    expect(result.kind).toBe("failed");
+    expect(result.classification).toBe("transient");
+  });
+
+  it("classifies WorkspacePreparationError as deterministic", () => {
+    const result = classifyFailure({
+      cancelRequested: false,
+      error: new WorkspacePreparationError("branch_conflict", "boom"),
+      events: []
+    });
+
+    expect(result.kind).toBe("failed");
+    expect(result.classification).toBe("deterministic");
+    expect(result.reason).toContain("workspace_branch_conflict");
+  });
+
+  it("classifies workflow render errors as deterministic", () => {
+    const result = classifyFailure({
+      cancelRequested: false,
+      error: new Error("workflow template references unknown variable {{x}}"),
+      events: []
+    });
+
+    expect(result.kind).toBe("failed");
+    expect(result.classification).toBe("deterministic");
+  });
+
+  it("classifies ENOENT validate errors as deterministic", () => {
+    const error = new Error("ENOENT: no such file") as Error & { code?: string };
+    error.code = "ENOENT";
+    const result = classifyFailure({
+      cancelRequested: false,
+      error,
+      events: []
+    });
+
+    expect(result.kind).toBe("failed");
+    expect(result.classification).toBe("deterministic");
+  });
+
+  it("classifies generic Error as transient", () => {
+    const result = classifyFailure({
+      cancelRequested: false,
+      error: new Error("connection reset"),
+      events: []
+    });
+
+    expect(result.kind).toBe("failed");
+    expect(result.classification).toBe("transient");
+  });
+});

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -460,6 +460,10 @@ describe("daemon dispatch", () => {
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
       githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 0 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
       logger: pino({ enabled: false }),
       port: 0,
       prepareIssueWorkspace
@@ -647,6 +651,10 @@ describe("daemon dispatch", () => {
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
       githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 0 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
       logger: pino({ enabled: false }),
       port: 0,
       prepareIssueWorkspace
@@ -878,7 +886,7 @@ async function waitForRun(
   state: string,
   options: { intervalMs?: number; timeoutMs?: number } = {}
 ): Promise<{ runs: StatusRun[] }> {
-  const timeoutMs = options.timeoutMs ?? 1_000;
+  const timeoutMs = options.timeoutMs ?? 5_000;
   const intervalMs = options.intervalMs ?? 10;
   const deadline = Date.now() + timeoutMs;
 
@@ -903,7 +911,7 @@ async function waitForStatusError(
   message: string,
   options: { intervalMs?: number; timeoutMs?: number } = {}
 ): Promise<void> {
-  const timeoutMs = options.timeoutMs ?? 1_000;
+  const timeoutMs = options.timeoutMs ?? 5_000;
   const intervalMs = options.intervalMs ?? 10;
   const deadline = Date.now() + timeoutMs;
 

--- a/tests/dispatch-cancellation.test.ts
+++ b/tests/dispatch-cancellation.test.ts
@@ -1,0 +1,358 @@
+import Database from "better-sqlite3";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+import type {
+  AgentProvider,
+  ProviderEvent,
+  ProviderRunInput
+} from "../src/provider.js";
+import type {
+  PreparedIssueWorkspace
+} from "../src/workspace.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-cancel-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+type ControllableProvider = AgentProvider & {
+  cancel: ReturnType<typeof vi.fn<(runId: string) => Promise<void>>>;
+  ready: Promise<void>;
+  validate: ReturnType<typeof vi.fn<(command: string) => Promise<void>>>;
+};
+
+function controllableProvider(): ControllableProvider {
+  const cancellers = new Map<string, () => void>();
+  let resolveReady: (() => void) | undefined;
+  const ready = new Promise<void>((resolve) => {
+    resolveReady = resolve;
+  });
+  let activeCount = 0;
+
+  const cancel = vi.fn((runId: string): Promise<void> => {
+    const stop = cancellers.get(runId);
+    if (stop !== undefined) {
+      stop();
+    }
+    return Promise.resolve();
+  });
+
+  const validate = vi.fn().mockResolvedValue(undefined);
+
+  return {
+    cancel,
+    name: "codex",
+    ready,
+    runAttempt(input: ProviderRunInput): AsyncGenerator<ProviderEvent> {
+      let stop: (() => void) | undefined;
+      const cancelled = new Promise<void>((resolve) => {
+        stop = resolve;
+      });
+      cancellers.set(input.run.id, () => stop?.());
+
+      activeCount += 1;
+      if (activeCount === 1) {
+        resolveReady?.();
+      }
+
+      async function* generator(): AsyncGenerator<ProviderEvent> {
+        try {
+          yield {
+            normalized: { sessionId: "fake", type: "session_started" },
+            raw: { kind: "session" }
+          };
+          await cancelled;
+          yield {
+            normalized: {
+              cancelled: true,
+              exitCode: null,
+              signal: "SIGTERM",
+              type: "process_exit"
+            },
+            raw: { cancelled: true, kind: "exit" }
+          };
+        } finally {
+          cancellers.delete(input.run.id);
+          activeCount -= 1;
+        }
+      }
+
+      return generator();
+    },
+    validate
+  } satisfies ControllableProvider;
+}
+
+const baseIssue = {
+  body: "issue body",
+  created_at: "2026-04-20T10:00:00Z",
+  html_url: "https://github.com/pmatos/symphonika/issues/8",
+  id: 5008,
+  number: 8,
+  state: "open",
+  title: "Lifecycle test issue",
+  updated_at: "2026-04-21T11:00:00Z"
+};
+
+function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
+  const workspacePath = path.join(
+    root,
+    ".symphonika",
+    "workspaces",
+    "symphonika",
+    "issues",
+    "8-lifecycle-test-issue"
+  );
+  return {
+    branchName: "sym/symphonika/8-lifecycle-test-issue",
+    branchRef: "refs/heads/sym/symphonika/8-lifecycle-test-issue",
+    cachePath: path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      ".cache",
+      "repo.git"
+    ),
+    issueDirectoryName: "8-lifecycle-test-issue",
+    reused: false,
+    workspacePath
+  };
+}
+
+async function writeProject(root: string): Promise<string> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 25",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "WORKFLOW.md"),
+    [
+      "Work on #{{issue.number}}: {{issue.title}}.",
+      "Use {{workspace.path}} on {{branch.name}}.",
+      ""
+    ].join("\n")
+  );
+  return path.join(root, "symphonika.yml");
+}
+
+async function waitForRunState(
+  url: string,
+  state: string,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<{ runs: Array<Record<string, unknown>> }> {
+  const intervalMs = options.intervalMs ?? 10;
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await fetch(`${url}/api/status`);
+    const body = (await response.json()) as {
+      runs?: Array<Record<string, unknown>>;
+    };
+    if (body.runs?.some((run) => run["state"] === state)) {
+      return { runs: body.runs };
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`run did not reach ${state} before timeout`);
+}
+
+describe("dispatch cancellation", () => {
+  it("cancels active run when issue is closed and removes operational labels best-effort", async () => {
+    const root = await makeTempRoot();
+    const prepared = preparedWorkspaceFixture(root);
+    await mkdir(prepared.workspacePath, { recursive: true });
+    await writeProject(root);
+
+    const provider = controllableProvider();
+    let listCallCount = 0;
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(null),
+      listOpenIssues: vi.fn(() => {
+        listCallCount += 1;
+        if (listCallCount === 1) {
+          return Promise.resolve([{ ...baseIssue, labels: ["agent-ready"] }]);
+        }
+        // Issue closed for subsequent polls.
+        return Promise.resolve([]);
+      }),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(prepared)
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-cancel-closed",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await provider.ready;
+      const status = await waitForRunState(daemon.url, "cancelled");
+      const run = status.runs[0] as Record<string, unknown>;
+
+      expect(provider.cancel).toHaveBeenCalledWith("run-cancel-closed");
+      expect(run["state"]).toBe("cancelled");
+      expect(run["cancelReason"]).toBe("closed_issue");
+      expect(run["cancelRequested"]).toBe(true);
+
+      const removeCalls = githubIssuesApi.removeLabelsFromIssue.mock.calls.map(
+        ([call]) => call as { labels: string[] }
+      );
+      expect(removeCalls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ labels: ["sym:running"] }),
+          expect.objectContaining({ labels: ["sym:claimed"] }),
+          expect.objectContaining({ labels: ["sym:failed"] })
+        ])
+      );
+
+      const addCalls = githubIssuesApi.addLabelsToIssue.mock.calls.map(
+        ([call]) => call as { labels: string[] }
+      );
+      expect(addCalls.some((call) => call.labels[0] === "sym:failed")).toBe(false);
+
+      // Workspace preserved.
+      await expect(stat(prepared.workspacePath)).resolves.toBeDefined();
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("cancels active run on eligibility loss and removes only sym:running", async () => {
+    const root = await makeTempRoot();
+    const prepared = preparedWorkspaceFixture(root);
+    await mkdir(prepared.workspacePath, { recursive: true });
+    await writeProject(root);
+
+    const provider = controllableProvider();
+    let listCallCount = 0;
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(null),
+      listOpenIssues: vi.fn(() => {
+        listCallCount += 1;
+        if (listCallCount === 1) {
+          return Promise.resolve([{ ...baseIssue, labels: ["agent-ready"] }]);
+        }
+        // Excluded label appears.
+        return Promise.resolve([
+          {
+            ...baseIssue,
+            labels: ["agent-ready", "needs-human", "sym:claimed", "sym:running"]
+          }
+        ]);
+      }),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(prepared)
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-cancel-eligibility",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await provider.ready;
+      const status = await waitForRunState(daemon.url, "cancelled");
+      const run = status.runs[0] as Record<string, unknown>;
+
+      expect(provider.cancel).toHaveBeenCalledWith("run-cancel-eligibility");
+      expect(run["cancelReason"]).toBe("eligibility_loss");
+
+      const removeCalls = githubIssuesApi.removeLabelsFromIssue.mock.calls.map(
+        ([call]) => call as { labels: string[] }
+      );
+      expect(removeCalls.some((call) => call.labels[0] === "sym:running")).toBe(true);
+      expect(removeCalls.some((call) => call.labels[0] === "sym:claimed")).toBe(false);
+
+      const addCalls = githubIssuesApi.addLabelsToIssue.mock.calls.map(
+        ([call]) => call as { labels: string[] }
+      );
+      expect(addCalls.some((call) => call.labels[0] === "sym:failed")).toBe(false);
+
+      const database = new Database(path.join(root, ".symphonika", "symphonika.db"), {
+        readonly: true
+      });
+      try {
+        const stored = database
+          .prepare("select state, cancel_reason from runs where id = ?")
+          .get("run-cancel-eligibility") as { state: string; cancel_reason: string };
+        expect(stored.state).toBe("cancelled");
+        expect(stored.cancel_reason).toBe("eligibility_loss");
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+});

--- a/tests/dispatch-continuation.test.ts
+++ b/tests/dispatch-continuation.test.ts
@@ -1,0 +1,325 @@
+import Database from "better-sqlite3";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+import type { LifecyclePolicy } from "../src/lifecycle/active-runs.js";
+import type { AgentProvider, ProviderEvent } from "../src/provider.js";
+import type {
+  PreparedIssueWorkspace
+} from "../src/workspace.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-cont-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+const baseIssue = {
+  body: "issue body",
+  created_at: "2026-04-20T10:00:00Z",
+  html_url: "https://github.com/pmatos/symphonika/issues/8",
+  id: 5008,
+  number: 8,
+  state: "open",
+  title: "Lifecycle test issue",
+  updated_at: "2026-04-21T11:00:00Z"
+};
+
+function preparedWorkspaceFixture(root: string, reused = false): PreparedIssueWorkspace {
+  const workspacePath = path.join(
+    root,
+    ".symphonika",
+    "workspaces",
+    "symphonika",
+    "issues",
+    "8-lifecycle-test-issue"
+  );
+  return {
+    branchName: "sym/symphonika/8-lifecycle-test-issue",
+    branchRef: "refs/heads/sym/symphonika/8-lifecycle-test-issue",
+    cachePath: path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      ".cache",
+      "repo.git"
+    ),
+    issueDirectoryName: "8-lifecycle-test-issue",
+    reused,
+    workspacePath
+  };
+}
+
+async function writeProject(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 25",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "WORKFLOW.md"),
+    [
+      "Work on #{{issue.number}}: {{issue.title}}.",
+      "Use {{workspace.path}} on {{branch.name}}.",
+      ""
+    ].join("\n")
+  );
+}
+
+const fastContinuationPolicy: LifecyclePolicy = {
+  continuation: { cap: 2, delayMs: 5 },
+  retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+};
+
+async function waitForCondition(
+  url: string,
+  predicate: (body: { runs: Array<Record<string, unknown>>; active?: unknown[] }) => boolean,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<{ runs: Array<Record<string, unknown>> }> {
+  const intervalMs = options.intervalMs ?? 10;
+  const timeoutMs = options.timeoutMs ?? 4_000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await fetch(`${url}/api/status`);
+    const body = (await response.json()) as {
+      active?: unknown[];
+      runs?: Array<Record<string, unknown>>;
+    };
+    if (body.runs !== undefined && predicate({ runs: body.runs, active: body.active ?? [] })) {
+      return { runs: body.runs };
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("condition not met before timeout");
+}
+
+describe("dispatch continuation cap", () => {
+  it("schedules continuations up to the cap, then writes a cap-reached failure row", async () => {
+    const root = await makeTempRoot();
+    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    await writeProject(root);
+
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      // every refresh returns the issue still eligible
+      getIssue: vi.fn().mockResolvedValue({ ...baseIssue, labels: ["agent-ready"] }),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    let createCount = 0;
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> => {
+        createCount += 1;
+        return Promise.resolve(preparedWorkspaceFixture(root, createCount > 1));
+      }
+    );
+    let runCounter = 0;
+    const createRunId = (): string => {
+      runCounter += 1;
+      return `run-cont-${runCounter}`;
+    };
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastContinuationPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      // Wait until cap-reached failure row appears
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some(
+          (run) =>
+            run["state"] === "failed" &&
+            run["terminalReason"] === "continuation cap reached"
+        )
+      );
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) => r.json())) as {
+        runs: Array<Record<string, unknown>>;
+      };
+
+      const successfulContinuations = status.runs.filter(
+        (run) => run["state"] === "succeeded" && run["isContinuation"] === true
+      );
+      const successfulFresh = status.runs.filter(
+        (run) => run["state"] === "succeeded" && run["isContinuation"] === false
+      );
+
+      // 1 fresh + 2 continuations succeed (cap=2)
+      expect(successfulFresh).toHaveLength(1);
+      expect(successfulContinuations).toHaveLength(2);
+
+      // Workspace reused from second attempt onward
+      expect(prepareIssueWorkspace).toHaveBeenCalledTimes(3);
+
+      // Cap-reached failure row visible
+      const capRow = status.runs.find(
+        (run) => run["terminalReason"] === "continuation cap reached"
+      );
+      expect(capRow).toMatchObject({
+        state: "failed",
+        isContinuation: true,
+        failureClassification: "deterministic"
+      });
+
+      // sym:failed added once for the cap-reached event
+      const failedAdds = githubIssuesApi.addLabelsToIssue.mock.calls
+        .map(([call]) => call as { labels: string[] })
+        .filter((call) => call.labels[0] === "sym:failed");
+      expect(failedAdds.length).toBeGreaterThanOrEqual(1);
+
+      const database = new Database(path.join(root, ".symphonika", "symphonika.db"), {
+        readonly: true
+      });
+      try {
+        const totalSucceeded = database
+          .prepare("select count(*) as c from runs where state = 'succeeded'")
+          .get() as { c: number };
+        expect(totalSucceeded.c).toBe(3);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("does not schedule continuation when refreshed issue is closed", async () => {
+    const root = await makeTempRoot();
+    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    await writeProject(root);
+
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(null),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(preparedWorkspaceFixture(root))
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-cont-closed",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastContinuationPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "succeeded")
+      );
+
+      // wait beyond continuation delay to confirm no extra scheduling
+      await new Promise((resolve) => setTimeout(resolve, 80));
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) => r.json())) as {
+        runs: Array<Record<string, unknown>>;
+      };
+      const continuations = status.runs.filter(
+        (run) => run["isContinuation"] === true
+      );
+      expect(continuations).toHaveLength(0);
+      const failedAdds = githubIssuesApi.addLabelsToIssue.mock.calls
+        .map(([call]) => call as { labels: string[] })
+        .filter((call) => call.labels[0] === "sym:failed");
+      expect(failedAdds).toHaveLength(0);
+    } finally {
+      await daemon.stop();
+    }
+  });
+});

--- a/tests/dispatch-mutex.test.ts
+++ b/tests/dispatch-mutex.test.ts
@@ -1,0 +1,292 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+import type { LifecyclePolicy } from "../src/lifecycle/active-runs.js";
+import type { AgentProvider, ProviderEvent } from "../src/provider.js";
+import type { PreparedIssueWorkspace } from "../src/workspace.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-mutex-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+const baseIssue = {
+  body: "issue body",
+  created_at: "2026-04-20T10:00:00Z",
+  html_url: "https://github.com/pmatos/symphonika/issues/8",
+  id: 5008,
+  number: 8,
+  state: "open",
+  title: "Lifecycle test issue",
+  updated_at: "2026-04-21T11:00:00Z"
+};
+
+function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
+  const workspacePath = path.join(
+    root,
+    ".symphonika",
+    "workspaces",
+    "symphonika",
+    "issues",
+    "8-lifecycle-test-issue"
+  );
+  return {
+    branchName: "sym/symphonika/8-lifecycle-test-issue",
+    branchRef: "refs/heads/sym/symphonika/8-lifecycle-test-issue",
+    cachePath: path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      ".cache",
+      "repo.git"
+    ),
+    issueDirectoryName: "8-lifecycle-test-issue",
+    reused: false,
+    workspacePath
+  };
+}
+
+async function writeProject(root: string, workflowTemplate: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 25",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(path.join(root, "WORKFLOW.md"), workflowTemplate);
+}
+
+const fastContinuationPolicy: LifecyclePolicy = {
+  continuation: { cap: 2, delayMs: 5 },
+  retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+};
+
+async function waitForCondition(
+  url: string,
+  predicate: (body: { runs: Array<Record<string, unknown>> }) => boolean,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<void> {
+  const intervalMs = options.intervalMs ?? 10;
+  const timeoutMs = options.timeoutMs ?? 4_000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await fetch(`${url}/api/status`);
+    const body = (await response.json()) as {
+      runs?: Array<Record<string, unknown>>;
+    };
+    if (body.runs !== undefined && predicate({ runs: body.runs })) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("condition not met before timeout");
+}
+
+describe("dispatch mutex", () => {
+  it("scheduled continuation never runs concurrently with another active dispatch", async () => {
+    const root = await makeTempRoot();
+    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    await writeProject(root, "Work {{issue.number}}\n");
+
+    let active = 0;
+    let maxActive = 0;
+
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        active += 1;
+        if (active > maxActive) {
+          maxActive = active;
+        }
+        try {
+          // Hold the run long enough to overlap with a scheduled continuation.
+          await new Promise((resolve) => setTimeout(resolve, 60));
+          yield {
+            normalized: { exitCode: 0, type: "process_exit" },
+            raw: { code: 0, kind: "exit" }
+          };
+        } finally {
+          active -= 1;
+        }
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue({ ...baseIssue, labels: ["agent-ready"] }),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(preparedWorkspaceFixture(root))
+    );
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => `run-mutex-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastContinuationPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      // Wait for cap-reached row (1 fresh + 2 succeeded continuations + cap-reached failed)
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some(
+          (run) =>
+            run["state"] === "failed" &&
+            run["terminalReason"] === "continuation cap reached"
+        )
+      );
+
+      expect(maxActive).toBe(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("renders run.continuation as true on continuation runs and false on the fresh run", async () => {
+    const root = await makeTempRoot();
+    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    await writeProject(
+      root,
+      "Continuation? {{run.continuation}} attempt={{run.attempt}}\n"
+    );
+
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue({ ...baseIssue, labels: ["agent-ready"] }),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(preparedWorkspaceFixture(root))
+    );
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => `run-cont-flag-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: { continuation: { cap: 1, delayMs: 5 }, retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 } },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      // Wait for the cap-reached failure row (fresh + 1 continuation succeed, cap=1)
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some(
+          (run) =>
+            run["state"] === "failed" &&
+            run["terminalReason"] === "continuation cap reached"
+        )
+      );
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) => r.json())) as {
+        runs: Array<Record<string, unknown>>;
+      };
+
+      const fresh = status.runs.find(
+        (run) =>
+          run["state"] === "succeeded" && run["isContinuation"] === false
+      );
+      const continuation = status.runs.find(
+        (run) =>
+          run["state"] === "succeeded" && run["isContinuation"] === true
+      );
+      expect(fresh).toBeDefined();
+      expect(continuation).toBeDefined();
+
+      const freshPrompt = await readFile(fresh?.["promptPath"] as string, "utf8");
+      const continuationPrompt = await readFile(
+        continuation?.["promptPath"] as string,
+        "utf8"
+      );
+
+      expect(freshPrompt).toContain("Continuation? false");
+      expect(continuationPrompt).toContain("Continuation? true");
+    } finally {
+      await daemon.stop();
+    }
+  });
+});

--- a/tests/dispatch-project-disable.test.ts
+++ b/tests/dispatch-project-disable.test.ts
@@ -1,0 +1,284 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+import type { LifecyclePolicy } from "../src/lifecycle/active-runs.js";
+import type { AgentProvider, ProviderEvent } from "../src/provider.js";
+import type {
+  PreparedIssueWorkspace
+} from "../src/workspace.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-disable-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+const baseIssue = {
+  body: "issue body",
+  created_at: "2026-04-20T10:00:00Z",
+  html_url: "https://github.com/pmatos/symphonika/issues/8",
+  id: 5008,
+  number: 8,
+  state: "open",
+  title: "Lifecycle test issue",
+  updated_at: "2026-04-21T11:00:00Z"
+};
+
+function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
+  const workspacePath = path.join(
+    root,
+    ".symphonika",
+    "workspaces",
+    "symphonika",
+    "issues",
+    "8-lifecycle-test-issue"
+  );
+  return {
+    branchName: "sym/symphonika/8-lifecycle-test-issue",
+    branchRef: "refs/heads/sym/symphonika/8-lifecycle-test-issue",
+    cachePath: path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      ".cache",
+      "repo.git"
+    ),
+    issueDirectoryName: "8-lifecycle-test-issue",
+    reused: false,
+    workspacePath
+  };
+}
+
+async function writeProject(
+  root: string,
+  overrides: { disabled?: boolean } = {}
+): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 25",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      `    disabled: ${overrides.disabled ?? false}`,
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "WORKFLOW.md"),
+    [
+      "Work on #{{issue.number}}: {{issue.title}}.",
+      "Use {{workspace.path}} on {{branch.name}}.",
+      ""
+    ].join("\n")
+  );
+}
+
+const fastContinuationPolicy: LifecyclePolicy = {
+  continuation: { cap: 3, delayMs: 5 },
+  retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+};
+
+async function waitForCondition(
+  url: string,
+  predicate: (body: { runs: Array<Record<string, unknown>> }) => boolean,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<void> {
+  const intervalMs = options.intervalMs ?? 10;
+  const timeoutMs = options.timeoutMs ?? 3_000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await fetch(`${url}/api/status`);
+    const body = (await response.json()) as {
+      runs?: Array<Record<string, unknown>>;
+    };
+    if (body.runs !== undefined && predicate({ runs: body.runs })) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("condition not met before timeout");
+}
+
+describe("dispatch project disable", () => {
+  it("disabling a project mid-flight does not interrupt the active run; no continuation is scheduled afterwards", async () => {
+    const root = await makeTempRoot();
+    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    await writeProject(root);
+
+    let runAttemptCount = 0;
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        runAttemptCount += 1;
+        // brief pause so the test can rewrite config mid-run
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      // continuation refresh always says still eligible (so we know dispatch is the gate)
+      getIssue: vi.fn().mockResolvedValue({ ...baseIssue, labels: ["agent-ready"] }),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(preparedWorkspaceFixture(root))
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => `run-disable-${runAttemptCount + 1}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastContinuationPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      // Wait until first run starts (registered in active runs)
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "running")
+      );
+
+      // Disable project mid-flight
+      await writeProject(root, { disabled: true });
+
+      // Wait for first run to succeed
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "succeeded")
+      );
+
+      // Active run is preserved (succeeded, no cancellation)
+      // Wait beyond continuation delay
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) => r.json())) as {
+        runs: Array<Record<string, unknown>>;
+      };
+      // No continuation rows (project is disabled, so dequeue dropped them)
+      const continuations = status.runs.filter(
+        (run) => run["isContinuation"] === true
+      );
+      expect(continuations).toHaveLength(0);
+      // Only the original succeeded run
+      expect(status.runs).toHaveLength(1);
+      expect(status.runs[0]?.["state"]).toBe("succeeded");
+
+      // Provider was never cancelled
+      expect(provider.cancel).not.toHaveBeenCalled();
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("does not dispatch new work when the only project is disabled at startup", async () => {
+    const root = await makeTempRoot();
+    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    await writeProject(root, { disabled: true });
+
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: {}
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(null),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValue([{ ...baseIssue, labels: ["agent-ready"] }]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(preparedWorkspaceFixture(root))
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastContinuationPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) => r.json())) as {
+        runs: Array<Record<string, unknown>>;
+      };
+      expect(status.runs).toHaveLength(0);
+      expect(provider.validate).not.toHaveBeenCalled();
+    } finally {
+      await daemon.stop();
+    }
+  });
+});

--- a/tests/dispatch-retry.test.ts
+++ b/tests/dispatch-retry.test.ts
@@ -201,7 +201,7 @@ describe("dispatch retry policy", () => {
       const status = await waitForCondition(
         daemon.url,
         ({ runs }) => runs.some((run) => run["state"] === "succeeded"),
-        { timeoutMs: 10_000 }
+        { timeoutMs: 30_000 }
       );
       const run = status.runs.find((entry) => entry["state"] === "succeeded");
       expect(run?.["retryCount"]).toBe(2);

--- a/tests/dispatch-retry.test.ts
+++ b/tests/dispatch-retry.test.ts
@@ -239,6 +239,163 @@ describe("dispatch retry policy", () => {
     }
   });
 
+  it("cancels a scheduled retry when the issue closes during backoff", async () => {
+    const root = await makeTempRoot();
+    const prepared = preparedWorkspaceFixture(root);
+    await mkdir(prepared.workspacePath, { recursive: true });
+    await writeProject(root);
+
+    let attempts = 0;
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        attempts += 1;
+        yield {
+          normalized: { exitCode: 1, type: "process_exit" },
+          raw: { code: 1, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    let listCalls = 0;
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      // executeRetry calls getIssue: simulate the issue closing during backoff.
+      getIssue: vi.fn().mockResolvedValue(null),
+      listOpenIssues: vi.fn(() => {
+        listCalls += 1;
+        if (listCalls === 1) {
+          return Promise.resolve([{ ...baseIssue, labels: ["agent-ready"] }]);
+        }
+        return Promise.resolve([]);
+      }),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(prepared)
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-retry-closed",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastRetryPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "cancelled")
+      );
+
+      // Give the system a window for any spurious second attempt.
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      expect(attempts).toBe(1);
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) => r.json())) as {
+        runs: Array<Record<string, unknown>>;
+      };
+      const run = status.runs.find((entry) => entry["state"] === "cancelled");
+      expect(run?.["cancelReason"]).toBe("closed_issue");
+      expect(run?.["cancelRequested"]).toBe(true);
+
+      const removeCalls = githubIssuesApi.removeLabelsFromIssue.mock.calls.map(
+        ([call]) => call as { labels: string[] }
+      );
+      expect(removeCalls.some((call) => call.labels[0] === "sym:claimed")).toBe(true);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("cancels a scheduled retry when the issue loses eligibility during backoff", async () => {
+    const root = await makeTempRoot();
+    const prepared = preparedWorkspaceFixture(root);
+    await mkdir(prepared.workspacePath, { recursive: true });
+    await writeProject(root);
+
+    let attempts = 0;
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        attempts += 1;
+        yield {
+          normalized: { exitCode: 1, type: "process_exit" },
+          raw: { code: 1, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    let listCalls = 0;
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      // executeRetry calls getIssue: simulate an excluded label appearing on the issue.
+      getIssue: vi.fn().mockResolvedValue({
+        ...baseIssue,
+        labels: ["agent-ready", "needs-human", "sym:claimed"]
+      }),
+      listOpenIssues: vi.fn(() => {
+        listCalls += 1;
+        if (listCalls === 1) {
+          return Promise.resolve([{ ...baseIssue, labels: ["agent-ready"] }]);
+        }
+        return Promise.resolve([]);
+      }),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(prepared)
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-retry-eligibility",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastRetryPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "cancelled")
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      expect(attempts).toBe(1);
+
+      const database = new Database(path.join(root, ".symphonika", "symphonika.db"), {
+        readonly: true
+      });
+      try {
+        const stored = database
+          .prepare("select state, cancel_reason from runs where id = ?")
+          .get("run-retry-eligibility") as { state: string; cancel_reason: string };
+        expect(stored.state).toBe("cancelled");
+        expect(stored.cancel_reason).toBe("eligibility_loss");
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("does not retry deterministic malformed_event failures", async () => {
     const root = await makeTempRoot();
     const prepared = preparedWorkspaceFixture(root);

--- a/tests/dispatch-retry.test.ts
+++ b/tests/dispatch-retry.test.ts
@@ -1,0 +1,305 @@
+import Database from "better-sqlite3";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+import type { LifecyclePolicy } from "../src/lifecycle/active-runs.js";
+import type { AgentProvider, ProviderEvent } from "../src/provider.js";
+import type {
+  PreparedIssueWorkspace
+} from "../src/workspace.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-retry-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+const baseIssue = {
+  body: "issue body",
+  created_at: "2026-04-20T10:00:00Z",
+  html_url: "https://github.com/pmatos/symphonika/issues/8",
+  id: 5008,
+  number: 8,
+  state: "open",
+  title: "Lifecycle test issue",
+  updated_at: "2026-04-21T11:00:00Z"
+};
+
+function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
+  const workspacePath = path.join(
+    root,
+    ".symphonika",
+    "workspaces",
+    "symphonika",
+    "issues",
+    "8-lifecycle-test-issue"
+  );
+  return {
+    branchName: "sym/symphonika/8-lifecycle-test-issue",
+    branchRef: "refs/heads/sym/symphonika/8-lifecycle-test-issue",
+    cachePath: path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      ".cache",
+      "repo.git"
+    ),
+    issueDirectoryName: "8-lifecycle-test-issue",
+    reused: false,
+    workspacePath
+  };
+}
+
+async function writeProject(root: string): Promise<string> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 25",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "WORKFLOW.md"),
+    [
+      "Work on #{{issue.number}}: {{issue.title}}.",
+      "Use {{workspace.path}} on {{branch.name}}.",
+      ""
+    ].join("\n")
+  );
+  return path.join(root, "symphonika.yml");
+}
+
+async function waitForCondition(
+  url: string,
+  predicate: (body: { runs: Array<Record<string, unknown>>; active?: unknown[] }) => boolean,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<{ runs: Array<Record<string, unknown>> }> {
+  const intervalMs = options.intervalMs ?? 10;
+  const timeoutMs = options.timeoutMs ?? 3_000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await fetch(`${url}/api/status`);
+    const body = (await response.json()) as {
+      active?: unknown[];
+      runs?: Array<Record<string, unknown>>;
+    };
+    if (body.runs !== undefined && predicate({ runs: body.runs, active: body.active ?? [] })) {
+      return { runs: body.runs };
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("condition not met before timeout");
+}
+
+const fastRetryPolicy: LifecyclePolicy = {
+  continuation: { cap: 0, delayMs: 0 },
+  retry: { cap: 3, delaysMs: [10, 20, 30], maxBackoffMs: 100 }
+};
+
+describe("dispatch retry policy", () => {
+  it("retries transient failures up to the cap and records retry_count", async () => {
+    const root = await makeTempRoot();
+    const prepared = preparedWorkspaceFixture(root);
+    await mkdir(prepared.workspacePath, { recursive: true });
+    await writeProject(root);
+
+    let attempts = 0;
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        attempts += 1;
+        if (attempts < 3) {
+          yield {
+            normalized: { exitCode: 1, type: "process_exit" },
+            raw: { code: 1, kind: "exit" }
+          };
+          return;
+        }
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(null),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(prepared)
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-retry",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastRetryPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      const status = await waitForCondition(
+        daemon.url,
+        ({ runs }) => runs.some((run) => run["state"] === "succeeded"),
+        { timeoutMs: 10_000 }
+      );
+      const run = status.runs.find((entry) => entry["state"] === "succeeded");
+      expect(run?.["retryCount"]).toBe(2);
+
+      const failedAddCalls = githubIssuesApi.addLabelsToIssue.mock.calls
+        .map(([call]) => call as { labels: string[] })
+        .filter((call) => call.labels[0] === "sym:failed");
+      expect(failedAddCalls).toHaveLength(0);
+
+      const database = new Database(path.join(root, ".symphonika", "symphonika.db"), {
+        readonly: true
+      });
+      try {
+        const attemptRows = database
+          .prepare("select attempt_number, state from attempts order by attempt_number")
+          .all() as { attempt_number: number; state: string }[];
+        expect(attemptRows.map((r) => r.attempt_number)).toEqual([1, 2, 3]);
+        expect(attemptRows[2]?.state).toBe("succeeded");
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("does not retry deterministic malformed_event failures", async () => {
+    const root = await makeTempRoot();
+    const prepared = preparedWorkspaceFixture(root);
+    await mkdir(prepared.workspacePath, { recursive: true });
+    await writeProject(root);
+
+    let attempts = 0;
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        attempts += 1;
+        yield {
+          normalized: { line: "{", message: "bad json", type: "malformed_event" },
+          raw: { kind: "malformed_json" }
+        };
+        yield {
+          normalized: { exitCode: 1, type: "process_exit" },
+          raw: { code: 1, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(null),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(prepared)
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-deterministic",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastRetryPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "failed")
+      );
+
+      // give a small window for any extra retry to happen (it shouldn't)
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      expect(attempts).toBe(1);
+
+      const status = await fetch(`${daemon.url}/api/status`).then((r) => r.json()) as {
+        runs: Array<Record<string, unknown>>;
+      };
+      const run = status.runs[0];
+      expect(run?.["retryCount"]).toBe(0);
+      expect(run?.["failureClassification"]).toBe("deterministic");
+      const failedAddCalls = githubIssuesApi.addLabelsToIssue.mock.calls
+        .map(([call]) => call as { labels: string[] })
+        .filter((call) => call.labels[0] === "sym:failed");
+      expect(failedAddCalls.length).toBeGreaterThan(0);
+    } finally {
+      await daemon.stop();
+    }
+  });
+});

--- a/tests/dispatch-retry.test.ts
+++ b/tests/dispatch-retry.test.ts
@@ -171,13 +171,24 @@ describe("dispatch retry policy", () => {
       validate: vi.fn().mockResolvedValue(undefined)
     };
 
+    let listCalls = 0;
+    const claimedIssue = {
+      ...baseIssue,
+      labels: ["agent-ready", "sym:claimed"]
+    };
     const githubIssuesApi = {
       addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
-      getIssue: vi.fn().mockResolvedValue(null),
-      listOpenIssues: vi
-        .fn()
-        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
-        .mockResolvedValue([]),
+      // After the first poll, simulate GitHub showing the issue with sym:claimed
+      // so dispatchTarget filters it out (reflecting real label persistence) and
+      // reconcile finds it in filteredIssues with ignoreOperationalLabels=true.
+      getIssue: vi.fn().mockResolvedValue(claimedIssue),
+      listOpenIssues: vi.fn(() => {
+        listCalls += 1;
+        if (listCalls === 1) {
+          return Promise.resolve([{ ...baseIssue, labels: ["agent-ready"] }]);
+        }
+        return Promise.resolve([claimedIssue]);
+      }),
       removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
     };
     const prepareIssueWorkspace = vi.fn(
@@ -253,13 +264,21 @@ describe("dispatch retry policy", () => {
       validate: vi.fn().mockResolvedValue(undefined)
     };
 
+    let listCalls = 0;
+    const claimedIssue = {
+      ...baseIssue,
+      labels: ["agent-ready", "sym:claimed", "sym:failed"]
+    };
     const githubIssuesApi = {
       addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
-      getIssue: vi.fn().mockResolvedValue(null),
-      listOpenIssues: vi
-        .fn()
-        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
-        .mockResolvedValue([]),
+      getIssue: vi.fn().mockResolvedValue(claimedIssue),
+      listOpenIssues: vi.fn(() => {
+        listCalls += 1;
+        if (listCalls === 1) {
+          return Promise.resolve([{ ...baseIssue, labels: ["agent-ready"] }]);
+        }
+        return Promise.resolve([claimedIssue]);
+      }),
       removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
     };
     const prepareIssueWorkspace = vi.fn(

--- a/tests/eligibility-helpers.test.ts
+++ b/tests/eligibility-helpers.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  evaluateProjectEligibility,
+  loadPollingProjectsByName,
+  type IssueSnapshot,
+  type PollingProjectConfig
+} from "../src/issue-polling.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-eligibility-"));
+  tempRoots.push(root);
+  return root;
+}
+
+const baseProject: PollingProjectConfig = {
+  agent: { provider: "codex" },
+  issue_filters: {
+    labels_all: ["agent-ready"],
+    labels_none: ["blocked", "needs-human"],
+    states: ["open"]
+  },
+  name: "symphonika",
+  priority: { default: 99, labels: {} },
+  tracker: {
+    kind: "github",
+    owner: "pmatos",
+    repo: "symphonika",
+    token: "$GITHUB_TOKEN"
+  }
+};
+
+function snapshot(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    body: "",
+    created_at: "2025-01-01T00:00:00Z",
+    id: 1,
+    labels: ["agent-ready"],
+    number: 7,
+    priority: 1,
+    state: "open",
+    title: "fixture",
+    updated_at: "2025-01-01T00:00:00Z",
+    url: "https://example/7",
+    ...overrides
+  };
+}
+
+describe("evaluateProjectEligibility", () => {
+  it("ignores operational labels when asked", () => {
+    const result = evaluateProjectEligibility(
+      snapshot({ labels: ["agent-ready", "sym:claimed", "sym:running"] }),
+      baseProject,
+      { ignoreOperationalLabels: true }
+    );
+
+    expect(result.eligible).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+
+  it("flags issues missing required labels", () => {
+    const result = evaluateProjectEligibility(
+      snapshot({ labels: ["sym:claimed"] }),
+      baseProject,
+      { ignoreOperationalLabels: true }
+    );
+
+    expect(result.eligible).toBe(false);
+    expect(result.reasons.some((reason) => reason.includes("agent-ready"))).toBe(true);
+  });
+
+  it("flags issues with excluded labels", () => {
+    const result = evaluateProjectEligibility(
+      snapshot({ labels: ["agent-ready", "needs-human", "sym:running"] }),
+      baseProject,
+      { ignoreOperationalLabels: true }
+    );
+
+    expect(result.eligible).toBe(false);
+    expect(result.reasons.some((reason) => reason.includes("needs-human"))).toBe(true);
+  });
+});
+
+describe("loadPollingProjectsByName", () => {
+  it("returns a map of configured projects keyed by name", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeFile(
+      configPath,
+      [
+        "polling:",
+        "  interval_ms: 30000",
+        "providers:",
+        "  codex:",
+        '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+        "  claude:",
+        '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+        "projects:",
+        "  - name: symphonika",
+        "    tracker:",
+        "      kind: github",
+        "      owner: pmatos",
+        "      repo: symphonika",
+        '      token: "$GITHUB_TOKEN"',
+        "    issue_filters:",
+        '      states: ["open"]',
+        '      labels_all: ["agent-ready"]',
+        '      labels_none: ["blocked"]',
+        "    priority:",
+        "      labels: {}",
+        "      default: 99",
+        "    agent:",
+        "      provider: codex",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadPollingProjectsByName(configPath);
+    expect(result.has("symphonika")).toBe(true);
+    expect(result.get("symphonika")?.tracker.repo).toBe("symphonika");
+  });
+});

--- a/tests/http-app.test.ts
+++ b/tests/http-app.test.ts
@@ -37,6 +37,7 @@ describe("HTTP app", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({
+      active: [],
       candidateIssues: [],
       dispatching: false,
       filteredIssues: [],
@@ -45,6 +46,7 @@ describe("HTTP app", () => {
         projects: []
       },
       runs: [],
+      scheduled: [],
       service: "symphonika",
       state: "idle",
       stateRoot: "/tmp/symphonika-state",

--- a/tests/reconcile.test.ts
+++ b/tests/reconcile.test.ts
@@ -1,0 +1,230 @@
+import pino from "pino";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  emptyIssuePollStatus,
+  type IssuePollStatus,
+  type IssueSnapshot,
+  type PollingProjectConfig
+} from "../src/issue-polling.js";
+import { ActiveRunRegistry, CANCEL_REASONS } from "../src/lifecycle/active-runs.js";
+import { reconcileActiveRuns } from "../src/lifecycle/reconcile.js";
+import { openRunStore, type RunStore } from "../src/run-store.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const logger = pino({ enabled: false });
+
+const project: PollingProjectConfig = {
+  agent: { provider: "codex" },
+  issue_filters: {
+    labels_all: ["agent-ready"],
+    labels_none: ["blocked", "needs-human"],
+    states: ["open"]
+  },
+  name: "symphonika",
+  priority: { default: 99, labels: {} },
+  tracker: {
+    kind: "github",
+    owner: "pmatos",
+    repo: "symphonika",
+    token: "$GITHUB_TOKEN"
+  }
+};
+
+function snapshot(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    body: "",
+    created_at: "2025-01-01T00:00:00Z",
+    id: 1,
+    labels: ["agent-ready", "sym:claimed", "sym:running"],
+    number: 7,
+    priority: 1,
+    state: "open",
+    title: "fixture",
+    updated_at: "2025-01-01T00:00:00Z",
+    url: "https://example/7",
+    ...overrides
+  };
+}
+
+async function withRunStore<T>(fn: (store: RunStore) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-reconcile-store-"));
+  const store = openRunStore({ stateRoot: root });
+  try {
+    return await fn(store);
+  } finally {
+    store.close();
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+function pollStatus(issues: IssueSnapshot[]): IssuePollStatus {
+  const status = emptyIssuePollStatus();
+  status.candidateIssues = issues.map((issue) => ({
+    issue,
+    project: project.name
+  }));
+  return status;
+}
+
+describe("reconcileActiveRuns", () => {
+  it("cancels with closed_issue when issue is absent and getIssue reports null", async () => {
+    await withRunStore(async (store) => {
+      store.createRun({
+        id: "run-a",
+        issue: snapshot(),
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const registry = new ActiveRunRegistry();
+      registry.register({
+        cancel,
+        issueNumber: 7,
+        projectName: project.name,
+        runId: "run-a"
+      });
+
+      const githubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue(null),
+        listOpenIssues: vi.fn().mockResolvedValue([])
+      };
+
+      await reconcileActiveRuns({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi,
+        logger,
+        pollStatus: pollStatus([]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(githubIssuesApi.getIssue).toHaveBeenCalledWith({
+        issueNumber: 7,
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret"
+      });
+      expect(registry.get("run-a")?.cancelReason).toBe(CANCEL_REASONS.CLOSED_ISSUE);
+      expect(store.listRuns()[0]?.cancelReason).toBe("closed_issue");
+    });
+  });
+
+  it("cancels with eligibility_loss when poll snapshot adds excluded label", async () => {
+    await withRunStore(async (store) => {
+      store.createRun({
+        id: "run-a",
+        issue: snapshot(),
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const registry = new ActiveRunRegistry();
+      registry.register({
+        cancel,
+        issueNumber: 7,
+        projectName: project.name,
+        runId: "run-a"
+      });
+
+      const status = pollStatus([
+        snapshot({ labels: ["agent-ready", "needs-human", "sym:claimed", "sym:running"] })
+      ]);
+
+      const githubIssuesApi = {
+        listOpenIssues: vi.fn().mockResolvedValue([])
+      };
+
+      await reconcileActiveRuns({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi,
+        logger,
+        pollStatus: status,
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(registry.get("run-a")?.cancelReason).toBe(
+        CANCEL_REASONS.ELIGIBILITY_LOSS
+      );
+    });
+  });
+
+  it("does not cancel when project is removed from config", async () => {
+    await withRunStore(async (store) => {
+      store.createRun({
+        id: "run-a",
+        issue: snapshot(),
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const registry = new ActiveRunRegistry();
+      registry.register({
+        cancel,
+        issueNumber: 7,
+        projectName: project.name,
+        runId: "run-a"
+      });
+
+      const githubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue(null),
+        listOpenIssues: vi.fn().mockResolvedValue([])
+      };
+
+      await reconcileActiveRuns({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi,
+        logger,
+        pollStatus: pollStatus([]),
+        projects: new Map(),
+        runStore: store
+      });
+
+      expect(cancel).not.toHaveBeenCalled();
+      expect(githubIssuesApi.getIssue).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does nothing when poll snapshot keeps the issue eligible", async () => {
+    await withRunStore(async (store) => {
+      store.createRun({
+        id: "run-a",
+        issue: snapshot(),
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const registry = new ActiveRunRegistry();
+      registry.register({
+        cancel,
+        issueNumber: 7,
+        projectName: project.name,
+        runId: "run-a"
+      });
+
+      await reconcileActiveRuns({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: { listOpenIssues: vi.fn().mockResolvedValue([]) },
+        logger,
+        pollStatus: pollStatus([snapshot()]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(cancel).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/run-store-lifecycle.test.ts
+++ b/tests/run-store-lifecycle.test.ts
@@ -1,0 +1,330 @@
+import Database from "better-sqlite3";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { databasePath, openRunStore } from "../src/run-store.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-run-store-lifecycle-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+function columnNames(database: Database.Database, table: string): string[] {
+  const rows = database
+    .prepare("select name from pragma_table_info(?)")
+    .all(table) as { name: string }[];
+  return rows.map((row) => row.name);
+}
+
+function seedRun(
+  store: ReturnType<typeof openRunStore>,
+  overrides: { id?: string; issueNumber?: number; projectName?: string } = {}
+): string {
+  const id = overrides.id ?? "run-1";
+  store.createRun({
+    id,
+    issue: {
+      body: "",
+      created_at: "2025-01-01T00:00:00Z",
+      id: 1000,
+      labels: ["agent-ready"],
+      number: overrides.issueNumber ?? 7,
+      priority: 1,
+      state: "open",
+      title: "fixture",
+      updated_at: "2025-01-01T00:00:00Z",
+      url: "https://example/1"
+    },
+    projectName: overrides.projectName ?? "symphonika",
+    providerCommand: "fake",
+    providerName: "codex"
+  });
+  return id;
+}
+
+describe("run-store lifecycle CRUD", () => {
+  it("markCancelRequested surfaces in listRuns", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      const id = seedRun(store);
+      store.markCancelRequested(id, "closed_issue");
+
+      const [run] = store.listRuns();
+      expect(run).toMatchObject({
+        id,
+        cancelRequested: true,
+        cancelReason: "closed_issue"
+      });
+
+      // idempotent
+      store.markCancelRequested(id, "closed_issue");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("recordTerminalReason persists reason and classification", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      const id = seedRun(store);
+      store.recordTerminalReason(id, "workspace_branch_conflict", "deterministic");
+
+      const [run] = store.listRuns();
+      expect(run).toMatchObject({
+        terminalReason: "workspace_branch_conflict",
+        failureClassification: "deterministic"
+      });
+    } finally {
+      store.close();
+    }
+  });
+
+  it("incrementRetryCount returns the new value across calls", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      const id = seedRun(store);
+      expect(store.incrementRetryCount(id)).toBe(1);
+      expect(store.incrementRetryCount(id)).toBe(2);
+      expect(store.runRetryCount(id)).toBe(2);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("countSucceededContinuations counts only succeeded continuation runs for the issue", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      seedRun(store, { id: "parent", issueNumber: 42 });
+      store.updateRunState("parent", "succeeded");
+
+      store.createContinuationRun({
+        id: "cont-1",
+        issue: {
+          body: "",
+          created_at: "2025-01-01T00:00:00Z",
+          id: 1042,
+          labels: ["agent-ready"],
+          number: 42,
+          priority: 1,
+          state: "open",
+          title: "fixture",
+          updated_at: "2025-01-01T00:00:00Z",
+          url: "https://example/42"
+        },
+        parentRunId: "parent",
+        projectName: "symphonika",
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      store.updateRunState("cont-1", "succeeded");
+
+      // sibling continuation that succeeded for a different issue must not count
+      seedRun(store, { id: "other-parent", issueNumber: 99 });
+      store.updateRunState("other-parent", "succeeded");
+
+      expect(store.countSucceededContinuations("symphonika", 42)).toBe(1);
+      expect(store.countSucceededContinuations("symphonika", 99)).toBe(0);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("listActiveRunIds returns non-terminal runs", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      seedRun(store, { id: "queued", issueNumber: 1 });
+      seedRun(store, { id: "running", issueNumber: 2 });
+      store.updateRunState("running", "running");
+      seedRun(store, { id: "done", issueNumber: 3 });
+      store.updateRunState("done", "succeeded");
+
+      const ids = store.listActiveRunIds().map((entry) => entry.runId).sort();
+      expect(ids).toEqual(["queued", "running"]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("createCapReachedFailureRun inserts a synthetic failed continuation row", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      seedRun(store, { id: "parent", issueNumber: 8 });
+      store.updateRunState("parent", "succeeded");
+
+      store.createCapReachedFailureRun({
+        id: "cap-1",
+        issue: {
+          body: "",
+          created_at: "2025-01-01T00:00:00Z",
+          id: 1008,
+          labels: ["agent-ready"],
+          number: 8,
+          priority: 1,
+          state: "open",
+          title: "fixture",
+          updated_at: "2025-01-01T00:00:00Z",
+          url: "https://example/8"
+        },
+        parentRunId: "parent",
+        projectName: "symphonika",
+        reason: "continuation cap reached"
+      });
+
+      const cap = store
+        .listRuns()
+        .find((entry) => entry.id === "cap-1");
+      expect(cap).toMatchObject({
+        state: "failed",
+        isContinuation: true,
+        continuationParentRunId: "parent",
+        terminalReason: "continuation cap reached",
+        failureClassification: "deterministic",
+        issueNumber: 8
+      });
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("run-store schema migration", () => {
+  it("preserves existing rows when adding lifecycle columns to an old database", async () => {
+    const root = await makeTempRoot();
+    const dbPath = databasePath(root);
+    const writer = new Database(dbPath);
+    try {
+      writer.exec(`
+        create table runs (
+          id text primary key,
+          project_name text not null,
+          issue_number integer not null,
+          issue_title text not null,
+          state text not null,
+          issue_snapshot_json text not null,
+          provider_name text,
+          provider_command text,
+          workspace_path text,
+          branch_name text,
+          branch_ref text,
+          prompt_path text,
+          metadata_path text,
+          issue_snapshot_path text,
+          raw_log_path text,
+          normalized_log_path text,
+          created_at text not null,
+          updated_at text not null
+        );
+        create table attempts (
+          id text primary key,
+          run_id text not null,
+          attempt_number integer not null,
+          state text not null,
+          provider_name text not null,
+          provider_command text not null,
+          workspace_path text not null,
+          branch_name text not null,
+          prompt_path text not null,
+          issue_snapshot_path text not null,
+          raw_log_path text not null,
+          normalized_log_path text not null,
+          created_at text not null,
+          updated_at text not null
+        );
+        create table run_state_transitions (
+          id integer primary key autoincrement,
+          run_id text not null,
+          sequence integer not null,
+          state text not null,
+          created_at text not null
+        );
+        create table provider_events (
+          id integer primary key autoincrement,
+          run_id text not null,
+          attempt_id text not null,
+          sequence integer not null,
+          type text not null,
+          raw_json text not null,
+          normalized_json text not null,
+          created_at text not null
+        );
+        insert into runs (
+          id, project_name, issue_number, issue_title, state, issue_snapshot_json,
+          created_at, updated_at
+        ) values (
+          'legacy-run', 'symphonika', 99, 't', 'succeeded', '{}',
+          '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z'
+        );
+      `);
+    } finally {
+      writer.close();
+    }
+
+    const store = openRunStore({ stateRoot: root });
+    store.close();
+
+    const reader = new Database(dbPath, { readonly: true });
+    try {
+      expect(columnNames(reader, "runs")).toEqual(
+        expect.arrayContaining([
+          "is_continuation",
+          "retry_count",
+          "cancel_requested"
+        ])
+      );
+      const row = reader.prepare("select id, retry_count, is_continuation from runs where id = ?").get("legacy-run") as
+        | { id: string; retry_count: number; is_continuation: number }
+        | undefined;
+      expect(row).toEqual({
+        id: "legacy-run",
+        retry_count: 0,
+        is_continuation: 0
+      });
+    } finally {
+      reader.close();
+    }
+  });
+
+  it("adds lifecycle columns on a fresh database", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    store.close();
+
+    const database = new Database(databasePath(root), { readonly: true });
+    try {
+      const runs = columnNames(database, "runs");
+      expect(runs).toEqual(
+        expect.arrayContaining([
+          "is_continuation",
+          "continuation_parent_run_id",
+          "retry_count",
+          "failure_classification",
+          "terminal_reason",
+          "cancel_requested",
+          "cancel_reason"
+        ])
+      );
+
+      const attempts = columnNames(database, "attempts");
+      expect(attempts).toEqual(expect.arrayContaining(["failure_classification"]));
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
-    testTimeout: 15_000
+    testTimeout: 35_000
   }
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"]
+    include: ["tests/**/*.test.ts"],
+    testTimeout: 15_000
   }
 });


### PR DESCRIPTION
## Summary

- Adds the full run lifecycle around active dispatch — cancellation when issues close or lose eligibility, transient retries with capped backoff, deterministic-failure handling, capped continuations after success, graceful Project disable/removal, and preserved workspaces and logs on every terminal path.
- Introduces `src/lifecycle/` (classifier, active-run registry + delayed scheduler, per-poll reconcile pass, RunController owning each run end-to-end). `dispatch.ts` becomes a thin shim over `RunController`; `daemon.ts` holds one long-lived registry.
- Schema migration via `pragma_table_info` adds `is_continuation`, `continuation_parent_run_id`, `retry_count`, `failure_classification`, `terminal_reason`, `cancel_requested`, `cancel_reason` (plus `failure_classification` on attempts). Surfaced on `RunStatus`/`/api/status` with new `active` and `scheduled` fields.

## Acceptance criteria (from issue #11)

- [x] Closed issues cancel active runs and remove operational labels best-effort.
- [x] Eligibility loss while running cancels active runs and removes `sym:running`.
- [x] Transient failures retry with capped backoff (`[10s, 30s, 2m]`, max 5m, cap 3) and `retry_count` tracking.
- [x] Deterministic failures (workspace conflict, render error, malformed event, validate ENOENT, input_required) do not retry and mark `sym:failed`.
- [x] Successful runs re-check eligibility via `getIssue` and schedule capped continuations (~1s delay, cap 3).
- [x] Continuation cap exhaustion writes a synthetic `failed` run row with `terminal_reason='continuation cap reached'` and adds `sym:failed`.
- [x] Project disable/removal stops new dispatch and drops scheduled retries/continuations at dequeue; existing runs continue.
- [x] Workspaces and logs preserved on every terminal path (success, failure, cancellation, cap-reached).
- [x] Tests cover cancellation, retries, deterministic failures, continuation cap, label updates, and Project disable.

## Test plan

- [x] `npx vitest run` — 108/108 passing (was 68); 9 consecutive runs stable.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npx eslint .` — clean.
- [ ] Manual smoke against a real `symphonika.yml` with the fake provider; confirm `/api/status` shows `active`, `scheduled`, `retryCount`, `terminalReason`, `cancelReason`.