### PR TITLE
Implement stale-claim recovery (#12)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,16 +5,19 @@ import { pathToFileURL } from "node:url";
 import type { DaemonHandle, StartDaemonOptions } from "./daemon.js";
 import { startDaemon } from "./daemon.js";
 import type {
+  ClearStaleOptions,
+  ClearStaleReport,
   DoctorOptions,
   DoctorReport,
   InitProjectOptions,
   InitProjectReport
 } from "./doctor.js";
-import { runDoctor, runInitProject } from "./doctor.js";
+import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
 import { VERSION } from "./version.js";
 
 export type CliDependencies = {
   registerSignalHandlers?: boolean;
+  runClearStale?: (options: ClearStaleOptions) => Promise<ClearStaleReport>;
   runDoctor?: (options: DoctorOptions) => Promise<DoctorReport>;
   runInitProject?: (options: InitProjectOptions) => Promise<InitProjectReport>;
   startDaemon?: (options: StartDaemonOptions) => Promise<DaemonHandle>;
@@ -23,6 +26,7 @@ export type CliDependencies = {
 export function buildCli(dependencies: CliDependencies = {}): Command {
   const doctor = dependencies.runDoctor ?? runDoctor;
   const initProject = dependencies.runInitProject ?? runInitProject;
+  const clearStale = dependencies.runClearStale ?? runClearStale;
   const start = dependencies.startDaemon ?? startDaemon;
   const registerSignalHandlers = dependencies.registerSignalHandlers ?? true;
   const program = new Command();
@@ -39,11 +43,27 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .action(async (options: { config: string }) => {
       const report = await doctor({ configPath: options.config });
 
+      const printStaleSection = (): void => {
+        for (const project of report.projects) {
+          if (project.staleIssues.length === 0) {
+            continue;
+          }
+          writeOut(
+            program,
+            `- project: ${project.name} — stale issues: ${project.staleIssues.length}\n`
+          );
+          for (const issue of project.staleIssues) {
+            writeOut(program, `    • #${issue.number}  ${issue.title} (${issue.url})\n`);
+          }
+        }
+      };
+
       if (report.ok) {
         writeOut(
           program,
           `doctor ok: ${report.projects.length} ${pluralize("project", report.projects.length)} valid\n`
         );
+        printStaleSection();
         return;
       }
 
@@ -51,6 +71,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
       for (const error of report.errors) {
         writeErr(program, `- ${error}\n`);
       }
+      printStaleSection();
       process.exitCode = 1;
     });
 
@@ -103,6 +124,59 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     });
 
   program
+    .command("clear-stale")
+    .description(
+      "remove sym:stale and sym:claimed from a target issue after explicit confirmation"
+    )
+    .argument("<project>", "project name from symphonika.yml")
+    .argument("<issue-number>", "GitHub issue number", parseIssueNumber)
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .option("--yes", "remove labels without an interactive prompt")
+    .action(
+      async (
+        project: string,
+        issueNumber: number,
+        options: { config: string; yes?: boolean }
+      ) => {
+        const emittedWarnings = new Set<string>();
+        const report = await clearStale({
+          configPath: options.config,
+          issueNumber,
+          onWarning: (warning) => {
+            emittedWarnings.add(warning);
+            writeErr(program, `warning: ${warning}\n`);
+          },
+          project,
+          yes: options.yes === true
+        });
+
+        for (const warning of report.warnings) {
+          if (emittedWarnings.has(warning)) {
+            continue;
+          }
+          writeErr(program, `warning: ${warning}\n`);
+        }
+
+        if (!report.ok) {
+          writeErr(program, "clear-stale failed:\n");
+          for (const error of report.errors) {
+            writeErr(program, `- ${error}\n`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        writeOut(
+          program,
+          `clear-stale ok: removed ${report.removedLabels.length} ${pluralize("label", report.removedLabels.length)} from ${report.repository}#${report.issueNumber}\n`
+        );
+        for (const label of report.removedLabels) {
+          writeOut(program, `- ${label}\n`);
+        }
+      }
+    );
+
+  program
     .command("daemon")
     .description("start the local Symphonika daemon without dispatching work")
     .option("--config <path>", "service config path", "symphonika.yml")
@@ -133,6 +207,16 @@ function parsePort(value: string): number {
   }
 
   return port;
+}
+
+function parseIssueNumber(value: string): number {
+  const issue = Number(value);
+
+  if (!Number.isInteger(issue) || issue < 1) {
+    throw new InvalidArgumentError("issue number must be a positive integer");
+  }
+
+  return issue;
 }
 
 function pluralize(word: string, count: number): string {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -166,7 +166,9 @@ export async function startDaemon(
           });
           await promise;
         },
+        issueNumber: item.issueNumber,
         kind: item.kind,
+        projectName: item.projectName,
         runId: item.runId
       });
     },

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -30,6 +30,7 @@ import {
   type RunControllerProjectConfig,
   type RunControllerProvidersConfig
 } from "./lifecycle/run-controller.js";
+import { detectStaleClaims } from "./lifecycle/stale-claims.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
 import { openRunStore } from "./run-store.js";
