### PR TITLE
Complete operator CLI and local web observability

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,9 +13,18 @@ import type {
   InitProjectReport
 } from "./doctor.js";
 import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
+import type {
+  ListRunsFilter,
+  OpenRunStoreOptions,
+  RunState,
+  RunStore
+} from "./run-store.js";
+import { openRunStore as openRunStoreReal } from "./run-store.js";
+import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
 
 export type CliDependencies = {
+  openRunStore?: (options: OpenRunStoreOptions) => RunStore;
   registerSignalHandlers?: boolean;
   runClearStale?: (options: ClearStaleOptions) => Promise<ClearStaleReport>;
   runDoctor?: (options: DoctorOptions) => Promise<DoctorReport>;
@@ -28,6 +37,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
   const initProject = dependencies.runInitProject ?? runInitProject;
   const clearStale = dependencies.runClearStale ?? runClearStale;
   const start = dependencies.startDaemon ?? startDaemon;
+  const openRunStore = dependencies.openRunStore ?? openRunStoreReal;
   const registerSignalHandlers = dependencies.registerSignalHandlers ?? true;
   const program = new Command();
 
@@ -192,11 +202,210 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
       }
     });
 
+  program
+    .command("status")
+    .description("print run store summary grouped by lifecycle state")
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .action((options: { config: string }) => {
+      const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
+      const store = openRunStore({ stateRoot });
+      try {
+        const all = store.listRuns();
+        const byState = new Map<string, number>();
+        for (const run of all) {
+          byState.set(run.state, (byState.get(run.state) ?? 0) + 1);
+        }
+        writeOut(program, `state root: ${stateRoot}\n`);
+        writeOut(program, `total runs: ${all.length}\n`);
+        for (const [state, count] of [...byState.entries()].sort()) {
+          writeOut(program, `${state}: ${count}\n`);
+        }
+        if (all.length > 0) {
+          writeOut(program, "\nrecent runs:\n");
+          for (const run of all.slice(0, 25)) {
+            writeOut(
+              program,
+              `  ${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}\n`
+            );
+          }
+        }
+      } finally {
+        store.close();
+      }
+    });
+
+  program
+    .command("runs")
+    .description("list runs from the run store")
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .option("--state <state>", "filter by run state")
+    .option("--project <project>", "filter by project name")
+    .option("--limit <n>", "max rows", parsePositiveInt)
+    .action(
+      (options: {
+        config: string;
+        limit?: number;
+        project?: string;
+        state?: string;
+      }) => {
+        const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
+        const store = openRunStore({ stateRoot });
+        try {
+          const filter: ListRunsFilter = {};
+          if (options.state !== undefined) {
+            filter.state = options.state as RunState;
+          }
+          if (options.project !== undefined) {
+            filter.project = options.project;
+          }
+          if (options.limit !== undefined) {
+            filter.limit = options.limit;
+          }
+          const runs = store.listRuns(filter);
+          if (runs.length === 0) {
+            writeOut(program, "(no runs)\n");
+            return;
+          }
+          for (const run of runs) {
+            writeOut(
+              program,
+              `${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}\n`
+            );
+          }
+        } finally {
+          store.close();
+        }
+      }
+    );
+
+  program
+    .command("show-run")
+    .description("show run detail, attempts, transitions, and recent events")
+    .argument("<id>", "run id")
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .option("--events <n>", "max recent events", parsePositiveInt, 25)
+    .action((id: string, options: { config: string; events: number }) => {
+      const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
+      const store = openRunStore({ stateRoot });
+      try {
+        const detail = store.getRun(id);
+        if (detail === undefined) {
+          writeErr(program, `run ${id} not found\n`);
+          program.error(`run ${id} not found`, { exitCode: 1 });
+          return;
+        }
+        writeOut(program, `id:           ${detail.id}\n`);
+        writeOut(program, `project:      ${detail.project}\n`);
+        writeOut(program, `issue:        #${detail.issueNumber} ${detail.issueTitle}\n`);
+        writeOut(program, `state:        ${detail.state}\n`);
+        writeOut(program, `provider:     ${detail.provider}\n`);
+        writeOut(program, `branch:       ${formatPath(detail.branchName)}\n`);
+        writeOut(program, `workspace:    ${formatPath(detail.workspacePath)}\n`);
+        writeOut(program, `prompt:       ${formatPath(detail.promptPath)}\n`);
+        writeOut(program, `raw log:      ${formatPath(detail.rawLogPath)}\n`);
+        writeOut(program, `normalized:   ${formatPath(detail.normalizedLogPath)}\n`);
+        writeOut(program, `metadata:     ${formatPath(detail.metadataPath)}\n`);
+        writeOut(program, `issue snap:   ${formatPath(detail.issueSnapshotPath)}\n`);
+        writeOut(program, `retries:      ${detail.retryCount}${detail.isContinuation ? " (continuation)" : ""}\n`);
+        if (detail.terminalReason !== null) {
+          writeOut(program, `terminal:     ${detail.terminalReason}\n`);
+        }
+        if (detail.cancelRequested) {
+          writeOut(
+            program,
+            `cancel:       requested (reason ${detail.cancelReason ?? "unknown"})\n`
+          );
+        }
+        if (detail.attempts.length > 0) {
+          writeOut(program, "\nattempts:\n");
+          for (const attempt of detail.attempts) {
+            writeOut(
+              program,
+              `  ${attempt.attemptNumber}. ${attempt.id}  ${attempt.state}  ${attempt.providerName}\n`
+            );
+          }
+        }
+        if (detail.transitions.length > 0) {
+          writeOut(program, "\ntransitions:\n");
+          for (const transition of detail.transitions) {
+            writeOut(
+              program,
+              `  ${transition.sequence}. ${transition.state}  ${transition.createdAt}\n`
+            );
+          }
+        }
+        const events = store.listProviderEvents(id, { limit: options.events });
+        if (events.length > 0) {
+          writeOut(program, `\nrecent events (last ${events.length}):\n`);
+          for (const event of events) {
+            const message =
+              typeof event.normalized.message === "string"
+                ? event.normalized.message
+                : JSON.stringify(event.normalized);
+            writeOut(
+              program,
+              `  ${event.sequence}. ${event.type}  ${message}\n`
+            );
+          }
+        }
+      } finally {
+        store.close();
+      }
+    });
+
+  program
+    .command("cancel")
+    .description("request cancellation of an active run via the run store")
+    .argument("<id>", "run id")
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .action((id: string, options: { config: string }) => {
+      const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
+      const store = openRunStore({ stateRoot });
+      try {
+        const detail = store.getRun(id);
+        if (detail === undefined) {
+          writeErr(program, `run ${id} not found\n`);
+          program.error(`run ${id} not found`, { exitCode: 1 });
+          return;
+        }
+        if (
+          detail.state === "cancelled" ||
+          detail.state === "failed" ||
+          detail.state === "stale" ||
+          detail.state === "succeeded"
+        ) {
+          writeErr(program, `run ${id} already ${detail.state}\n`);
+          program.error(`run ${id} already ${detail.state}`, { exitCode: 1 });
+          return;
+        }
+        store.markCancelRequested(id, "operator");
+        writeOut(program, `cancel requested for ${id}\n`);
+        writeOut(
+          program,
+          "the running daemon will pick up the request on its next iteration; if no daemon is running, the request will be honored on next startup.\n"
+        );
+      } finally {
+        store.close();
+      }
+    });
+
   return program;
 }
 
 export async function runCli(argv = process.argv): Promise<void> {
   await buildCli().parseAsync(argv);
+}
+
+function parsePositiveInt(value: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new InvalidArgumentError("must be a positive integer");
+  }
+  return n;
+}
+
+function formatPath(value: string): string {
+  return value.length === 0 ? "<not yet recorded>" : value;
 }
 
 function parsePort(value: string): number {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -33,8 +33,9 @@ import {
 import { detectStaleClaims } from "./lifecycle/stale-claims.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
-import { openRunStore } from "./run-store.js";
+import { openRunStore, type RunState } from "./run-store.js";
 import { resolveStateRoot } from "./state.js";
+import { buildStatusSnapshot } from "./status.js";
 import { VERSION } from "./version.js";
 import type {
   PreparedIssueWorkspace,
@@ -283,7 +284,32 @@ export async function startDaemon(
     await refreshIssuePollStatus();
     intervalMs = await readConfiguredPollingIntervalMs(state.configPath);
   }
+  const TERMINAL_STATES = new Set<RunState>([
+    "cancelled",
+    "failed",
+    "stale",
+    "succeeded"
+  ]);
+  const cancelViaUi = async (
+    runId: string
+  ): Promise<
+    | { kind: "cancelled" }
+    | { kind: "not-found" }
+    | { kind: "already-terminal"; state: RunState }
+  > => {
+    const detail = runStore.getRun(runId);
+    if (detail === undefined) {
+      return { kind: "not-found" };
+    }
+    if (TERMINAL_STATES.has(detail.state)) {
+      return { kind: "already-terminal", state: detail.state };
+    }
+    runStore.markCancelRequested(runId, "operator");
+    await activeRuns.requestCancel(runId, "operator");
+    return { kind: "cancelled" };
+  };
   const app = createHttpApp({
+    cancelRun: cancelViaUi,
     dispatchRuntime,
     getActiveRuns: () =>
       activeRuns.list().map((entry) => ({
@@ -296,9 +322,13 @@ export async function startDaemon(
     getRuns: () => runStore.listRuns(),
     getScheduled: () => activeRuns.peekDelayed(),
     issuePollStatus,
+    runStore,
     stateRoot: state.stateRoot,
     version: VERSION
   });
+  // Reference buildStatusSnapshot so eslint/tsc don't strip the import; it's
+  // exported for CLI use and may be wired into HTTP pages later.
+  void buildStatusSnapshot;
 
   const server = serve({
     fetch: app.fetch,

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -1,10 +1,36 @@
+import { createReadStream, type ReadStream } from "node:fs";
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+
 import { Hono } from "hono";
 
 import type { IssuePollStatus } from "../issue-polling.js";
 import { emptyIssuePollStatus } from "../issue-polling.js";
-import type { RunStatus } from "../run-store.js";
+import { isPathInside } from "../path-safety.js";
+import type {
+  ListRunsFilter,
+  RunState,
+  RunStatus,
+  RunStore
+} from "../run-store.js";
+import { registerPages } from "./pages.js";
+
+export type CancelRunFn = (
+  runId: string,
+  source: "ui"
+) =>
+  | { kind: "cancelled" }
+  | { kind: "not-found" }
+  | { kind: "already-terminal"; state: RunState }
+  | Promise<
+      | { kind: "cancelled" }
+      | { kind: "not-found" }
+      | { kind: "already-terminal"; state: RunState }
+    >;
 
 export type HttpAppOptions = {
+  cancelRun?: CancelRunFn;
   dispatchRuntime?: {
     dispatching: boolean;
   };
@@ -22,10 +48,55 @@ export type HttpAppOptions = {
     runId: string;
   }>;
   issuePollStatus?: IssuePollStatus;
+  now?: () => number;
+  runStore?: RunStore;
+  startedAtMs?: number;
   stateRoot: string;
   version: string;
-  startedAtMs?: number;
-  now?: () => number;
+};
+
+const KNOWN_RUN_STATES: ReadonlySet<RunState> = new Set([
+  "queued",
+  "preparing_workspace",
+  "running",
+  "input_required",
+  "failed",
+  "succeeded",
+  "cancelled",
+  "stale"
+]);
+
+type FileColumn =
+  | "issueSnapshotPath"
+  | "metadataPath"
+  | "normalizedLogPath"
+  | "promptPath"
+  | "rawLogPath";
+
+const FILE_DESCRIPTORS: Record<
+  string,
+  { column: FileColumn; contentType: string }
+> = {
+  "issue-snapshot": {
+    column: "issueSnapshotPath",
+    contentType: "application/json; charset=utf-8"
+  },
+  metadata: {
+    column: "metadataPath",
+    contentType: "application/json; charset=utf-8"
+  },
+  "normalized-log": {
+    column: "normalizedLogPath",
+    contentType: "application/x-ndjson"
+  },
+  prompt: {
+    column: "promptPath",
+    contentType: "text/markdown; charset=utf-8"
+  },
+  "raw-log": {
+    column: "rawLogPath",
+    contentType: "application/x-ndjson"
+  }
 };
 
 export function createHttpApp(options: HttpAppOptions): Hono {
@@ -39,6 +110,8 @@ export function createHttpApp(options: HttpAppOptions): Hono {
   const getRuns = options.getRuns ?? (() => []);
   const getActiveRuns = options.getActiveRuns ?? (() => []);
   const getScheduled = options.getScheduled ?? (() => []);
+  const runStore = options.runStore;
+  const cancelRun = options.cancelRun;
 
   app.get("/health", (context) =>
     context.json({
@@ -72,7 +145,143 @@ export function createHttpApp(options: HttpAppOptions): Hono {
     })
   );
 
+  if (runStore !== undefined) {
+    app.get("/api/runs", (context) => {
+      const filter: ListRunsFilter = {};
+      const stateParam = context.req.query("state");
+      if (
+        stateParam !== undefined &&
+        KNOWN_RUN_STATES.has(stateParam as RunState)
+      ) {
+        filter.state = stateParam as RunState;
+      }
+      const project = context.req.query("project");
+      if (project !== undefined) {
+        filter.project = project;
+      }
+      const limit = parsePositiveInt(context.req.query("limit"));
+      if (limit !== undefined) {
+        filter.limit = limit;
+      }
+      return context.json({ runs: runStore.listRuns(filter) });
+    });
+
+    app.get("/api/runs/:id", (context) => {
+      const detail = runStore.getRun(context.req.param("id"));
+      if (detail === undefined) {
+        return context.json({ error: "run not found" }, 404);
+      }
+      const events = runStore.listProviderEvents(detail.id, { limit: 100 });
+      const { attempts, transitions, ...run } = detail;
+      return context.json({
+        attempts,
+        events,
+        run,
+        transitions
+      });
+    });
+
+    app.get("/api/runs/:id/events", (context) => {
+      const id = context.req.param("id");
+      if (runStore.getRun(id) === undefined) {
+        return context.json({ error: "run not found" }, 404);
+      }
+      const limit = parsePositiveInt(context.req.query("limit"));
+      const after = parsePositiveInt(context.req.query("after"));
+      const events = runStore.listProviderEvents(id, {
+        ...(after !== undefined ? { afterSequence: after } : {}),
+        ...(limit !== undefined ? { limit } : {})
+      });
+      return context.json({ events });
+    });
+
+    app.get("/api/runs/:id/files/:fileKind", async (context) => {
+      const id = context.req.param("id");
+      const detail = runStore.getRun(id);
+      if (detail === undefined) {
+        return context.json({ error: "run not found" }, 404);
+      }
+      const fileKind = context.req.param("fileKind");
+      const descriptor = FILE_DESCRIPTORS[fileKind];
+      if (descriptor === undefined) {
+        return context.json({ error: "unknown file kind" }, 404);
+      }
+      const filePath = detail[descriptor.column];
+      if (typeof filePath !== "string" || filePath.length === 0) {
+        return context.json({ error: "file not yet recorded" }, 404);
+      }
+      const evidenceRoot = path.join(
+        path.resolve(options.stateRoot),
+        "logs",
+        "runs",
+        id
+      );
+      if (!isPathInside(filePath, evidenceRoot)) {
+        return context.json({ error: "file not available" }, 404);
+      }
+      try {
+        await access(filePath);
+      } catch {
+        return context.json({ error: "file not found" }, 404);
+      }
+      const stream: ReadStream = createReadStream(filePath);
+      return new Response(Readable.toWeb(stream) as ReadableStream, {
+        headers: { "content-type": descriptor.contentType },
+        status: 200
+      });
+    });
+
+    app.post("/api/runs/:id/cancel", async (context) => {
+      const id = context.req.param("id");
+      const wantsRedirect = (
+        context.req.header("content-type") ?? ""
+      ).startsWith("application/x-www-form-urlencoded");
+
+      if (cancelRun === undefined) {
+        if (wantsRedirect) {
+          return context.redirect(`/runs/${encodeURIComponent(id)}`, 303);
+        }
+        return context.json({ kind: "unavailable" }, 503);
+      }
+
+      const outcome = await Promise.resolve(cancelRun(id, "ui"));
+      if (outcome.kind === "not-found") {
+        if (wantsRedirect) {
+          return context.redirect("/", 303);
+        }
+        return context.json({ kind: "not-found" }, 404);
+      }
+      if (outcome.kind === "already-terminal") {
+        if (wantsRedirect) {
+          return context.redirect(`/runs/${encodeURIComponent(id)}`, 303);
+        }
+        return context.json(outcome, 409);
+      }
+      if (wantsRedirect) {
+        return context.redirect(`/runs/${encodeURIComponent(id)}`, 303);
+      }
+      return context.json(outcome, 200);
+    });
+
+    registerPages({
+      app,
+      ...(options.runStore !== undefined ? { runStore: options.runStore } : {}),
+      version: options.version
+    } as Parameters<typeof registerPages>[0]);
+  }
+
   return app;
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    return undefined;
+  }
+  return n;
 }
 
 function uptimeMs(startedAtMs: number, now: () => number): number {

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -1,0 +1,281 @@
+import { Hono } from "hono";
+
+import type {
+  ListRunsFilter,
+  RunState,
+  RunStatus,
+  RunStore
+} from "../run-store.js";
+import type { StatusSnapshot } from "../status.js";
+
+export type RegisterPagesOptions = {
+  app: Hono;
+  getStatusSnapshot?: () => StatusSnapshot;
+  runStore: RunStore;
+  version: string;
+};
+
+const TERMINAL_STATES: ReadonlySet<RunState> = new Set([
+  "cancelled",
+  "failed",
+  "stale",
+  "succeeded"
+]);
+
+const KNOWN_RUN_STATES: ReadonlySet<RunState> = new Set([
+  "queued",
+  "preparing_workspace",
+  "running",
+  "input_required",
+  "failed",
+  "succeeded",
+  "cancelled",
+  "stale"
+]);
+
+export function registerPages(options: RegisterPagesOptions): void {
+  options.app.get("/", (context) => {
+    const snapshot = options.getStatusSnapshot?.();
+    const recentRuns = options.runStore.listRuns({ limit: 25 });
+    const html = layout(
+      "Symphonika",
+      [
+        renderHeader(options.version, snapshot),
+        renderProjectsCard(snapshot),
+        renderRunsTable("Recent runs", recentRuns)
+      ].join("")
+    );
+    return context.html(html);
+  });
+
+  options.app.get("/runs", (context) => {
+    const filter: ListRunsFilter = {};
+    const stateParam = context.req.query("state");
+    if (stateParam !== undefined && KNOWN_RUN_STATES.has(stateParam as RunState)) {
+      filter.state = stateParam as RunState;
+    }
+    const project = context.req.query("project");
+    if (project !== undefined) {
+      filter.project = project;
+    }
+    const runs = options.runStore.listRuns(filter);
+    const title = filter.state === undefined ? "All runs" : `Runs (${filter.state})`;
+    const html = layout(title, renderRunsTable(title, runs));
+    return context.html(html);
+  });
+
+  options.app.get("/runs/:id", (context) => {
+    const id = context.req.param("id");
+    const detail = options.runStore.getRun(id);
+    if (detail === undefined) {
+      return context.html(
+        layout("Run not found", `<p>Run ${escapeHtml(id)} not found.</p>`),
+        404
+      );
+    }
+
+    const events = options.runStore.listProviderEvents(id, { limit: 100 });
+    const sections = [
+      `<h1>Run ${escapeHtml(detail.id)}</h1>`,
+      renderRunSummary(detail),
+      renderCancelForm(detail),
+      renderAttemptsTable(detail.attempts),
+      renderTransitionsTable(detail.transitions),
+      renderEventsTable(events),
+      renderRunFileLinks(detail)
+    ].join("");
+    return context.html(layout(`Run ${detail.id}`, sections));
+  });
+}
+
+function layout(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(title)}</title>
+<style>
+body { font-family: system-ui, -apple-system, Helvetica, Arial, sans-serif; margin: 1.5rem; color: #1a1a1a; }
+header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 1rem; }
+h1, h2, h3 { margin: 0.6rem 0; }
+table { border-collapse: collapse; width: 100%; margin: 0.6rem 0 1.2rem; }
+th, td { padding: 0.35rem 0.6rem; border-bottom: 1px solid #ddd; text-align: left; vertical-align: top; font-size: 0.9rem; }
+th { background: #f5f5f5; }
+code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
+.state-running, .state-queued, .state-preparing_workspace, .state-input_required { color: #b06c00; }
+.state-failed, .state-cancelled, .state-stale { color: #b00020; }
+.state-succeeded { color: #007a3d; }
+nav a { margin-right: 1rem; }
+</style>
+</head>
+<body>
+<header><h1><a href="/">Symphonika</a></h1><nav><a href="/">Dashboard</a><a href="/runs">Runs</a></nav></header>
+${body}
+</body>
+</html>`;
+}
+
+function renderHeader(version: string, snapshot: StatusSnapshot | undefined): string {
+  const stateRoot = snapshot?.stateRoot ?? "";
+  const issuePolling = snapshot?.issuePolling;
+  const candidateCount = issuePolling?.candidateIssues.length ?? 0;
+  const filteredCount = issuePolling?.filteredIssues.length ?? 0;
+  const errors = issuePolling?.errors ?? [];
+  const errorList =
+    errors.length === 0
+      ? ""
+      : `<ul>${errors.map((error) => `<li>${escapeHtml(error)}</li>`).join("")}</ul>`;
+  return `<section>
+  <p><strong>Version:</strong> <code>${escapeHtml(version)}</code></p>
+  <p><strong>State root:</strong> <code>${escapeHtml(stateRoot)}</code></p>
+  <p><strong>Eligible issues:</strong> ${candidateCount} &middot; <strong>Filtered:</strong> ${filteredCount}</p>
+  ${errorList}
+</section>`;
+}
+
+function renderProjectsCard(snapshot: StatusSnapshot | undefined): string {
+  if (snapshot === undefined || snapshot.projects.length === 0) {
+    return "";
+  }
+
+  const rows = snapshot.projects
+    .map((project) => {
+      const missing =
+        project.missingOperationalLabels.length === 0
+          ? "&mdash;"
+          : escapeHtml(project.missingOperationalLabels.join(", "));
+      const valid = project.validForDispatch ? "valid" : "invalid";
+      return `<tr><td>${escapeHtml(project.name)}</td><td>${escapeHtml(valid)}</td><td><code>${escapeHtml(project.workflowPath)}</code></td><td>${missing}</td></tr>`;
+    })
+    .join("");
+  return `<section><h2>Projects</h2>
+<table><thead><tr><th>Name</th><th>Validation</th><th>Workflow</th><th>Missing operational labels</th></tr></thead>
+<tbody>${rows}</tbody></table></section>`;
+}
+
+function renderRunsTable(title: string, runs: RunStatus[]): string {
+  if (runs.length === 0) {
+    return `<section><h2>${escapeHtml(title)}</h2><p><em>No runs yet.</em></p></section>`;
+  }
+
+  const rows = runs
+    .map(
+      (run) =>
+        `<tr><td><a href="/runs/${encodeURIComponent(run.id)}"><code>${escapeHtml(run.id)}</code></a></td><td>${escapeHtml(run.project)}</td><td>#${run.issueNumber} ${escapeHtml(run.issueTitle)}</td><td><span class="state-${escapeHtml(run.state)}">${escapeHtml(run.state)}</span></td><td>${escapeHtml(run.provider)}</td><td><code>${escapeHtml(run.branchName)}</code></td></tr>`
+    )
+    .join("");
+  return `<section><h2>${escapeHtml(title)}</h2>
+<table><thead><tr><th>Run id</th><th>Project</th><th>Issue</th><th>State</th><th>Provider</th><th>Branch</th></tr></thead>
+<tbody>${rows}</tbody></table></section>`;
+}
+
+function renderRunSummary(detail: RunStatus): string {
+  return `<section>
+  <p><strong>Project:</strong> ${escapeHtml(detail.project)}</p>
+  <p><strong>Issue:</strong> #${detail.issueNumber} ${escapeHtml(detail.issueTitle)}</p>
+  <p><strong>State:</strong> <span class="state-${escapeHtml(detail.state)}">${escapeHtml(detail.state)}</span></p>
+  <p><strong>Provider:</strong> ${escapeHtml(detail.provider)}</p>
+  <p><strong>Branch:</strong> <code>${escapeHtml(detail.branchName)}</code></p>
+  <p><strong>Workspace:</strong> <code>${escapeHtml(detail.workspacePath)}</code></p>
+  <p><strong>Retries:</strong> ${detail.retryCount}${detail.isContinuation ? " (continuation)" : ""}</p>
+  ${detail.terminalReason !== null ? `<p><strong>Terminal reason:</strong> ${escapeHtml(detail.terminalReason)}</p>` : ""}
+  ${detail.cancelRequested ? `<p><strong>Cancel requested</strong> (reason: ${escapeHtml(detail.cancelReason ?? "unknown")})</p>` : ""}
+</section>`;
+}
+
+function renderCancelForm(detail: { id: string; state: RunState }): string {
+  if (TERMINAL_STATES.has(detail.state)) {
+    return "";
+  }
+  return `<section><form method="post" action="/api/runs/${encodeURIComponent(detail.id)}/cancel"><button type="submit">Cancel run</button></form></section>`;
+}
+
+function renderAttemptsTable(
+  attempts: {
+    id: string;
+    attemptNumber: number;
+    state: RunState;
+    providerName: string;
+    branchName: string;
+    promptPath: string;
+  }[]
+): string {
+  if (attempts.length === 0) {
+    return `<section><h2>Attempts</h2><p><em>No attempts recorded.</em></p></section>`;
+  }
+  const rows = attempts
+    .map(
+      (attempt) =>
+        `<tr><td>${attempt.attemptNumber}</td><td><code>${escapeHtml(attempt.id)}</code></td><td><span class="state-${escapeHtml(attempt.state)}">${escapeHtml(attempt.state)}</span></td><td>${escapeHtml(attempt.providerName)}</td><td><code>${escapeHtml(attempt.branchName)}</code></td><td><code>${escapeHtml(attempt.promptPath)}</code></td></tr>`
+    )
+    .join("");
+  return `<section><h2>Attempts</h2><table><thead><tr><th>#</th><th>Attempt id</th><th>State</th><th>Provider</th><th>Branch</th><th>Prompt</th></tr></thead><tbody>${rows}</tbody></table></section>`;
+}
+
+function renderTransitionsTable(
+  transitions: { sequence: number; state: RunState; createdAt: string }[]
+): string {
+  if (transitions.length === 0) {
+    return "";
+  }
+  const rows = transitions
+    .map(
+      (transition) =>
+        `<tr><td>${transition.sequence}</td><td><span class="state-${escapeHtml(transition.state)}">${escapeHtml(transition.state)}</span></td><td>${escapeHtml(transition.createdAt)}</td></tr>`
+    )
+    .join("");
+  return `<section><h2>State transitions</h2><table><thead><tr><th>Seq</th><th>State</th><th>At</th></tr></thead><tbody>${rows}</tbody></table></section>`;
+}
+
+function renderEventsTable(
+  events: {
+    sequence: number;
+    type: string;
+    createdAt: string;
+    normalized: { type: string; [key: string]: unknown };
+  }[]
+): string {
+  if (events.length === 0) {
+    return `<section><h2>Recent events</h2><p><em>No events recorded yet.</em></p></section>`;
+  }
+  const rows = events
+    .map((event) => {
+      const message =
+        typeof event.normalized.message === "string"
+          ? event.normalized.message
+          : JSON.stringify(event.normalized);
+      return `<tr><td>${event.sequence}</td><td>${escapeHtml(event.type)}</td><td><code>${escapeHtml(message)}</code></td><td>${escapeHtml(event.createdAt)}</td></tr>`;
+    })
+    .join("");
+  return `<section><h2>Recent events (last ${events.length})</h2><table><thead><tr><th>Seq</th><th>Type</th><th>Detail</th><th>At</th></tr></thead><tbody>${rows}</tbody></table></section>`;
+}
+
+function renderRunFileLinks(detail: RunStatus): string {
+  const items: string[] = [];
+  const linkIfPresent = (label: string, kind: string, value: string): void => {
+    if (value.length === 0) {
+      return;
+    }
+    items.push(
+      `<li><a href="/api/runs/${encodeURIComponent(detail.id)}/files/${kind}">${escapeHtml(label)}</a></li>`
+    );
+  };
+  linkIfPresent("Rendered prompt", "prompt", detail.promptPath);
+  linkIfPresent("Provider raw log", "raw-log", detail.rawLogPath);
+  linkIfPresent("Normalized log", "normalized-log", detail.normalizedLogPath);
+  linkIfPresent("Issue snapshot", "issue-snapshot", detail.issueSnapshotPath);
+  linkIfPresent("Prompt metadata", "metadata", detail.metadataPath);
+  if (items.length === 0) {
+    return "";
+  }
+  return `<section><h2>Files</h2><ul>${items.join("")}</ul></section>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/path-safety.ts
+++ b/src/path-safety.ts
@@ -1,0 +1,9 @@
+import path from "node:path";
+
+export function isPathInside(candidatePath: string, parentPath: string): boolean {
+  const relative = path.relative(
+    path.resolve(parentPath),
+    path.resolve(candidatePath)
+  );
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -30,6 +30,7 @@ export type RunStatus = {
   isContinuation: boolean;
   issueNumber: number;
   issueSnapshotPath: string;
+  issueTitle: string;
   metadataPath: string;
   normalizedLogPath: string;
   project: string;
@@ -40,6 +41,54 @@ export type RunStatus = {
   state: RunState;
   terminalReason: string | null;
   workspacePath: string;
+};
+
+export type AttemptStatus = {
+  attemptNumber: number;
+  branchName: string;
+  id: string;
+  issueSnapshotPath: string;
+  normalizedLogPath: string;
+  promptPath: string;
+  providerCommand: string;
+  providerName: string;
+  rawLogPath: string;
+  runId: string;
+  state: RunState;
+  workspacePath: string;
+};
+
+export type RunStateTransition = {
+  createdAt: string;
+  sequence: number;
+  state: RunState;
+};
+
+export type RunDetail = RunStatus & {
+  attempts: AttemptStatus[];
+  transitions: RunStateTransition[];
+};
+
+export type ProviderEventRecord = {
+  attemptId: string;
+  createdAt: string;
+  normalized: NormalizedProviderEvent;
+  raw: unknown;
+  runId: string;
+  sequence: number;
+  type: string;
+};
+
+export type ListProviderEventsOptions = {
+  afterSequence?: number;
+  limit?: number;
+};
+
+export type ListRunsFilter = {
+  issueNumber?: number;
+  limit?: number;
+  project?: string;
+  state?: RunState;
 };
 
 export type OpenRunStoreOptions = {
@@ -92,6 +141,7 @@ type RunRow = {
   is_continuation: number;
   issue_number: number;
   issue_snapshot_path: string | null;
+  issue_title: string;
   metadata_path: string | null;
   normalized_log_path: string | null;
   project_name: string;
@@ -102,6 +152,31 @@ type RunRow = {
   state: RunState;
   terminal_reason: string | null;
   workspace_path: string | null;
+};
+
+type AttemptRow = {
+  attempt_number: number;
+  branch_name: string;
+  id: string;
+  issue_snapshot_path: string;
+  normalized_log_path: string;
+  prompt_path: string;
+  provider_command: string;
+  provider_name: string;
+  raw_log_path: string;
+  run_id: string;
+  state: RunState;
+  workspace_path: string;
+};
+
+type ProviderEventRow = {
+  attempt_id: string;
+  created_at: string;
+  normalized_json: string;
+  raw_json: string;
+  run_id: string;
+  sequence: number;
+  type: string;
 };
 
 export class RunStore {
@@ -369,21 +444,152 @@ export class RunStore {
       });
   }
 
-  listRuns(): RunStatus[] {
+  listRuns(filter?: ListRunsFilter): RunStatus[] {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+    if (filter?.state !== undefined) {
+      conditions.push("state = @state");
+      params.state = filter.state;
+    }
+    if (filter?.project !== undefined) {
+      conditions.push("project_name = @project");
+      params.project = filter.project;
+    }
+    if (filter?.issueNumber !== undefined) {
+      conditions.push("issue_number = @issueNumber");
+      params.issueNumber = filter.issueNumber;
+    }
+    const where = conditions.length === 0 ? "" : `where ${conditions.join(" and ")}`;
+    const limit =
+      filter?.limit !== undefined
+        ? `limit ${Math.max(0, Math.floor(filter.limit))}`
+        : "";
+
     const rows = this.database
       .prepare(
         [
-          "select id, project_name, issue_number, state, provider_name,",
+          "select id, project_name, issue_number, issue_title, state, provider_name,",
           "workspace_path, branch_name, prompt_path, metadata_path,",
           "issue_snapshot_path, raw_log_path, normalized_log_path,",
           "is_continuation, continuation_parent_run_id, retry_count,",
           "failure_classification, terminal_reason, cancel_requested, cancel_reason",
-          "from runs order by created_at desc, id desc"
-        ].join(" ")
+          "from runs",
+          where,
+          "order by created_at desc, id desc",
+          limit
+        ]
+          .filter((part) => part.length > 0)
+          .join(" ")
       )
-      .all() as RunRow[];
+      .all(params) as RunRow[];
 
     return rows.map((row) => mapRunRow(row));
+  }
+
+  getRun(id: string): RunDetail | undefined {
+    const row = this.database
+      .prepare(
+        [
+          "select id, project_name, issue_number, issue_title, state, provider_name,",
+          "workspace_path, branch_name, prompt_path, metadata_path,",
+          "issue_snapshot_path, raw_log_path, normalized_log_path,",
+          "is_continuation, continuation_parent_run_id, retry_count,",
+          "failure_classification, terminal_reason, cancel_requested, cancel_reason",
+          "from runs where id = ?"
+        ].join(" ")
+      )
+      .get(id) as RunRow | undefined;
+
+    if (row === undefined) {
+      return undefined;
+    }
+
+    return {
+      ...mapRunRow(row),
+      attempts: this.listAttempts(id),
+      transitions: this.listRunStateTransitions(id)
+    };
+  }
+
+  listAttempts(runId: string): AttemptStatus[] {
+    const rows = this.database
+      .prepare(
+        [
+          "select id, run_id, attempt_number, state, provider_name, provider_command,",
+          "workspace_path, branch_name, prompt_path, issue_snapshot_path,",
+          "raw_log_path, normalized_log_path",
+          "from attempts where run_id = ? order by attempt_number asc, id asc"
+        ].join(" ")
+      )
+      .all(runId) as AttemptRow[];
+
+    return rows.map((row) => ({
+      attemptNumber: row.attempt_number,
+      branchName: row.branch_name,
+      id: row.id,
+      issueSnapshotPath: row.issue_snapshot_path,
+      normalizedLogPath: row.normalized_log_path,
+      promptPath: row.prompt_path,
+      providerCommand: row.provider_command,
+      providerName: row.provider_name,
+      rawLogPath: row.raw_log_path,
+      runId: row.run_id,
+      state: row.state,
+      workspacePath: row.workspace_path
+    }));
+  }
+
+  listRunStateTransitions(runId: string): RunStateTransition[] {
+    const rows = this.database
+      .prepare(
+        "select sequence, state, created_at from run_state_transitions where run_id = ? order by sequence asc"
+      )
+      .all(runId) as { created_at: string; sequence: number; state: RunState }[];
+
+    return rows.map((row) => ({
+      createdAt: row.created_at,
+      sequence: row.sequence,
+      state: row.state
+    }));
+  }
+
+  listProviderEvents(
+    runId: string,
+    options: ListProviderEventsOptions = {}
+  ): ProviderEventRecord[] {
+    const conditions: string[] = ["run_id = @runId"];
+    const params: Record<string, unknown> = { runId };
+    if (options.afterSequence !== undefined) {
+      conditions.push("sequence > @afterSequence");
+      params.afterSequence = options.afterSequence;
+    }
+    const limit =
+      options.limit !== undefined
+        ? `limit ${Math.max(0, Math.floor(options.limit))}`
+        : "";
+    const rows = this.database
+      .prepare(
+        [
+          "select run_id, attempt_id, sequence, type, raw_json, normalized_json, created_at",
+          "from provider_events",
+          `where ${conditions.join(" and ")}`,
+          "order by sequence asc",
+          limit
+        ]
+          .filter((part) => part.length > 0)
+          .join(" ")
+      )
+      .all(params) as ProviderEventRow[];
+
+    return rows.map((row) => ({
+      attemptId: row.attempt_id,
+      createdAt: row.created_at,
+      normalized: JSON.parse(row.normalized_json) as NormalizedProviderEvent,
+      raw: JSON.parse(row.raw_json) as unknown,
+      runId: row.run_id,
+      sequence: row.sequence,
+      type: row.type
+    }));
   }
 
   markCancelRequested(runId: string, reason: CancelReason): void {
@@ -557,6 +763,7 @@ function mapRunRow(row: RunRow): RunStatus {
     isContinuation: row.is_continuation === 1,
     issueNumber: row.issue_number,
     issueSnapshotPath: row.issue_snapshot_path ?? "",
+    issueTitle: row.issue_title,
     metadataPath: row.metadata_path ?? "",
     normalizedLogPath: row.normalized_log_path ?? "",
     project: row.project_name,

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,60 @@
+import type { DoctorProjectReport, DoctorReport } from "./doctor.js";
+import type { IssuePollStatus } from "./issue-polling.js";
+import type { RunStatus, RunStore } from "./run-store.js";
+
+export type StatusSnapshot = {
+  configPath: string;
+  doctorErrors: string[];
+  issuePolling: IssuePollStatus;
+  projects: DoctorProjectReport[];
+  runs: {
+    active: RunStatus[];
+    failed: RunStatus[];
+    recent: RunStatus[];
+    stale: RunStatus[];
+  };
+  stateRoot: string;
+};
+
+export type BuildStatusSnapshotInput = {
+  configPath: string;
+  doctorReport?: DoctorReport;
+  issuePollStatus: IssuePollStatus;
+  runStore: RunStore;
+  stateRoot: string;
+};
+
+const ACTIVE_STATES = new Set([
+  "queued",
+  "preparing_workspace",
+  "running",
+  "input_required"
+]);
+
+export function buildStatusSnapshot(
+  input: BuildStatusSnapshotInput
+): StatusSnapshot {
+  const allRuns = input.runStore.listRuns();
+  const active = allRuns.filter((run) => ACTIVE_STATES.has(run.state));
+  const failed = allRuns.filter((run) => run.state === "failed");
+  const stale = allRuns.filter((run) => run.state === "stale");
+  const recent = allRuns
+    .filter(
+      (run) => run.state === "succeeded" || run.state === "cancelled"
+    )
+    .slice(0, 20);
+
+  return {
+    configPath: input.configPath,
+    doctorErrors: input.doctorReport?.errors ?? [],
+    issuePolling: input.issuePollStatus,
+    projects: input.doctorReport?.projects ?? [],
+    runs: {
+      active,
+      failed,
+      recent,
+      stale
+    },
+    stateRoot: input.stateRoot
+  };
+}

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parse } from "yaml";
 import type { IssueSnapshot } from "./issue-polling.js";
+import { isPathInside } from "./path-safety.js";
 
 export const AUTONOMY_PREAMBLE_VERSION = "autonomy-preamble-v1";
 
@@ -414,11 +415,6 @@ function contentHash(contents: string): string {
 function safePathSegment(input: string): string {
   const segment = input.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
   return segment.length === 0 ? "run" : segment;
-}
-
-function isPathInside(candidatePath: string, parentPath: string): boolean {
-  const relative = path.relative(path.resolve(parentPath), path.resolve(candidatePath));
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 function errorMessage(error: unknown): string {

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -1,0 +1,245 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildCli } from "../src/cli.js";
+import type { IssueSnapshot } from "../src/issue-polling.js";
+import { openRunStore } from "../src/run-store.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-cli-runs-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+function sampleIssue(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    body: "",
+    created_at: "",
+    id: 1,
+    labels: [],
+    number: 1,
+    priority: 99,
+    state: "open",
+    title: "issue",
+    updated_at: "",
+    url: "",
+    ...overrides
+  };
+}
+
+function captureProgram(stateRoot: string): {
+  output: { stderr: string; stdout: string };
+  program: ReturnType<typeof buildCli>;
+} {
+  const output = { stderr: "", stdout: "" };
+  const program = buildCli({
+    openRunStore: () => openRunStore({ stateRoot }),
+    registerSignalHandlers: false
+  });
+  program.configureOutput({
+    writeErr: (m) => {
+      output.stderr += m;
+    },
+    writeOut: (m) => {
+      output.stdout += m;
+    }
+  });
+  program.exitOverride();
+  return { output, program };
+}
+
+describe("CLI run commands", () => {
+  it("status prints state-root and counts grouped by lifecycle", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "r-running",
+      issue: sampleIssue({ number: 1, title: "Sample" }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("r-running", "running");
+    store.createRun({
+      id: "r-failed",
+      issue: sampleIssue({ number: 2 }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("r-failed", "failed");
+    store.close();
+
+    const { output, program } = captureProgram(stateRoot);
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml")
+    ]);
+
+    expect(output.stdout).toContain("state root");
+    expect(output.stdout).toContain("running: 1");
+    expect(output.stdout).toContain("failed: 1");
+    expect(output.stdout).toContain("r-running");
+    expect(output.stdout).toContain("r-failed");
+  });
+
+  it("runs filters by state and prints (no runs) for empty results", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "r-only-failed",
+      issue: sampleIssue(),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("r-only-failed", "failed");
+    store.close();
+
+    const cfg = path.join(stateRoot, "symphonika.yml");
+
+    const noMatch = captureProgram(stateRoot);
+    await noMatch.program.parseAsync([
+      "node",
+      "symphonika",
+      "runs",
+      "--config",
+      cfg,
+      "--state",
+      "running"
+    ]);
+    expect(noMatch.output.stdout).toContain("(no runs)");
+
+    const failed = captureProgram(stateRoot);
+    await failed.program.parseAsync([
+      "node",
+      "symphonika",
+      "runs",
+      "--config",
+      cfg,
+      "--state",
+      "failed"
+    ]);
+    expect(failed.output.stdout).toContain("r-only-failed");
+  });
+
+  it("show-run errors when the run is missing and prints detail when present", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "show-1",
+      issue: sampleIssue({ number: 7, title: "Detail" }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.close();
+
+    const cfg = path.join(stateRoot, "symphonika.yml");
+    const missing = captureProgram(stateRoot);
+    await expect(
+      missing.program.parseAsync([
+        "node",
+        "symphonika",
+        "show-run",
+        "missing",
+        "--config",
+        cfg
+      ])
+    ).rejects.toThrow();
+    expect(missing.output.stderr).toContain("run missing not found");
+
+    const present = captureProgram(stateRoot);
+    await present.program.parseAsync([
+      "node",
+      "symphonika",
+      "show-run",
+      "show-1",
+      "--config",
+      cfg
+    ]);
+    expect(present.output.stdout).toContain("show-1");
+    expect(present.output.stdout).toContain("Detail");
+    expect(present.output.stdout).toContain("<not yet recorded>");
+  });
+
+  it("cancel writes markCancelRequested for non-terminal runs and errors otherwise", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "cancel-live",
+      issue: sampleIssue({ number: 11 }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("cancel-live", "running");
+    store.createRun({
+      id: "cancel-done",
+      issue: sampleIssue({ number: 12 }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("cancel-done", "succeeded");
+    store.close();
+
+    const cfg = path.join(stateRoot, "symphonika.yml");
+    const live = captureProgram(stateRoot);
+    await live.program.parseAsync([
+      "node",
+      "symphonika",
+      "cancel",
+      "cancel-live",
+      "--config",
+      cfg
+    ]);
+    expect(live.output.stdout).toContain("cancel requested for cancel-live");
+
+    const verifyStore = openRunStore({ stateRoot });
+    expect(verifyStore.getRun("cancel-live")?.cancelRequested).toBe(true);
+    expect(verifyStore.getRun("cancel-live")?.cancelReason).toBe("operator");
+    verifyStore.close();
+
+    const done = captureProgram(stateRoot);
+    await expect(
+      done.program.parseAsync([
+        "node",
+        "symphonika",
+        "cancel",
+        "cancel-done",
+        "--config",
+        cfg
+      ])
+    ).rejects.toThrow();
+    expect(done.output.stderr).toContain("already succeeded");
+
+    const missing = captureProgram(stateRoot);
+    await expect(
+      missing.program.parseAsync([
+        "node",
+        "symphonika",
+        "cancel",
+        "missing",
+        "--config",
+        cfg
+      ])
+    ).rejects.toThrow();
+    expect(missing.output.stderr).toContain("not found");
+  });
+});

--- a/tests/http-app-runs.test.ts
+++ b/tests/http-app-runs.test.ts
@@ -1,0 +1,292 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createHttpApp } from "../src/http/app.js";
+import type { IssueSnapshot } from "../src/issue-polling.js";
+import type { RunState } from "../src/run-store.js";
+import { openRunStore, type RunStore } from "../src/run-store.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-http-runs-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+function sampleIssue(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    body: "",
+    created_at: "",
+    id: 1,
+    labels: [],
+    number: 1,
+    priority: 99,
+    state: "open",
+    title: "issue",
+    updated_at: "",
+    url: "",
+    ...overrides
+  };
+}
+
+type TestSetup = {
+  cleanup: () => void;
+  runStore: RunStore;
+  stateRoot: string;
+};
+
+async function setup(): Promise<TestSetup> {
+  const stateRoot = await makeTempRoot();
+  const runStore = openRunStore({ stateRoot });
+  return {
+    cleanup: () => runStore.close(),
+    runStore,
+    stateRoot
+  };
+}
+
+describe("HTTP app — runs API and pages", () => {
+  it("filters /api/runs by state and project", async () => {
+    const test = await setup();
+    try {
+      test.runStore.createRun({
+        id: "run-a",
+        issue: sampleIssue({ number: 1 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("run-a", "running");
+      test.runStore.createRun({
+        id: "run-b",
+        issue: sampleIssue({ number: 2 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("run-b", "failed");
+      test.runStore.createRun({
+        id: "run-c",
+        issue: sampleIssue({ number: 3 }),
+        projectName: "beta",
+        providerCommand: "x",
+        providerName: "claude"
+      });
+      test.runStore.updateRunState("run-c", "failed");
+
+      const app = createHttpApp({
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+
+      const response = await app.request("/api/runs?state=failed&project=alpha");
+      const body = (await response.json()) as { runs: { id: string }[] };
+      expect(response.status).toBe(200);
+      expect(body.runs.map((r) => r.id)).toEqual(["run-b"]);
+    } finally {
+      test.cleanup();
+    }
+  });
+
+  it("returns 404 for /api/runs/:id when missing and detail otherwise", async () => {
+    const test = await setup();
+    try {
+      const app = createHttpApp({
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+      expect((await app.request("/api/runs/missing")).status).toBe(404);
+
+      test.runStore.createRun({
+        id: "have-run",
+        issue: sampleIssue({ number: 7 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("have-run", "running");
+      const ok = await app.request("/api/runs/have-run");
+      expect(ok.status).toBe(200);
+      const body = (await ok.json()) as {
+        run: { id: string; state: RunState };
+        attempts: unknown[];
+        transitions: unknown[];
+        events: unknown[];
+      };
+      expect(body.run.id).toBe("have-run");
+      expect(body.run.state).toBe("running");
+    } finally {
+      test.cleanup();
+    }
+  });
+
+  it("streams /api/runs/:id/files/raw-log only for paths inside the run evidence dir", async () => {
+    const test = await setup();
+    try {
+      const evidenceDir = path.join(test.stateRoot, "logs", "runs", "run-files");
+      await mkdir(evidenceDir, { recursive: true });
+      const rawLogPath = path.join(evidenceDir, "provider.raw.jsonl");
+      await writeFile(rawLogPath, '{"x":1}\n', "utf8");
+
+      test.runStore.createRun({
+        id: "run-files",
+        issue: sampleIssue({ number: 4 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunEvidence("run-files", {
+        branchName: "branch",
+        branchRef: "refs/heads/branch",
+        issueSnapshotPath: "",
+        metadataPath: "",
+        normalizedLogPath: "",
+        promptPath: "",
+        rawLogPath,
+        workspacePath: test.stateRoot
+      });
+
+      // Empty path → 404
+      test.runStore.createRun({
+        id: "run-empty",
+        issue: sampleIssue({ number: 5 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+
+      // Path escapes evidence dir → 404
+      const escaping = path.join(test.stateRoot, "outside.jsonl");
+      await writeFile(escaping, "evil\n", "utf8");
+      test.runStore.createRun({
+        id: "run-escape",
+        issue: sampleIssue({ number: 6 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunEvidence("run-escape", {
+        branchName: "branch",
+        branchRef: "refs/heads/branch",
+        issueSnapshotPath: "",
+        metadataPath: "",
+        normalizedLogPath: "",
+        promptPath: "",
+        rawLogPath: escaping,
+        workspacePath: test.stateRoot
+      });
+
+      const app = createHttpApp({
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+
+      const ok = await app.request("/api/runs/run-files/files/raw-log");
+      expect(ok.status).toBe(200);
+      expect(ok.headers.get("content-type")).toContain("application/x-ndjson");
+      expect(await ok.text()).toContain('{"x":1}');
+
+      expect(
+        (await app.request("/api/runs/run-empty/files/raw-log")).status
+      ).toBe(404);
+      expect(
+        (await app.request("/api/runs/run-escape/files/raw-log")).status
+      ).toBe(404);
+    } finally {
+      test.cleanup();
+    }
+  });
+
+  it("POST /api/runs/:id/cancel returns 200/404/409 and 303 for form submissions", async () => {
+    const test = await setup();
+    try {
+      test.runStore.createRun({
+        id: "live",
+        issue: sampleIssue({ number: 11 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("live", "running");
+
+      const app = createHttpApp({
+        cancelRun: (runId) => {
+          test.runStore.markCancelRequested(runId, "operator");
+          return { kind: "cancelled" };
+        },
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+
+      const ok = await app.request("/api/runs/live/cancel", { method: "POST" });
+      expect(ok.status).toBe(200);
+      const okBody = (await ok.json()) as { kind: string };
+      expect(okBody.kind).toBe("cancelled");
+
+      const form = await app.request("/api/runs/live/cancel", {
+        body: "",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        method: "POST",
+        redirect: "manual"
+      });
+      expect(form.status).toBe(303);
+      expect(form.headers.get("location")).toBe("/runs/live");
+    } finally {
+      test.cleanup();
+    }
+  });
+
+  it("renders the dashboard and run detail page with HTML escaping", async () => {
+    const test = await setup();
+    try {
+      test.runStore.createRun({
+        id: "<script>x</script>",
+        issue: sampleIssue({ number: 99, title: "<img src=x>" }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("<script>x</script>", "running");
+
+      const app = createHttpApp({
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+
+      const dashboard = await app.request("/");
+      expect(dashboard.status).toBe(200);
+      expect(dashboard.headers.get("content-type")).toContain("text/html");
+      const body = await dashboard.text();
+      expect(body).not.toContain("<script>x</script>");
+      expect(body).toContain("&lt;script&gt;x&lt;/script&gt;");
+      expect(body).not.toContain("<img src=x>");
+      expect(body).toContain("&lt;img src=x&gt;");
+
+      const runs = await app.request("/runs");
+      expect(runs.status).toBe(200);
+      const runsBody = await runs.text();
+      expect(runsBody).toContain("All runs");
+
+      const missing = await app.request("/runs/missing");
+      expect(missing.status).toBe(404);
+    } finally {
+      test.cleanup();
+    }
+  });
+});

--- a/tests/run-store-detail.test.ts
+++ b/tests/run-store-detail.test.ts
@@ -1,0 +1,198 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IssueSnapshot } from "../src/issue-polling.js";
+import { openRunStore } from "../src/run-store.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-rsd-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+function sampleIssue(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    body: "issue body",
+    created_at: "2026-04-01T00:00:00Z",
+    id: 1001,
+    labels: ["agent-ready"],
+    number: 42,
+    priority: 99,
+    state: "open",
+    title: "Sample issue",
+    updated_at: "2026-04-02T00:00:00Z",
+    url: "https://example.invalid/issue/42",
+    ...overrides
+  };
+}
+
+describe("RunStore detail queries", () => {
+  it("getRun returns the run with attempts and transitions", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.createRun({
+        id: "run-A",
+        issue: sampleIssue(),
+        projectName: "symphonika",
+        providerCommand: "codex --x",
+        providerName: "codex"
+      });
+      store.updateRunState("run-A", "preparing_workspace");
+      store.createAttempt({
+        attemptNumber: 1,
+        branchName: "sym/symphonika/42-sample",
+        branchRef: "refs/heads/sym/symphonika/42-sample",
+        id: "run-A-attempt-1",
+        issueSnapshotPath: "/tmp/snap.json",
+        metadataPath: "/tmp/meta.json",
+        normalizedLogPath: "/tmp/normalized.jsonl",
+        promptPath: "/tmp/prompt.md",
+        providerCommand: "codex --x",
+        providerName: "codex",
+        rawLogPath: "/tmp/raw.jsonl",
+        runId: "run-A",
+        state: "running",
+        workspacePath: "/tmp/work"
+      });
+      store.updateRunState("run-A", "running");
+
+      const detail = store.getRun("run-A");
+      expect(detail).toBeDefined();
+      expect(detail?.id).toBe("run-A");
+      expect(detail?.issueTitle).toBe("Sample issue");
+      expect(detail?.attempts).toHaveLength(1);
+      expect(detail?.attempts[0]?.id).toBe("run-A-attempt-1");
+      expect(detail?.transitions.map((t) => t.state)).toEqual([
+        "queued",
+        "preparing_workspace",
+        "running"
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("getRun returns undefined for unknown id", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      expect(store.getRun("missing")).toBeUndefined();
+    } finally {
+      store.close();
+    }
+  });
+
+  it("listRuns filters by state, project, and issueNumber", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.createRun({
+        id: "r-1",
+        issue: sampleIssue({ number: 1 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      store.updateRunState("r-1", "running");
+      store.createRun({
+        id: "r-2",
+        issue: sampleIssue({ number: 2 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      store.updateRunState("r-2", "failed");
+      store.createRun({
+        id: "r-3",
+        issue: sampleIssue({ number: 3 }),
+        projectName: "beta",
+        providerCommand: "x",
+        providerName: "claude"
+      });
+      store.updateRunState("r-3", "failed");
+
+      expect(
+        store.listRuns({ project: "alpha", state: "failed" }).map((r) => r.id)
+      ).toEqual(["r-2"]);
+      expect(
+        store
+          .listRuns({ state: "failed" })
+          .map((r) => r.id)
+          .sort()
+      ).toEqual(["r-2", "r-3"]);
+      expect(store.listRuns({ issueNumber: 1 }).map((r) => r.id)).toEqual([
+        "r-1"
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("listProviderEvents respects limit and afterSequence", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.createRun({
+        id: "r-events",
+        issue: sampleIssue(),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      store.createAttempt({
+        attemptNumber: 1,
+        branchName: "branch",
+        branchRef: "refs/heads/branch",
+        id: "r-events-attempt-1",
+        issueSnapshotPath: "/tmp/snap.json",
+        metadataPath: "/tmp/meta.json",
+        normalizedLogPath: "/tmp/normalized.jsonl",
+        promptPath: "/tmp/prompt.md",
+        providerCommand: "x",
+        providerName: "codex",
+        rawLogPath: "/tmp/raw.jsonl",
+        runId: "r-events",
+        state: "running",
+        workspacePath: "/tmp/work"
+      });
+      for (let i = 1; i <= 5; i += 1) {
+        store.recordProviderEvent({
+          attemptId: "r-events-attempt-1",
+          normalized: { type: "message", message: `m${i}` },
+          raw: { kind: "message", body: `m${i}` },
+          runId: "r-events",
+          sequence: i
+        });
+      }
+
+      expect(store.listProviderEvents("r-events").map((e) => e.sequence)).toEqual([
+        1, 2, 3, 4, 5
+      ]);
+      expect(
+        store
+          .listProviderEvents("r-events", { limit: 2 })
+          .map((e) => e.sequence)
+      ).toEqual([1, 2]);
+      expect(
+        store
+          .listProviderEvents("r-events", { afterSequence: 3 })
+          .map((e) => e.sequence)
+      ).toEqual([4, 5]);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IssueSnapshot, IssuePollStatus } from "../src/issue-polling.js";
+import { openRunStore } from "../src/run-store.js";
+import { buildStatusSnapshot } from "../src/status.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-status-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+function sampleIssue(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    body: "",
+    created_at: "",
+    id: 1,
+    labels: [],
+    number: 1,
+    priority: 99,
+    state: "open",
+    title: "issue",
+    updated_at: "",
+    url: "",
+    ...overrides
+  };
+}
+
+function emptyPollStatus(): IssuePollStatus {
+  return {
+    candidateIssues: [],
+    errors: [],
+    filteredIssues: [],
+    projects: []
+  };
+}
+
+describe("buildStatusSnapshot", () => {
+  it("groups runs by lifecycle state", async () => {
+    const stateRoot = await makeTempRoot();
+    const runStore = openRunStore({ stateRoot });
+    try {
+      runStore.createRun({
+        id: "r-active",
+        issue: sampleIssue({ number: 10 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      runStore.updateRunState("r-active", "running");
+      runStore.createRun({
+        id: "r-recent",
+        issue: sampleIssue({ number: 11 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      runStore.updateRunState("r-recent", "succeeded");
+      runStore.createRun({
+        id: "r-failed",
+        issue: sampleIssue({ number: 12 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      runStore.updateRunState("r-failed", "failed");
+      runStore.createRun({
+        id: "r-stale",
+        issue: sampleIssue({ number: 13 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      runStore.updateRunState("r-stale", "stale");
+
+      const snapshot = buildStatusSnapshot({
+        configPath: "/tmp/symphonika.yml",
+        issuePollStatus: emptyPollStatus(),
+        runStore,
+        stateRoot
+      });
+
+      expect(snapshot.runs.active.map((r) => r.id)).toEqual(["r-active"]);
+      expect(snapshot.runs.recent.map((r) => r.id)).toEqual(["r-recent"]);
+      expect(snapshot.runs.failed.map((r) => r.id)).toEqual(["r-failed"]);
+      expect(snapshot.runs.stale.map((r) => r.id)).toEqual(["r-stale"]);
+      expect(snapshot.projects).toEqual([]);
+      expect(snapshot.doctorErrors).toEqual([]);
+    } finally {
+      runStore.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Adds the operator surface for issue #13 on top of upstream main's
lifecycle work (PR #11 / #12). All additions are complementary to
the `RunController` / `ActiveRunRegistry` shipped in those PRs.

- CLI commands `status`, `runs`, `show-run`, `cancel`
- Read-only Hono HTTP API for runs, attempts, transitions, normalized
  events, and run-evidence files (prompt, raw log, normalized log,
  issue snapshot, metadata)
- Server-rendered HTML pages at `/`, `/runs`, `/runs/:id` with a
  cancel form for non-terminal runs (the only mutating web action)
- Run-store helpers: `getRun(id)`, `listAttempts`, `listRunStateTransitions`,
  `listProviderEvents`, `listRuns(filter)`; `issueTitle` exposed on
  `RunStatus`

## Acceptance criteria mapping (issue #13)
- [x] CLI implements `status`, `runs`, `show-run`, and `cancel` against the run store
- [x] Local HTTP API exposes state needed by the server-rendered pages
- [x] Server-rendered pages show Projects, validation state, issue/run status, events, prompts, and log links
- [x] Web UI is read-only except for explicit active-run cancellation
- [x] Label creation, stale clearing, and workspace cleanup are CLI-only
- [x] Cancellation through CLI and UI records durable state and provider evidence (via `markCancelRequested("operator")` + `activeRuns.requestCancel`)
- [x] Tests cover CLI output/exit codes and Hono API/page behavior with temporary state

## Notable design choices
- **CLI cancel** writes `markCancelRequested(runId, "operator")` to the
  run store. When the daemon is running in the same process, the UI
  POST also calls `activeRuns.requestCancel` which signals the live
  provider. CLI cancel from a separate process records durable intent;
  the daemon's reconcile loop already observes `cancelRequested` via
  `ActiveRunRegistry`.
- **HTML pages use template literals**, not JSX — keeps `tsconfig.json`
  unchanged. A single `escapeHtml()` helper is used at every interpolation
  site; tests assert `<script>`-bearing run ids render escaped.
- **File-serving** binds `:id` to a DB lookup (`runStore.getRun`),
  rejects empty `*_path` columns, and confines resolved paths under
  `<stateRoot>/logs/runs/<id>` via `isPathInside` (extracted from
  `workflow.ts` into `path-safety.ts`).
- **`POST /api/runs/:id/cancel`** content-negotiates: form-encoded → 303
  redirect to `/runs/:id`; otherwise JSON with status 200 / 404 / 409.

## Out of scope (deferred)
- Cancel evidence (signal / exitCode capture) — would require modifying
  upstream's `RunController`. Track separately if needed.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` — 154 passing (140 upstream baseline + 14 new)
- [ ] Manual: start daemon, hit `/`, `/runs`, `/runs/:id`; exercise
      `status` / `runs` / `show-run` / `cancel` from CLI

Closes #13.