@@ -82,6 +83,13 @@ export async function startDaemon(
   const runStore = openRunStore({
     stateRoot: state.stateRoot
   });
+  const sweptOnStartup = runStore.markLeakedRunsAsStale();
+  if (sweptOnStartup.length > 0) {
+    logger.info(
+      { swept: sweptOnStartup },
+      "symphonika startup: marked leaked runs as stale"
+    );
+  }
   const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;
   const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
   const env = options.env ?? process.env;
@@ -217,6 +225,24 @@ export async function startDaemon(
     } catch (error) {
       logger.error({ err: error }, "symphonika reconcile failed");
     }
+
+    if (dispatchMutex.held) {
+      return;
+    }
+
+    try {
+      await detectStaleClaims({
+        activeRuns,
+        env,
+        githubIssuesApi,
+        logger,
+        pollStatus: issuePollStatus,
+        projects,
+        runStore
+      });
+    } catch (error) {
+      logger.error({ err: error }, "symphonika stale-claim detection failed");
+    }
   };
   const launchDispatch = (): void => {
     if (
@@ -281,6 +307,7 @@ export async function startDaemon(
   const port = resolveListeningPort(server, requestedPort);
   const url = `http://${host}:${port}`;
   if (state.configExists) {
+    await reconcile();
     if (issuePollStatus.candidateIssues.length > 0) {
       launchDispatch();
     }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,6 +4,10 @@ import { Octokit } from "@octokit/rest";
 import { parse } from "yaml";
 import { z } from "zod";
 
+import {
+  DEFAULT_GITHUB_ISSUES_API,
+  type GitHubIssuesApi
+} from "./issue-polling.js";
 import { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
@@ -17,11 +21,19 @@ export type DoctorOptions = {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   githubApi?: GitHubApi;
+  githubIssuesApi?: GitHubIssuesApi;
+};
+
+export type StaleIssueSummary = {
+  number: number;
+  title: string;
+  url: string;
 };
 
 export type DoctorProjectReport = {
   missingOperationalLabels: string[];
   name: string;
+  staleIssues: StaleIssueSummary[];
   validForDispatch: boolean;
   workflowPath: string;
 };
@@ -67,9 +79,30 @@ export type GitHubRepositoryAccess = {
 export type GitHubApi = {
   createLabel: (input: GitHubRepositoryInput & { name: string }) => Promise<void>;
   listLabels: (input: GitHubRepositoryInput) => Promise<string[]>;
+  removeIssueLabel?: (
+    input: GitHubRepositoryInput & { issueNumber: number; name: string }
+  ) => Promise<void>;
   validateRepositoryAccess: (
     input: GitHubRepositoryInput
   ) => Promise<GitHubRepositoryAccess>;
+};
+
+export type ClearStaleOptions = DoctorOptions & {
+  issueNumber: number;
+  onWarning?: (warning: string) => void;
+  project: string;
+  yes?: boolean;
+};
+
+export type ClearStaleReport = {
+  configPath: string;
+  errors: string[];
+  issueNumber: number;
+  ok: boolean;
+  project: string;
+  removedLabels: string[];
+  repository: string;
+  warnings: string[];
 };
 
 type ServiceConfig = z.infer<typeof serviceConfigSchema>;
@@ -202,6 +235,7 @@ export async function runDoctor(
   const configPath = path.resolve(cwd, options.configPath ?? "symphonika.yml");
   const env = options.env ?? process.env;
   const githubApi = options.githubApi ?? DEFAULT_GITHUB_API;
+  const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
   const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;
   const errors: string[] = [];
   const projects: DoctorProjectReport[] = [];
@@ -228,14 +262,83 @@ export async function runDoctor(
     const workflowPath = path.resolve(path.dirname(configPath), project.workflow);
     const workflowErrors = await validateWorkflowContract(workflowPath);
     errors.push(...workflowErrors);
+    const staleIssues = await fetchStaleIssues(
+      project,
+      env,
+      githubIssuesApi
+    );
     projects.push({
       ...validation,
       name: project.name,
+      staleIssues,
       workflowPath
     });
   }
 
   return report(configPath, errors, projects);
+}
+
+async function fetchStaleIssues(
+  project: ProjectConfig,
+  env: NodeJS.ProcessEnv,
+  githubIssuesApi: GitHubIssuesApi
+): Promise<StaleIssueSummary[]> {
+  const token = resolveEnvBackedValue(project.tracker.token, env);
+  if (token === undefined) {
+    return [];
+  }
+  let issues;
+  try {
+    issues = await githubIssuesApi.listOpenIssues({
+      owner: project.tracker.owner,
+      repo: project.tracker.repo,
+      token
+    });
+  } catch {
+    return [];
+  }
+  const stale: StaleIssueSummary[] = [];
+  for (const raw of issues) {
+    const labelNames = labelNamesOf(raw.labels);
+    if (!labelNames.includes("sym:stale")) {
+      continue;
+    }
+    const number = typeof raw.number === "number" ? raw.number : undefined;
+    if (number === undefined) {
+      continue;
+    }
+    stale.push({
+      number,
+      title: typeof raw.title === "string" ? raw.title : "",
+      url:
+        typeof raw.html_url === "string"
+          ? raw.html_url
+          : typeof raw.url === "string"
+            ? raw.url
+            : ""
+    });
+  }
+  return stale;
+}
+
+function labelNamesOf(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  const names: string[] = [];
+  for (const entry of input) {
+    if (typeof entry === "string") {
+      names.push(entry);
+    } else if (
+      typeof entry === "object" &&
+      entry !== null &&
+      "name" in entry &&
+      typeof (entry as { name: unknown }).name === "string"
+    ) {
+      names.push((entry as { name: string }).name);
+    }
+  }
+  return names;
 }
 
 export async function runInitProject(
@@ -338,6 +441,122 @@ export async function runInitProject(
   return initProjectReport(configPath, errors, warnings, projects);
 }
 
+const STALE_CLEAR_LABELS = ["sym:stale", "sym:claimed"] as const;
+
+export async function runClearStale(
+  options: ClearStaleOptions
+): Promise<ClearStaleReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const configPath = path.resolve(cwd, options.configPath ?? "symphonika.yml");
+  const env = options.env ?? process.env;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const removedLabels: string[] = [];
+  const result = (
+    repository: string,
+    ok = false
+  ): ClearStaleReport => ({
+    configPath,
+    errors,
+    issueNumber: options.issueNumber,
+    ok,
+    project: options.project,
+    removedLabels,
+    repository,
+    warnings
+  });
+
+  const rawConfig = await readConfig(configPath, errors);
+  if (rawConfig === undefined) {
+    return result("");
+  }
+  const parsedConfig = parseServiceConfig(rawConfig, errors);
+  if (parsedConfig === undefined) {
+    return result("");
+  }
+
+  const project = parsedConfig.projects.find(
+    (entry) => entry.name === options.project
+  );
+  if (project === undefined) {
+    errors.push(`projects.${options.project} not found in config`);
+    return result("");
+  }
+
+  const repositoryName = `${project.tracker.owner}/${project.tracker.repo}`;
+  const token = resolveEnvBackedValue(project.tracker.token, env);
+  if (token === undefined) {
+    const variableName = envReferenceName(project.tracker.token);
+    errors.push(
+      variableName === undefined
+        ? `projects.${project.name}.tracker.token must reference an environment variable like $GITHUB_TOKEN`
+        : `projects.${project.name}.tracker.token references unset environment variable $${variableName}`
+    );
+    return result(repositoryName);
+  }
+
+  const githubApi = options.githubApi ?? DEFAULT_GITHUB_API;
+  const repository = {
+    owner: project.tracker.owner,
+    repo: project.tracker.repo,
+    token
+  };
+  const access = await githubApi.validateRepositoryAccess(repository);
+  if (!access.ok) {
+    errors.push(
+      `projects.${project.name}.tracker.repository ${repositoryName} is not accessible: ${access.message ?? "unknown GitHub error"}`
+    );
+    return result(repositoryName);
+  }
+
+  const warning = `clear-stale ${options.yes === true ? "will" : "would"} remove ${STALE_CLEAR_LABELS.join(", ")} from ${repositoryName}#${options.issueNumber}`;
+  warnings.push(warning);
+  options.onWarning?.(warning);
+
+  if (options.yes !== true) {
+    errors.push("pass --yes to remove stale-claim labels non-interactively");
+    return result(repositoryName);
+  }
+
+  if (githubApi.removeIssueLabel === undefined) {
+    errors.push(
+      `projects.${project.name}.tracker.repository ${repositoryName} GitHub adapter does not support removeIssueLabel`
+    );
+    return result(repositoryName);
+  }
+
+  let allOk = true;
+  for (const label of STALE_CLEAR_LABELS) {
+    try {
+      await githubApi.removeIssueLabel({
+        ...repository,
+        issueNumber: options.issueNumber,
+        name: label
+      });
+      removedLabels.push(label);
+    } catch (error) {
+      if (isOctokitNotFoundError(error)) {
+        removedLabels.push(label);
+        continue;
+      }
+      allOk = false;
+      errors.push(
+        `projects.${project.name}.tracker.repository ${repositoryName} could not remove label ${label} from issue ${options.issueNumber}: ${errorMessage(error)}`
+      );
+    }
+  }
+
+  return result(repositoryName, allOk);
+}
+
+function isOctokitNotFoundError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" && status === 404;
+}
+
 class OctokitGitHubApi implements GitHubApi {
   async validateRepositoryAccess(
     input: GitHubRepositoryInput
@@ -378,6 +597,18 @@ class OctokitGitHubApi implements GitHubApi {
     await octokit.rest.issues.createLabel({
       color: labelDescription.color,
       description: labelDescription.description,
+      name: input.name,
+      owner: input.owner,
+      repo: input.repo
+    });
+  }
+
+  async removeIssueLabel(
+    input: GitHubRepositoryInput & { issueNumber: number; name: string }
+  ): Promise<void> {
+    const octokit = this.octokit(input.token);
+    await octokit.rest.issues.removeLabel({
+      issue_number: input.issueNumber,
       name: input.name,
       owner: input.owner,
       repo: input.repo

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -441,7 +441,7 @@ export async function runInitProject(
   return initProjectReport(configPath, errors, warnings, projects);
 }
 
-const STALE_CLEAR_LABELS = ["sym:stale", "sym:claimed"] as const;
+const STALE_CLEAR_LABELS = ["sym:stale", "sym:claimed", "sym:running"] as const;
 
 export async function runClearStale(
   options: ClearStaleOptions

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -62,6 +62,9 @@ export function createHttpApp(options: HttpAppOptions): Hono {
       runs: getRuns(),
       scheduled: getScheduled(),
       service: "symphonika",
+      staleIssues: issuePollStatus.filteredIssues.filter((entry) =>
+        entry.issue.labels.includes("sym:stale")
+      ),
       state: dispatchRuntime.dispatching ? "dispatching" : "idle",
       dispatching: dispatchRuntime.dispatching,
       stateRoot: options.stateRoot,

--- a/src/lifecycle/active-runs.ts
+++ b/src/lifecycle/active-runs.ts
@@ -65,13 +65,17 @@ export type ScheduledWorkKind = "retry" | "continuation";
 export type ScheduledWorkInput = {
   delayMs: number;
   fire: () => Promise<void>;
+  issueNumber: number;
   kind: ScheduledWorkKind;
+  projectName: string;
   runId: string;
 };
 
 type ScheduledItem = {
   dueAt: number;
+  issueNumber: number;
   kind: ScheduledWorkKind;
+  projectName: string;
   runId: string;
   timeout: ReturnType<typeof setTimeout>;
 };
@@ -132,7 +136,9 @@ export class ActiveRunRegistry {
     const dueAt = Date.now() + input.delayMs;
     const item: ScheduledItem = {
       dueAt,
+      issueNumber: input.issueNumber,
       kind: input.kind,
+      projectName: input.projectName,
       runId: input.runId,
       timeout: setTimeout(() => {
         this.scheduled.delete(item);
@@ -150,6 +156,13 @@ export class ActiveRunRegistry {
       dueAt: item.dueAt,
       kind: item.kind,
       runId: item.runId
+    }));
+  }
+
+  scheduledIssueKeys(): { issueNumber: number; projectName: string }[] {
+    return Array.from(this.scheduled, (item) => ({
+      issueNumber: item.issueNumber,
+      projectName: item.projectName
     }));
   }
 

--- a/src/lifecycle/reconcile.ts
+++ b/src/lifecycle/reconcile.ts
@@ -11,6 +11,7 @@ import {
 import type { RunStore } from "../run-store.js";
 
 import { ActiveRunRegistry, CANCEL_REASONS } from "./active-runs.js";
+import { resolveToken } from "./token.js";
 
 export type ReconcileInput = {
   activeRuns: ActiveRunRegistry;
@@ -126,11 +127,3 @@ function findIssueSnapshot(
   return undefined;
 }
 
-function resolveToken(reference: string, env: NodeJS.ProcessEnv): string | undefined {
-  const match = /^\$([A-Za-z_][A-Za-z0-9_]*)$/.exec(reference);
-  if (match === null) {
-    return undefined;
-  }
-  const value = env[match[1] ?? ""];
-  return value === undefined || value.length === 0 ? undefined : value;
-}

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -60,7 +60,9 @@ export type RunControllerProvidersConfig = {
 export type ScheduleHandler = (input: {
   delayMs: number;
   fire: () => Promise<void>;
+  issueNumber: number;
   kind: "retry" | "continuation";
+  projectName: string;
   runId: string;
 }) => void;
 
@@ -882,7 +884,9 @@ export class RunController {
             projectName: input.project.name,
             runId: input.runId
           }),
+        issueNumber: input.issue.number,
         kind: "retry",
+        projectName: input.project.name,
         runId: input.runId
       });
       return;
@@ -943,7 +947,9 @@ export class RunController {
           parentRunId: input.runId,
           projectName: input.project.name
         }),
+      issueNumber: refreshed.number,
       kind: "continuation",
+      projectName: input.project.name,
       runId: input.runId
     });
   }

--- a/src/lifecycle/stale-claims.ts
+++ b/src/lifecycle/stale-claims.ts
@@ -99,6 +99,9 @@ function collectLiveKeys(input: DetectStaleClaimsInput): Set<string> {
   for (const entry of input.activeRuns.list()) {
     keys.add(issueKey(entry.projectName, entry.issueNumber));
   }
+  for (const entry of input.activeRuns.scheduledIssueKeys()) {
+    keys.add(issueKey(entry.projectName, entry.issueNumber));
+  }
   for (const entry of input.runStore.listActiveRunIds()) {
     keys.add(issueKey(entry.projectName, entry.issueNumber));
   }

--- a/src/lifecycle/stale-claims.ts
+++ b/src/lifecycle/stale-claims.ts
@@ -1,0 +1,120 @@
+import type { Logger } from "pino";
+
+import type {
+  GitHubIssuesApi,
+  IssuePollStatus,
+  PollingProjectConfig
+} from "../issue-polling.js";
+import type { RunStore } from "../run-store.js";
+
+import type { ActiveRunRegistry } from "./active-runs.js";
+import { resolveToken } from "./token.js";
+
+export type DetectStaleClaimsInput = {
+  activeRuns: ActiveRunRegistry;
+  env: NodeJS.ProcessEnv;
+  githubIssuesApi: GitHubIssuesApi;
+  logger: Logger;
+  pollStatus: IssuePollStatus;
+  projects: Map<string, PollingProjectConfig>;
+  runStore: RunStore;
+};
+
+export type StaleClaimMark = {
+  issueNumber: number;
+  project: string;
+};
+
+const STALE_LABEL = "sym:stale";
+const CLAIM_LABELS = ["sym:claimed", "sym:running"] as const;
+
+export async function detectStaleClaims(
+  input: DetectStaleClaimsInput
+): Promise<StaleClaimMark[]> {
+  const marks: StaleClaimMark[] = [];
+  const liveKeys = collectLiveKeys(input);
+
+  for (const filtered of input.pollStatus.filteredIssues) {
+    const project = input.projects.get(filtered.project);
+    if (project === undefined) {
+      continue;
+    }
+    const issue = filtered.issue;
+    if (issue.state !== "open") {
+      continue;
+    }
+    if (!hasAnyLabel(issue.labels, CLAIM_LABELS)) {
+      continue;
+    }
+    if (issue.labels.includes(STALE_LABEL)) {
+      continue;
+    }
+    if (liveKeys.has(issueKey(filtered.project, issue.number))) {
+      continue;
+    }
+
+    const token = resolveToken(project.tracker.token, input.env);
+    if (token === undefined) {
+      input.logger.warn(
+        { project: filtered.project, issueNumber: issue.number },
+        "symphonika stale-claim detection skipped: token unavailable"
+      );
+      continue;
+    }
+
+    const addLabelsToIssue = input.githubIssuesApi.addLabelsToIssue;
+    if (addLabelsToIssue === undefined) {
+      input.logger.warn(
+        { project: filtered.project, issueNumber: issue.number },
+        "symphonika stale-claim detection skipped: addLabelsToIssue not available"
+      );
+      continue;
+    }
+
+    try {
+      await addLabelsToIssue({
+        issueNumber: issue.number,
+        labels: [STALE_LABEL],
+        owner: project.tracker.owner,
+        repo: project.tracker.repo,
+        token
+      });
+      marks.push({
+        issueNumber: issue.number,
+        project: filtered.project
+      });
+    } catch (error) {
+      input.logger.warn(
+        { err: error, project: filtered.project, issueNumber: issue.number },
+        "symphonika stale-claim detection failed for issue"
+      );
+    }
+  }
+
+  return marks;
+}
+
+function collectLiveKeys(input: DetectStaleClaimsInput): Set<string> {
+  const keys = new Set<string>();
+  for (const entry of input.activeRuns.list()) {
+    keys.add(issueKey(entry.projectName, entry.issueNumber));
+  }
+  for (const entry of input.runStore.listActiveRunIds()) {
+    keys.add(issueKey(entry.projectName, entry.issueNumber));
+  }
+  return keys;
+}
+
+function issueKey(projectName: string, issueNumber: number): string {
+  return `${projectName}#${issueNumber}`;
+}
+
+function hasAnyLabel(labels: string[], targets: ReadonlyArray<string>): boolean {
+  for (const target of targets) {
+    if (labels.includes(target)) {
+      return true;
+    }
+  }
+  return false;
+}
+

--- a/src/lifecycle/token.ts
+++ b/src/lifecycle/token.ts
@@ -1,0 +1,11 @@
+export function resolveToken(
+  reference: string,
+  env: NodeJS.ProcessEnv
+): string | undefined {
+  const match = /^\$([A-Za-z_][A-Za-z0-9_]*)$/.exec(reference);
+  if (match === null) {
+    return undefined;
+  }
+  const value = env[match[1] ?? ""];
+  return value === undefined || value.length === 0 ? undefined : value;
+}

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -394,6 +394,26 @@ export class RunStore {
       .run(reason, timestamp(), runId);
   }
 
+  markLeakedRunsAsStale(
+    reason = "leaked_active_run"
+  ): { runId: string; projectName: string; issueNumber: number }[] {
+    const rows = this.database
+      .prepare(
+        "select id, project_name, issue_number from runs where state in ('queued','preparing_workspace','running')"
+      )
+      .all() as { id: string; project_name: string; issue_number: number }[];
+    const swept = rows.map((row) => ({
+      issueNumber: row.issue_number,
+      projectName: row.project_name,
+      runId: row.id
+    }));
+    for (const entry of swept) {
+      this.recordTerminalReason(entry.runId, reason);
+      this.updateRunState(entry.runId, "stale");
+    }
+    return swept;
+  }
+
   private migrate(): void {
     this.database.exec(`
       create table if not exists runs (

--- a/tests/active-runs.test.ts
+++ b/tests/active-runs.test.ts
@@ -57,7 +57,9 @@ describe("ActiveRunRegistry", () => {
       registry.scheduleDelayed({
         delayMs: 50,
         fire,
+        issueNumber: 1,
         kind: "retry",
+        projectName: "p",
         runId: "run-a"
       });
 
@@ -81,7 +83,9 @@ describe("ActiveRunRegistry", () => {
       registry.scheduleDelayed({
         delayMs: 50,
         fire,
+        issueNumber: 1,
         kind: "continuation",
+        projectName: "p",
         runId: "run-a"
       });
       registry.cancelAll();

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -55,10 +55,10 @@ describe("CLI", () => {
           issueNumber: options.issueNumber,
           ok: true,
           project: options.project,
-          removedLabels: ["sym:stale", "sym:claimed"],
+          removedLabels: ["sym:stale", "sym:claimed", "sym:running"],
           repository: "pmatos/symphonika",
           warnings: [
-            "clear-stale will remove sym:stale, sym:claimed from pmatos/symphonika#42"
+            "clear-stale will remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#42"
           ]
         } satisfies ClearStaleReport);
       }
@@ -91,6 +91,7 @@ describe("CLI", () => {
     expect(output.stdout).toContain("clear-stale ok");
     expect(output.stdout).toContain("sym:stale");
     expect(output.stdout).toContain("sym:claimed");
+    expect(output.stdout).toContain("sym:running");
   });
 
   it("clear-stale exits non-zero when the runner reports failure (no --yes)", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import { buildCli } from "../src/cli.js";
 import type { StartDaemonOptions } from "../src/daemon.js";
-import type { InitProjectOptions } from "../src/doctor.js";
+import type {
+  ClearStaleOptions,
+  ClearStaleReport,
+  InitProjectOptions
+} from "../src/doctor.js";
 
 describe("CLI", () => {
   it("starts the daemon with the selected config path and port", async () => {
@@ -36,6 +40,176 @@ describe("CLI", () => {
       configPath: "custom.yml",
       port: 4001
     });
+  });
+
+  it("clear-stale calls the underlying runner with --yes and prints removed labels", async () => {
+    const calls: ClearStaleOptions[] = [];
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({
+      registerSignalHandlers: false,
+      runClearStale: (options) => {
+        calls.push(options);
+        return Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          issueNumber: options.issueNumber,
+          ok: true,
+          project: options.project,
+          removedLabels: ["sym:stale", "sym:claimed"],
+          repository: "pmatos/symphonika",
+          warnings: [
+            "clear-stale will remove sym:stale, sym:claimed from pmatos/symphonika#42"
+          ]
+        } satisfies ClearStaleReport);
+      }
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "clear-stale",
+      "symphonika",
+      "42",
+      "--yes"
+    ]);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      configPath: "symphonika.yml",
+      issueNumber: 42,
+      project: "symphonika",
+      yes: true
+    });
+    expect(output.stdout).toContain("clear-stale ok");
+    expect(output.stdout).toContain("sym:stale");
+    expect(output.stdout).toContain("sym:claimed");
+  });
+
+  it("clear-stale exits non-zero when the runner reports failure (no --yes)", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({
+      registerSignalHandlers: false,
+      runClearStale: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: ["pass --yes to remove stale-claim labels non-interactively"],
+          issueNumber: 7,
+          ok: false,
+          project: "symphonika",
+          removedLabels: [],
+          repository: "pmatos/symphonika",
+          warnings: [
+            "clear-stale would remove sym:stale, sym:claimed from pmatos/symphonika#7"
+          ]
+        } satisfies ClearStaleReport)
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    try {
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "clear-stale",
+        "symphonika",
+        "7"
+      ]);
+
+      expect(process.exitCode).toBe(1);
+      expect(output.stderr).toContain("clear-stale failed");
+      expect(output.stderr).toContain("pass --yes");
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("clear-stale rejects non-numeric issue arguments", async () => {
+    const program = buildCli({
+      registerSignalHandlers: false,
+      runClearStale: () =>
+        Promise.reject(new Error("should not be invoked"))
+    });
+    program.exitOverride();
+    for (const command of program.commands) {
+      command.exitOverride();
+    }
+    program.configureOutput({
+      writeErr: () => {
+        /* swallow Commander's stderr noise */
+      },
+      writeOut: () => {
+        /* swallow Commander's stdout noise */
+      }
+    });
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "symphonika",
+        "clear-stale",
+        "symphonika",
+        "not-a-number",
+        "--yes"
+      ])
+    ).rejects.toThrow(/issue number/i);
+  });
+
+  it("doctor prints stale issues per project after the OK summary", async () => {
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({
+      registerSignalHandlers: false,
+      runDoctor: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          ok: true,
+          projects: [
+            {
+              missingOperationalLabels: [],
+              name: "symphonika",
+              staleIssues: [
+                {
+                  number: 42,
+                  title: "Orphan claimed issue",
+                  url: "https://github.com/pmatos/symphonika/issues/42"
+                }
+              ],
+              validForDispatch: true,
+              workflowPath: "/tmp/WORKFLOW.md"
+            }
+          ]
+        })
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    await program.parseAsync(["node", "symphonika", "doctor"]);
+
+    expect(output.stdout).toContain("doctor ok");
+    expect(output.stdout).toContain("project: symphonika — stale issues: 1");
+    expect(output.stdout).toContain("#42  Orphan claimed issue");
   });
 
   it("runs init-project with the selected config path and explicit confirmation", async () => {

--- a/tests/daemon-issue-polling.test.ts
+++ b/tests/daemon-issue-polling.test.ts
@@ -269,6 +269,45 @@ describe("daemon GitHub issue polling", () => {
     }
   });
 
+  it("marks GitHub issues stale when sym:claimed is present and no live run exists", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready", "sym:claimed"],
+          number: 77,
+          title: "Orphan claimed issue"
+        })
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      await waitFor(() =>
+        Promise.resolve(githubIssuesApi.addLabelsToIssue.mock.calls.length >= 1)
+      );
+      expect(githubIssuesApi.addLabelsToIssue).toHaveBeenCalledWith({
+        issueNumber: 77,
+        labels: ["sym:stale"],
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret-token"
+      });
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("continues polling valid projects when another project entry is invalid", async () => {
     const root = await makeTempRoot();
     await writeConfigWithInvalidAndValidProjects(root);

--- a/tests/doctor-github.test.ts
+++ b/tests/doctor-github.test.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  runClearStale,
   runDoctor,
   runInitProject,
   type GitHubApi
 } from "../src/doctor.js";
+import type { GitHubIssuesApi } from "../src/issue-polling.js";
 import type { AgentProviderRegistry } from "../src/provider.js";
 
 const tempRoots: string[] = [];
@@ -120,6 +122,65 @@ describe("GitHub Project validation", () => {
       validForDispatch: false
     });
     expect(githubApi.createLabel).not.toHaveBeenCalled();
+  });
+
+  it("surfaces sym:stale issues per project in the doctor report", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue([
+        "agent-ready",
+        "sym:claimed",
+        "sym:running",
+        "sym:failed",
+        "sym:stale"
+      ]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+    const githubIssuesApi: GitHubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        {
+          html_url: "https://github.com/pmatos/symphonika/issues/77",
+          id: 5077,
+          labels: [{ name: "agent-ready" }, { name: "sym:claimed" }, { name: "sym:stale" }],
+          number: 77,
+          state: "open",
+          title: "Orphan claimed issue"
+        },
+        {
+          html_url: "https://github.com/pmatos/symphonika/issues/78",
+          id: 5078,
+          labels: [{ name: "agent-ready" }],
+          number: 78,
+          state: "open",
+          title: "Plain ready issue"
+        }
+      ])
+    };
+
+    const report = await runDoctor({
+      agentProviders: fakeAgentProviders(),
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      githubIssuesApi
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.projects[0]?.staleIssues).toEqual([
+      {
+        number: 77,
+        title: "Orphan claimed issue",
+        url: "https://github.com/pmatos/symphonika/issues/77"
+      }
+    ]);
+    expect(githubIssuesApi.listOpenIssues).toHaveBeenCalledWith({
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
   });
 
   it("reports label-listing failures without throwing", async () => {
@@ -294,6 +355,163 @@ describe("GitHub Project initialization", () => {
       createdOperationalLabels: ["sym:running"],
       missingOperationalLabels: ["sym:running", "sym:stale"]
     });
+  });
+});
+
+describe("runClearStale", () => {
+  it("refuses to remove labels without --yes", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      removeIssueLabel: vi.fn(),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runClearStale({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      issueNumber: 42,
+      project: "symphonika"
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.warnings).toContain(
+      "clear-stale would remove sym:stale, sym:claimed from pmatos/symphonika#42"
+    );
+    expect(report.errors).toContain(
+      "pass --yes to remove stale-claim labels non-interactively"
+    );
+    expect(report.removedLabels).toEqual([]);
+    expect(githubApi.removeIssueLabel).not.toHaveBeenCalled();
+  });
+
+  it("removes sym:stale and sym:claimed when --yes is supplied", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      removeIssueLabel: vi.fn().mockResolvedValue(undefined),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runClearStale({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      issueNumber: 42,
+      project: "symphonika",
+      yes: true
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
+    expect(report.repository).toBe("pmatos/symphonika");
+    expect(report.warnings).toContain(
+      "clear-stale will remove sym:stale, sym:claimed from pmatos/symphonika#42"
+    );
+    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(2);
+    expect(githubApi.removeIssueLabel).toHaveBeenNthCalledWith(1, {
+      issueNumber: 42,
+      name: "sym:stale",
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
+    expect(githubApi.removeIssueLabel).toHaveBeenNthCalledWith(2, {
+      issueNumber: 42,
+      name: "sym:claimed",
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
+  });
+
+  it("treats label-not-found as a successful removal", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      removeIssueLabel: vi
+        .fn()
+        .mockImplementationOnce(() => Promise.reject(notFound))
+        .mockResolvedValueOnce(undefined),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runClearStale({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      issueNumber: 99,
+      project: "symphonika",
+      yes: true
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
+  });
+
+  it("reports unknown projects as an error", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      removeIssueLabel: vi.fn(),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runClearStale({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      issueNumber: 1,
+      project: "missing",
+      yes: true
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors[0]).toMatch(/missing.*not found/i);
+    expect(githubApi.removeIssueLabel).not.toHaveBeenCalled();
+  });
+
+  it("reports repository access failures and skips label removal", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      removeIssueLabel: vi.fn(),
+      validateRepositoryAccess: vi
+        .fn()
+        .mockResolvedValue({ ok: false, message: "Bad credentials" })
+    };
+
+    const report = await runClearStale({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      issueNumber: 1,
+      project: "symphonika",
+      yes: true
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "projects.symphonika.tracker.repository pmatos/symphonika is not accessible: Bad credentials"
+    );
+    expect(githubApi.removeIssueLabel).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/doctor-github.test.ts
+++ b/tests/doctor-github.test.ts
@@ -380,13 +380,52 @@ describe("runClearStale", () => {
 
     expect(report.ok).toBe(false);
     expect(report.warnings).toContain(
-      "clear-stale would remove sym:stale, sym:claimed from pmatos/symphonika#42"
+      "clear-stale would remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#42"
     );
     expect(report.errors).toContain(
       "pass --yes to remove stale-claim labels non-interactively"
     );
     expect(report.removedLabels).toEqual([]);
     expect(githubApi.removeIssueLabel).not.toHaveBeenCalled();
+  });
+
+  it("removes sym:stale, sym:claimed, and sym:running when --yes is supplied", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      removeIssueLabel: vi.fn().mockResolvedValue(undefined),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runClearStale({
+      configPath: "symphonika.yml",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      issueNumber: 84,
+      project: "symphonika",
+      yes: true
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.removedLabels).toEqual([
+      "sym:stale",
+      "sym:claimed",
+      "sym:running"
+    ]);
+    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(3);
+    expect(githubApi.removeIssueLabel).toHaveBeenNthCalledWith(3, {
+      issueNumber: 84,
+      name: "sym:running",
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
+    expect(report.warnings[0]).toContain(
+      "sym:stale, sym:claimed, sym:running"
+    );
   });
 
   it("removes sym:stale and sym:claimed when --yes is supplied", async () => {
@@ -410,12 +449,16 @@ describe("runClearStale", () => {
     });
 
     expect(report.ok).toBe(true);
-    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
+    expect(report.removedLabels).toEqual([
+      "sym:stale",
+      "sym:claimed",
+      "sym:running"
+    ]);
     expect(report.repository).toBe("pmatos/symphonika");
     expect(report.warnings).toContain(
-      "clear-stale will remove sym:stale, sym:claimed from pmatos/symphonika#42"
+      "clear-stale will remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#42"
     );
-    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(2);
+    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(3);
     expect(githubApi.removeIssueLabel).toHaveBeenNthCalledWith(1, {
       issueNumber: 42,
       name: "sym:stale",
@@ -457,7 +500,11 @@ describe("runClearStale", () => {
     });
 
     expect(report.ok).toBe(true);
-    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
+    expect(report.removedLabels).toEqual([
+      "sym:stale",
+      "sym:claimed",
+      "sym:running"
+    ]);
   });
 
   it("reports unknown projects as an error", async () => {

--- a/tests/eligibility-helpers.test.ts
+++ b/tests/eligibility-helpers.test.ts
@@ -80,6 +80,16 @@ describe("evaluateProjectEligibility", () => {
     expect(result.reasons.some((reason) => reason.includes("agent-ready"))).toBe(true);
   });
 
+  it("flags sym:stale as ineligible by default (operational-label rule)", () => {
+    const result = evaluateProjectEligibility(
+      snapshot({ labels: ["agent-ready", "sym:stale"] }),
+      baseProject
+    );
+
+    expect(result.eligible).toBe(false);
+    expect(result.reasons).toContain("has operational label sym:stale");
+  });
+
   it("flags issues with excluded labels", () => {
     const result = evaluateProjectEligibility(
       snapshot({ labels: ["agent-ready", "needs-human", "sym:running"] }),

--- a/tests/http-app.test.ts
+++ b/tests/http-app.test.ts
@@ -24,6 +24,47 @@ describe("HTTP app", () => {
     });
   });
 
+  it("surfaces filteredIssues carrying sym:stale in a dedicated staleIssues array", async () => {
+    const baseIssue = {
+      body: "",
+      created_at: "2025-01-01T00:00:00Z",
+      id: 1,
+      number: 1,
+      priority: 0,
+      state: "open",
+      title: "stale fixture",
+      updated_at: "2025-01-01T00:00:00Z",
+      url: "https://example/1"
+    };
+    const stale = {
+      issue: { ...baseIssue, labels: ["agent-ready", "sym:claimed", "sym:stale"], number: 9 },
+      project: "p",
+      reasons: ["has operational label sym:stale"]
+    };
+    const claimed = {
+      issue: { ...baseIssue, labels: ["agent-ready", "sym:claimed"], number: 10 },
+      project: "p",
+      reasons: ["has operational label sym:claimed"]
+    };
+
+    const app = createHttpApp({
+      issuePollStatus: {
+        candidateIssues: [],
+        errors: [],
+        filteredIssues: [stale, claimed],
+        projects: []
+      },
+      stateRoot: "/tmp/symphonika-state",
+      startedAtMs: 1_000,
+      version: "0.1.0",
+      now: () => 1_001
+    });
+
+    const response = await app.request("/api/status");
+    const body = (await response.json()) as { staleIssues: typeof claimed[] };
+    expect(body.staleIssues).toEqual([stale]);
+  });
+
   it("reports an idle non-dispatching status", async () => {
     const app = createHttpApp({
       stateRoot: "/tmp/symphonika-state",
@@ -48,6 +89,7 @@ describe("HTTP app", () => {
       runs: [],
       scheduled: [],
       service: "symphonika",
+      staleIssues: [],
       state: "idle",
       stateRoot: "/tmp/symphonika-state",
       uptimeMs: 100

--- a/tests/run-store-lifecycle.test.ts
+++ b/tests/run-store-lifecycle.test.ts
@@ -161,6 +161,60 @@ describe("run-store lifecycle CRUD", () => {
     }
   });
 
+  it("markLeakedRunsAsStale transitions non-terminal runs to stale", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      seedRun(store, { id: "queued", issueNumber: 1 });
+      seedRun(store, { id: "running", issueNumber: 2 });
+      store.updateRunState("running", "running");
+      seedRun(store, { id: "preparing", issueNumber: 3 });
+      store.updateRunState("preparing", "preparing_workspace");
+      seedRun(store, { id: "succeeded", issueNumber: 4 });
+      store.updateRunState("succeeded", "succeeded");
+      seedRun(store, { id: "failed", issueNumber: 5 });
+      store.updateRunState("failed", "failed");
+
+      const swept = store.markLeakedRunsAsStale();
+
+      expect(swept.map((entry) => entry.runId).sort()).toEqual([
+        "preparing",
+        "queued",
+        "running"
+      ]);
+      expect(swept).toEqual(
+        expect.arrayContaining([
+          { runId: "queued", projectName: "symphonika", issueNumber: 1 },
+          { runId: "running", projectName: "symphonika", issueNumber: 2 },
+          { runId: "preparing", projectName: "symphonika", issueNumber: 3 }
+        ])
+      );
+
+      const runsById = new Map(store.listRuns().map((entry) => [entry.id, entry]));
+      expect(runsById.get("queued")).toMatchObject({
+        state: "stale",
+        terminalReason: "leaked_active_run"
+      });
+      expect(runsById.get("running")?.state).toBe("stale");
+      expect(runsById.get("preparing")?.state).toBe("stale");
+      expect(runsById.get("succeeded")?.state).toBe("succeeded");
+      expect(runsById.get("failed")?.state).toBe("failed");
+      expect(store.listActiveRunIds()).toEqual([]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("markLeakedRunsAsStale is idempotent on a clean database", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      expect(store.markLeakedRunsAsStale()).toEqual([]);
+    } finally {
+      store.close();
+    }
+  });
+
   it("createCapReachedFailureRun inserts a synthetic failed continuation row", async () => {
     const root = await makeTempRoot();
     const store = openRunStore({ stateRoot: root });

--- a/tests/stale-claims.test.ts
+++ b/tests/stale-claims.test.ts
@@ -285,6 +285,51 @@ describe("detectStaleClaims", () => {
     });
   });
 
+  it("does not mark when a retry is scheduled for the issue (registry empty, run-store row terminal)", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({ labels: ["agent-ready", "sym:claimed"] });
+      // Simulate transient-retry state: original run is unregistered and
+      // the run-store row has transitioned to 'failed' awaiting the next
+      // attempt. sym:claimed has been re-asserted by run-controller.
+      store.createRun({
+        id: "run-retry",
+        issue,
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      store.updateRunState("run-retry", "failed");
+
+      const registry = new ActiveRunRegistry();
+      registry.scheduleDelayed({
+        delayMs: 30_000,
+        fire: () => Promise.resolve(),
+        issueNumber: issue.number,
+        kind: "retry",
+        projectName: project.name,
+        runId: "run-retry"
+      });
+
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+      const marks = await detectStaleClaims({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).not.toHaveBeenCalled();
+      expect(marks).toEqual([]);
+      registry.cancelAll();
+    });
+  });
+
   it("does not mark when run-store reports an active run for the issue", async () => {
     await withRunStore(async (store) => {
       const issue = snapshot({ labels: ["agent-ready", "sym:claimed"] });

--- a/tests/stale-claims.test.ts
+++ b/tests/stale-claims.test.ts
@@ -1,0 +1,410 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import pino from "pino";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  emptyIssuePollStatus,
+  type IssuePollStatus,
+  type IssueSnapshot,
+  type PollingProjectConfig
+} from "../src/issue-polling.js";
+import { ActiveRunRegistry } from "../src/lifecycle/active-runs.js";
+import { detectStaleClaims } from "../src/lifecycle/stale-claims.js";
+import { openRunStore, type RunStore } from "../src/run-store.js";
+
+const logger = pino({ enabled: false });
+
+const project: PollingProjectConfig = {
+  agent: { provider: "codex" },
+  issue_filters: {
+    labels_all: ["agent-ready"],
+    labels_none: ["blocked", "needs-human"],
+    states: ["open"]
+  },
+  name: "symphonika",
+  priority: { default: 99, labels: {} },
+  tracker: {
+    kind: "github",
+    owner: "pmatos",
+    repo: "symphonika",
+    token: "$GITHUB_TOKEN"
+  }
+};
+
+function snapshot(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    body: "",
+    created_at: "2025-01-01T00:00:00Z",
+    id: 1,
+    labels: ["agent-ready"],
+    number: 7,
+    priority: 1,
+    state: "open",
+    title: "fixture",
+    updated_at: "2025-01-01T00:00:00Z",
+    url: "https://example/7",
+    ...overrides
+  };
+}
+
+async function withRunStore<T>(fn: (store: RunStore) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-stale-claims-store-"));
+  const store = openRunStore({ stateRoot: root });
+  try {
+    return await fn(store);
+  } finally {
+    store.close();
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+function pollStatusWithFiltered(issues: IssueSnapshot[]): IssuePollStatus {
+  const status = emptyIssuePollStatus();
+  status.filteredIssues = issues.map((issue) => ({
+    issue,
+    project: project.name,
+    reasons: ["fixture-filtered"]
+  }));
+  return status;
+}
+
+describe("detectStaleClaims", () => {
+  it("scopes liveness checks per project when issue numbers collide", async () => {
+    await withRunStore(async (store) => {
+      const projectB: PollingProjectConfig = {
+        ...project,
+        name: "other",
+        tracker: { ...project.tracker, owner: "other-owner", repo: "other-repo" }
+      };
+      const issueLive = snapshot({
+        labels: ["agent-ready", "sym:claimed"],
+        number: 42,
+        url: "https://example/p1/42"
+      });
+      const issueOrphan = snapshot({
+        labels: ["agent-ready", "sym:claimed"],
+        number: 42,
+        url: "https://example/p2/42"
+      });
+
+      const status = emptyIssuePollStatus();
+      status.filteredIssues = [
+        { issue: issueLive, project: project.name, reasons: ["fixture"] },
+        { issue: issueOrphan, project: projectB.name, reasons: ["fixture"] }
+      ];
+
+      const registry = new ActiveRunRegistry();
+      registry.register({
+        cancel: () => Promise.resolve(),
+        issueNumber: 42,
+        projectName: project.name,
+        runId: "run-live"
+      });
+
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+
+      const marks = await detectStaleClaims({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: status,
+        projects: new Map([
+          [project.name, project],
+          [projectB.name, projectB]
+        ]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).toHaveBeenCalledTimes(1);
+      expect(addLabelsToIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "other-owner",
+          repo: "other-repo",
+          issueNumber: 42
+        })
+      );
+      expect(marks).toEqual([{ project: projectB.name, issueNumber: 42 }]);
+    });
+  });
+
+  it("skips when githubIssuesApi.addLabelsToIssue is undefined", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({ labels: ["agent-ready", "sym:claimed"] });
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(marks).toEqual([]);
+    });
+  });
+
+  it("skips when the project tracker token env var is unset", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({ labels: ["agent-ready", "sym:claimed"] });
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: {},
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).not.toHaveBeenCalled();
+      expect(marks).toEqual([]);
+    });
+  });
+
+  it("continues processing other issues when addLabelsToIssue throws", async () => {
+    await withRunStore(async (store) => {
+      const issueA = snapshot({
+        labels: ["agent-ready", "sym:claimed"],
+        number: 11,
+        url: "https://example/11"
+      });
+      const issueB = snapshot({
+        labels: ["agent-ready", "sym:claimed"],
+        number: 12,
+        url: "https://example/12"
+      });
+      const addLabelsToIssue = vi
+        .fn()
+        .mockImplementationOnce(() => Promise.reject(new Error("boom")))
+        .mockResolvedValueOnce(undefined);
+
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issueA, issueB]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).toHaveBeenCalledTimes(2);
+      expect(marks).toEqual([{ project: project.name, issueNumber: 12 }]);
+    });
+  });
+
+  it("does not mark issues that have only sym:failed (no claim/running)", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({ labels: ["agent-ready", "sym:failed"] });
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).not.toHaveBeenCalled();
+      expect(marks).toEqual([]);
+    });
+  });
+
+  it("does not mark issues whose state is closed", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({
+        labels: ["agent-ready", "sym:claimed"],
+        state: "closed"
+      });
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).not.toHaveBeenCalled();
+      expect(marks).toEqual([]);
+    });
+  });
+
+  it("does not re-mark issues that already carry sym:stale", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({
+        labels: ["agent-ready", "sym:claimed", "sym:stale"]
+      });
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).not.toHaveBeenCalled();
+      expect(marks).toEqual([]);
+    });
+  });
+
+  it("does not mark when run-store reports an active run for the issue", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({ labels: ["agent-ready", "sym:claimed"] });
+      store.createRun({
+        id: "run-store-only",
+        issue,
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).not.toHaveBeenCalled();
+      expect(marks).toEqual([]);
+    });
+  });
+
+  it("does not mark when an in-memory run is registered for the issue", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({ labels: ["agent-ready", "sym:claimed"] });
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+      const registry = new ActiveRunRegistry();
+      registry.register({
+        cancel: () => Promise.resolve(),
+        issueNumber: issue.number,
+        projectName: project.name,
+        runId: "run-live"
+      });
+
+      const marks = await detectStaleClaims({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).not.toHaveBeenCalled();
+      expect(marks).toEqual([]);
+    });
+  });
+
+  it("marks an issue with sym:running and no live run as sym:stale", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({
+        labels: ["agent-ready", "sym:running"],
+        number: 8,
+        url: "https://example/8"
+      });
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issueNumber: 8,
+          labels: ["sym:stale"]
+        })
+      );
+      expect(marks).toEqual([{ project: project.name, issueNumber: 8 }]);
+    });
+  });
+
+  it("marks an issue with sym:claimed and no live run as sym:stale", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({
+        labels: ["agent-ready", "sym:claimed"]
+      });
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).toHaveBeenCalledWith({
+        issueNumber: 7,
+        labels: ["sym:stale"],
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret"
+      });
+      expect(marks).toEqual([{ project: project.name, issueNumber: 7 }]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #12.

- Detect GitHub issues that carry `sym:claimed` or `sym:running` but have no live local run, mark them `sym:stale`, and exclude them from eligibility (already enforced via `REQUIRED_OPERATIONAL_LABELS`; verification test added).
- New `clear-stale <project> <issue-number>` CLI command removes `sym:stale` and `sym:claimed` only after `--yes` (per SPEC §13 and ADR-0038); 404 from GitHub is treated as success.
- Daemon now sweeps leaked run-store rows into `RunState='stale'` at startup, and runs the stale-claim detector after every reconcile (skipped while `dispatchMutex` is held to close the claim-label/registry race window).
- `doctor` and `/api/status` both surface stale issues — `doctor` lists per-project entries after the OK summary; `/api/status` exposes a derived `staleIssues` array.
- `resolveToken` extracted to `src/lifecycle/token.ts` so reconcile and the new stale detector share one helper.

## Acceptance criteria

- [x] Startup reconciliation detects claimed/running labels without a live local run
- [x] Detected stale claims are marked with `sym:stale`
- [x] Stale issues are excluded from eligibility (regression test added)
- [x] `doctor` and status output report stale issues clearly
- [x] `clear-stale` requires confirmation before removing `sym:stale` and `sym:claimed`
- [x] No TTL auto-clear behavior in v1
- [x] Tests cover detection, label updates, eligibility blocking, confirmed clearing, and refusal without confirmation

## Test plan

- [x] `npm test` — 138/138 pass (was 112 before; +26 tests)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Manual: run `symphonika daemon` against a repo with an orphaned `sym:claimed` issue and verify `sym:stale` appears
- [ ] Manual: run `symphonika clear-stale <project> <issue>` without `--yes` and verify it warns + exits non-zero
- [ ] Manual: run `symphonika clear-stale <project> <issue> --yes` and verify both labels are removed
- [ ] Manual: run `symphonika doctor` and verify the stale-issues section appears after the OK summary