### PR TITLE
Wire self-hosting bootstrap config and smoke test (#14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,35 @@ jobs:
           path: dist
           if-no-files-found: error
           retention-days: 7
+
+  smoke:
+    name: Smoke (opt-in)
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.SYMPHONIKA_SMOKE_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      # Install the agent provider declared in symphonika.yml (`agent.provider: codex`).
+      # If a Codex CLI binary is not available in the runner image, switch this step
+      # and `agent.provider` together to keep `doctor` validation aligned.
+      - name: Install codex CLI
+        run: |
+          if ! command -v codex >/dev/null 2>&1; then
+            echo "::error::codex binary not found on PATH; install it before enabling SYMPHONIKA_SMOKE_ENABLED" >&2
+            exit 1
+          fi
+          codex --version
+      - name: Run symphonika smoke
+        env:
+          GITHUB_TOKEN: ${{ secrets.SYMPHONIKA_SMOKE_GITHUB_TOKEN }}
+        run: npm run smoke -- --config symphonika.yml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log*
 
 .claude/settings.local.json
 .claude/worktrees/
+.ultraplan/

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,62 @@
+# Symphonika implementation issue: #{{issue.number}} {{issue.title}}
+
+## Source of truth
+
+- Implementation contract: `SPEC.md`
+- Domain language: `CONTEXT.md`
+- Architecture decisions: `docs/adr/`
+- Repository conventions: `AGENTS.md`
+
+The upstream `symphony/` directory is a reference submodule and must not be modified.
+
+## Issue under work
+
+- Number: #{{issue.number}}
+- Title: {{issue.title}}
+- URL: {{issue.url}}
+- Labels: {{issue.labels}}
+- Created: {{issue.created_at}}
+- Updated: {{issue.updated_at}}
+
+### Issue body
+
+{{issue.body}}
+
+## Run context
+
+- Project: {{project.name}}
+- Run id: {{run.id}}
+- Attempt: {{run.attempt}}
+- Continuation: {{run.continuation}}
+- Provider: {{provider.name}}
+
+## Workspace
+
+Your current working directory is {{workspace.path}}.
+Workspace root: {{workspace.root}}.
+Previous attempt detected: {{workspace.previous_attempt}}.
+
+You are on the issue branch {{branch.name}} ({{branch.ref}}).
+Stay on this branch for all commits. Do not switch branches or open new ones.
+
+## What to do
+
+1. Read `SPEC.md`, `CONTEXT.md`, `AGENTS.md`, and any ADRs in `docs/adr/` that touch the area you are about to change.
+2. Investigate the issue body and any code paths it references before writing code. Prefer small, vertical slices.
+3. Implement the change. Add or update tests under `tests/` so the new behavior is covered. Do not silently relax existing tests.
+4. Run the full local quality gate before pushing:
+   - `npm run lint`
+   - `npm run typecheck`
+   - `npm test`
+   - `npm run build`
+5. Commit your changes with a focused message. Push the branch {{branch.name}} to `origin`.
+6. Open a pull request against `main` that links to {{issue.url}}.
+7. If a workflow handoff label such as `needs-review` or `needs-human` is appropriate, apply it before exiting.
+8. Update `SPEC.md`, `CONTEXT.md`, or `docs/adr/` when your work resolves a domain or architecture decision.
+
+## Constraints
+
+- This run executes with full local permissions; do not request operator input.
+- If you discover that the issue is blocked, ambiguous, or already resolved, leave a clear note in the workspace (for example, an `EVIDENCE.md` at `{{workspace.path}}/EVIDENCE.md`) and exit cleanly rather than guessing.
+- Do not create or edit GitHub labels in the `sym:*` namespace. Those are owned by the orchestrator.
+- Do not modify the `symphony/` submodule.

--- a/docs/smoke.md
+++ b/docs/smoke.md
@@ -96,3 +96,9 @@ present.
   `sym:claimed` or `sym:running` and there is no live local run, doctor will
   surface a `sym:stale` warning. Clear it with
   `symphonika clear-stale <project> <issue> --yes`.
+- **Workspace remote is HTTPS by default.** The bootstrap `symphonika.yml`
+  uses an HTTPS remote so clones work in stock GitHub-hosted runners and on
+  any machine without configured SSH keys. Operators who prefer SSH (e.g.
+  for push convenience) can override `workspace.git.remote` locally — most
+  conveniently by copying the file to `symphonika.local.yml` (already
+  gitignored via `*.local`) and pointing `--config` at it.

--- a/docs/smoke.md
+++ b/docs/smoke.md
@@ -1,0 +1,98 @@
+# Smoke command
+
+`symphonika smoke` performs exactly one orchestration cycle for the configured
+bootstrap Project and exits. It is the opt-in acceptance path used to verify
+self-hosting end-to-end without leaving a long-lived daemon running.
+
+The smoke command is **not** the daemon. It does not poll on an interval, does
+not retry, and does not schedule continuations after a successful run.
+
+## What it does
+
+1. Validates `symphonika.yml` and `WORKFLOW.md` via `symphonika doctor`. If any
+   doctor error is reported, smoke aborts before touching the issue tracker.
+2. Polls GitHub once for issues that match the Project's `labels_all` /
+   `labels_none` filters.
+3. If at least one eligible issue is found, claims it (adds `sym:claimed`,
+   then `sym:running`), prepares a deterministic Git worktree under
+   `<state.root>/workspaces/<project>/issues/<n>-<slug>/`, renders the workflow
+   prompt, and launches the configured agent provider (Codex or Claude).
+4. Persists evidence under `<state.root>/logs/runs/<run-id>/`:
+   - `prompt.md`
+   - `prompt-metadata.json`
+   - `issue-snapshot.json`
+   - `provider.raw.jsonl`
+   - `provider.normalized.jsonl`
+5. Awaits the provider attempt to terminate, prints the run summary (run id,
+   state, branch, workspace, log paths), and exits.
+
+Exit codes:
+
+- `0` — smoke succeeded, or there was no eligible issue to dispatch.
+- `1` — doctor reported errors, the configured provider exited non-zero, or
+  the provider requested operator input.
+
+## Prerequisites
+
+1. **Service config and workflow contract** at the repo root: `symphonika.yml`
+   and `WORKFLOW.md`. The non-secret bootstrap config in this repository
+   targets the `pmatos/symphonika` Project with `agent.provider: codex`.
+2. **GitHub credentials**: export `GITHUB_TOKEN` (or the variable referenced
+   by `tracker.token` in your config) with write access to issues for the
+   target repository.
+3. **Operational labels created**: the four `sym:*` labels must already exist
+   on the target repository. Smoke never creates labels itself. Run
+   `symphonika init-project --yes` once as an operator to create them.
+4. **Provider binary on `PATH`**: install the binary that matches
+   `agent.provider`. Codex provides `codex`; Claude provides `claude`.
+5. **At least one issue labeled `agent-ready`** that does not also carry any
+   excluded label (`blocked`, `needs-human`, `sym:stale`).
+
+## Running locally
+
+```sh
+export GITHUB_TOKEN=<your-personal-token>
+npx symphonika doctor
+npx symphonika init-project --yes   # one-time, creates sym:* labels
+npm run smoke                       # equivalent to: symphonika smoke
+```
+
+The first invocation will create `.symphonika/` under the directory containing
+`symphonika.yml`. That path is already gitignored.
+
+## CI gating
+
+The CI smoke job in `.github/workflows/ci.yml` is **skipped by default**. It
+only runs when both of the following are true:
+
+- The repository variable `SYMPHONIKA_SMOKE_ENABLED` is set to `true`, **or**
+  the workflow is triggered manually via `workflow_dispatch`.
+- The repository secret `SYMPHONIKA_SMOKE_GITHUB_TOKEN` is configured. The
+  step exposes it to the run as `GITHUB_TOKEN`. If the secret is missing,
+  `doctor` will fail with a clear error and the job exits non-zero.
+
+The job uses an explicit job-scoped `permissions:` block (`contents: read`,
+`issues: write`) so it can apply the orchestrator's operational labels.
+
+Forked pull requests cannot read repository secrets or variables, so the gate
+above keeps the smoke job skipped for forks even if the workflow file is
+present.
+
+## Caveats
+
+- **Full-permission execution.** The agent provider runs without sandboxing
+  and can push commits, modify files, and call GitHub APIs through your
+  credentials. Treat `symphonika smoke` like a manual `git push --force` —
+  inspect the workflow contract and the eligible issue first.
+- **Do not run smoke while the daemon is running.** Both processes claim
+  issues independently. If they race, expect duplicate claims, double label
+  writes, or a `sym:stale` mark on a healthy run. Stop the daemon first.
+- **`agent-ready` is workflow-side, not operational.** Smoke does not create
+  this label. Apply it to the target issue manually before invoking smoke.
+- **Submodules are not initialized.** The `symphony/` upstream reference
+  submodule is left empty in the worktree. The bootstrap workflow contract
+  treats `symphony/` as a reference, so this is expected.
+- **Stale claims block dispatch.** If a previous attempt left the issue with
+  `sym:claimed` or `sym:running` and there is no live local run, doctor will
+  surface a `sym:stale` warning. Clear it with
+  `symphonika clear-stale <project> <issue> --yes`.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsx src/cli.ts",
     "lint": "eslint .",
+    "smoke": "tsx src/cli.ts smoke",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,8 @@ import type {
   RunStore
 } from "./run-store.js";
 import { openRunStore as openRunStoreReal } from "./run-store.js";
+import type { SmokeOptions, SmokeReport } from "./smoke.js";
+import { runSmoke } from "./smoke.js";
 import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
 
@@ -29,6 +31,7 @@ export type CliDependencies = {
   runClearStale?: (options: ClearStaleOptions) => Promise<ClearStaleReport>;
   runDoctor?: (options: DoctorOptions) => Promise<DoctorReport>;
   runInitProject?: (options: InitProjectOptions) => Promise<InitProjectReport>;
+  runSmoke?: (options: SmokeOptions) => Promise<SmokeReport>;
   startDaemon?: (options: StartDaemonOptions) => Promise<DaemonHandle>;
 };
 
@@ -36,6 +39,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
   const doctor = dependencies.runDoctor ?? runDoctor;
   const initProject = dependencies.runInitProject ?? runInitProject;
   const clearStale = dependencies.runClearStale ?? runClearStale;
+  const smoke = dependencies.runSmoke ?? runSmoke;
   const start = dependencies.startDaemon ?? startDaemon;
   const openRunStore = dependencies.openRunStore ?? openRunStoreReal;
   const registerSignalHandlers = dependencies.registerSignalHandlers ?? true;
@@ -199,6 +203,56 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
 
       if (registerSignalHandlers) {
         registerShutdownHandlers(daemon);
+      }
+    });
+
+  program
+    .command("smoke")
+    .description(
+      "claim and run one agent-ready issue once via the configured provider, then exit"
+    )
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .action(async (options: { config: string }) => {
+      const report = await smoke({ configPath: options.config });
+
+      for (const warning of report.warnings) {
+        writeErr(program, `warning: ${warning}\n`);
+      }
+
+      if (!report.ok) {
+        writeErr(program, "smoke failed:\n");
+        for (const error of report.errors) {
+          writeErr(program, `- ${error}\n`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!report.dispatched) {
+        writeOut(
+          program,
+          `smoke skipped: ${report.skipReason ?? "no eligible issues to dispatch"}\n`
+        );
+        return;
+      }
+
+      const detail = report.runDetail;
+      writeOut(program, `smoke ok: dispatched ${report.runId ?? ""}\n`);
+      if (detail !== undefined) {
+        writeOut(program, `project:      ${detail.project}\n`);
+        writeOut(program, `issue:        #${detail.issueNumber} ${detail.issueTitle}\n`);
+        writeOut(program, `state:        ${detail.state}\n`);
+        writeOut(program, `provider:     ${detail.provider}\n`);
+        writeOut(program, `branch:       ${formatPath(detail.branchName)}\n`);
+        writeOut(program, `workspace:    ${formatPath(detail.workspacePath)}\n`);
+        writeOut(program, `prompt:       ${formatPath(detail.promptPath)}\n`);
+        writeOut(program, `raw log:      ${formatPath(detail.rawLogPath)}\n`);
+        writeOut(program, `normalized:   ${formatPath(detail.normalizedLogPath)}\n`);
+        writeOut(program, `metadata:     ${formatPath(detail.metadataPath)}\n`);
+        writeOut(program, `issue snap:   ${formatPath(detail.issueSnapshotPath)}\n`);
+        if (detail.terminalReason !== null) {
+          writeOut(program, `terminal:     ${detail.terminalReason}\n`);
+        }
       }
     });
 

--- a/src/smoke.ts
+++ b/src/smoke.ts
@@ -1,0 +1,194 @@
+import path from "node:path";
+
+import {
+  dispatchOneEligibleIssue,
+  type DispatchIssueOptions
+} from "./dispatch.js";
+import {
+  runDoctor,
+  type DoctorOptions,
+  type GitHubApi
+} from "./doctor.js";
+import {
+  DEFAULT_GITHUB_ISSUES_API,
+  pollConfiguredGitHubIssues,
+  type GitHubIssuesApi
+} from "./issue-polling.js";
+import type { AgentProviderRegistry } from "./provider.js";
+import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
+import { openRunStore, type RunDetail } from "./run-store.js";
+import { resolveStateRoot } from "./state.js";
+import type {
+  PreparedIssueWorkspace,
+  PrepareIssueWorkspaceInput
+} from "./workspace.js";
+
+export type SmokeOptions = {
+  agentProviders?: AgentProviderRegistry;
+  configPath?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  githubApi?: GitHubApi;
+  githubIssuesApi?: GitHubIssuesApi;
+  prepareIssueWorkspace?: (
+    input: PrepareIssueWorkspaceInput
+  ) => Promise<PreparedIssueWorkspace>;
+};
+
+export type SmokeRunDetail = Pick<
+  RunDetail,
+  | "branchName"
+  | "id"
+  | "issueNumber"
+  | "issueSnapshotPath"
+  | "issueTitle"
+  | "metadataPath"
+  | "normalizedLogPath"
+  | "project"
+  | "promptPath"
+  | "provider"
+  | "rawLogPath"
+  | "state"
+  | "terminalReason"
+  | "workspacePath"
+>;
+
+export type SmokeReport = {
+  configPath: string;
+  dispatched: boolean;
+  errors: string[];
+  ok: boolean;
+  runDetail?: SmokeRunDetail;
+  runId?: string;
+  skipReason?: string;
+  warnings: string[];
+};
+
+export async function runSmoke(options: SmokeOptions = {}): Promise<SmokeReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const configPath = path.resolve(cwd, options.configPath ?? "symphonika.yml");
+  const env = options.env ?? process.env;
+  const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;
+  const githubIssuesApi =
+    options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const doctorOptions: DoctorOptions = {
+    agentProviders,
+    configPath,
+    cwd,
+    env,
+    githubIssuesApi
+  };
+  if (options.githubApi !== undefined) {
+    doctorOptions.githubApi = options.githubApi;
+  }
+  const doctorReport = await runDoctor(doctorOptions);
+  if (!doctorReport.ok) {
+    errors.push(...doctorReport.errors);
+    return {
+      configPath,
+      dispatched: false,
+      errors,
+      ok: false,
+      warnings
+    };
+  }
+
+  const state = resolveStateRoot({ configPath, cwd });
+  const runStore = openRunStore({ stateRoot: state.stateRoot });
+  try {
+    const issuePollStatus = await pollConfiguredGitHubIssues({
+      configPath,
+      env,
+      githubIssuesApi
+    });
+
+    if (issuePollStatus.errors.length > 0) {
+      errors.push(...issuePollStatus.errors);
+      return {
+        configPath,
+        dispatched: false,
+        errors,
+        ok: false,
+        warnings
+      };
+    }
+
+    if (issuePollStatus.candidateIssues.length === 0) {
+      return {
+        configPath,
+        dispatched: false,
+        errors,
+        ok: true,
+        skipReason: "no eligible issues to dispatch",
+        warnings
+      };
+    }
+
+    const dispatchOptions: DispatchIssueOptions = {
+      agentProviders,
+      configDir: state.configDir,
+      configPath,
+      env,
+      githubIssuesApi,
+      issuePollStatus,
+      runStore,
+      stateRoot: state.stateRoot
+    };
+    if (options.prepareIssueWorkspace !== undefined) {
+      dispatchOptions.prepareIssueWorkspace = options.prepareIssueWorkspace;
+    }
+    const dispatchResult = await dispatchOneEligibleIssue(dispatchOptions);
+
+    if (!dispatchResult.dispatched) {
+      return {
+        configPath,
+        dispatched: false,
+        errors,
+        ok: true,
+        skipReason: dispatchResult.reason,
+        warnings
+      };
+    }
+
+    const detail = runStore.getRun(dispatchResult.runId);
+    const runDetail = detail === undefined ? undefined : pickRunDetail(detail);
+    const ok = runDetail === undefined ? true : isTerminalSuccess(runDetail.state);
+    return {
+      configPath,
+      dispatched: true,
+      errors,
+      ok,
+      ...(runDetail === undefined ? {} : { runDetail }),
+      runId: dispatchResult.runId,
+      warnings
+    };
+  } finally {
+    runStore.close();
+  }
+}
+
+function pickRunDetail(detail: RunDetail): SmokeRunDetail {
+  return {
+    branchName: detail.branchName,
+    id: detail.id,
+    issueNumber: detail.issueNumber,
+    issueSnapshotPath: detail.issueSnapshotPath,
+    issueTitle: detail.issueTitle,
+    metadataPath: detail.metadataPath,
+    normalizedLogPath: detail.normalizedLogPath,
+    project: detail.project,
+    promptPath: detail.promptPath,
+    provider: detail.provider,
+    rawLogPath: detail.rawLogPath,
+    state: detail.state,
+    terminalReason: detail.terminalReason,
+    workspacePath: detail.workspacePath
+  };
+}
+
+function isTerminalSuccess(state: RunDetail["state"]): boolean {
+  return state === "succeeded";
+}

--- a/symphonika.yml
+++ b/symphonika.yml
@@ -33,7 +33,7 @@ projects:
     workspace:
       root: ./.symphonika/workspaces/symphonika
       git:
-        remote: git@github.com:pmatos/symphonika.git
+        remote: https://github.com/pmatos/symphonika.git
         base_branch: main
     agent:
       provider: codex

--- a/symphonika.yml
+++ b/symphonika.yml
@@ -1,0 +1,40 @@
+state:
+  root: ./.symphonika
+
+polling:
+  interval_ms: 30000
+
+providers:
+  codex:
+    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"
+  claude:
+    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"
+
+projects:
+  - name: symphonika
+    disabled: false
+    weight: 1
+    tracker:
+      kind: github
+      owner: pmatos
+      repo: symphonika
+      token: "$GITHUB_TOKEN"
+    issue_filters:
+      states: ["open"]
+      labels_all: ["agent-ready"]
+      labels_none: ["blocked", "needs-human", "sym:stale"]
+    priority:
+      labels:
+        "priority:critical": 0
+        "priority:high": 1
+        "priority:medium": 2
+        "priority:low": 3
+      default: 99
+    workspace:
+      root: ./.symphonika/workspaces/symphonika
+      git:
+        remote: git@github.com:pmatos/symphonika.git
+        base_branch: main
+    agent:
+      provider: codex
+    workflow: ./WORKFLOW.md

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -7,6 +7,7 @@ import type {
   ClearStaleReport,
   InitProjectOptions
 } from "../src/doctor.js";
+import type { SmokeOptions, SmokeReport } from "../src/smoke.js";
 
 describe("CLI", () => {
   it("starts the daemon with the selected config path and port", async () => {
@@ -135,6 +136,144 @@ describe("CLI", () => {
       expect(process.exitCode).toBe(1);
       expect(output.stderr).toContain("clear-stale failed");
       expect(output.stderr).toContain("pass --yes");
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("smoke forwards --config to the runner and prints a dispatched-run summary", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    const calls: SmokeOptions[] = [];
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({
+      registerSignalHandlers: false,
+      runSmoke: (options) => {
+        calls.push(options);
+        return Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          dispatched: true,
+          errors: [],
+          ok: true,
+          runDetail: {
+            branchName: "sym/symphonika/42-x",
+            id: "run-x",
+            issueNumber: 42,
+            issueSnapshotPath: "/tmp/state/logs/runs/run-x/issue-snapshot.json",
+            issueTitle: "Title",
+            metadataPath: "/tmp/state/logs/runs/run-x/prompt-metadata.json",
+            normalizedLogPath:
+              "/tmp/state/logs/runs/run-x/provider.normalized.jsonl",
+            project: "symphonika",
+            promptPath: "/tmp/state/logs/runs/run-x/prompt.md",
+            provider: "codex",
+            rawLogPath: "/tmp/state/logs/runs/run-x/provider.raw.jsonl",
+            state: "succeeded",
+            terminalReason: null,
+            workspacePath: "/tmp/state/workspaces/symphonika/issues/42-x"
+          },
+          runId: "run-x",
+          warnings: []
+        } satisfies SmokeReport);
+      }
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    try {
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "smoke",
+        "--config",
+        "custom.yml"
+      ]);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toMatchObject({ configPath: "custom.yml" });
+      expect(output.stdout).toContain("smoke ok");
+      expect(output.stdout).toContain("run-x");
+      expect(output.stdout).toContain("succeeded");
+      expect(process.exitCode).not.toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("smoke exits non-zero when the runner reports a doctor failure", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({
+      registerSignalHandlers: false,
+      runSmoke: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          dispatched: false,
+          errors: [
+            "projects.symphonika.tracker.repository pmatos/symphonika is missing operational labels: sym:claimed"
+          ],
+          ok: false,
+          warnings: []
+        } satisfies SmokeReport)
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    try {
+      await program.parseAsync(["node", "symphonika", "smoke"]);
+
+      expect(process.exitCode).toBe(1);
+      expect(output.stderr).toContain("smoke failed");
+      expect(output.stderr).toContain("missing operational labels");
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("smoke prints a skipReason when no eligible issue exists and exits zero", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({
+      registerSignalHandlers: false,
+      runSmoke: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          dispatched: false,
+          errors: [],
+          ok: true,
+          skipReason: "no eligible issues to dispatch",
+          warnings: []
+        } satisfies SmokeReport)
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    try {
+      await program.parseAsync(["node", "symphonika", "smoke"]);
+
+      expect(process.exitCode).not.toBe(1);
+      expect(output.stdout).toContain("smoke skipped");
+      expect(output.stdout).toContain("no eligible issues");
     } finally {
       process.exitCode = previousExitCode;
     }

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,359 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  REQUIRED_OPERATIONAL_LABELS,
+  type GitHubApi
+} from "../src/doctor.js";
+import type { GitHubIssuesApi } from "../src/issue-polling.js";
+import type {
+  AgentProvider,
+  AgentProviderRegistry,
+  ProviderEvent
+} from "../src/provider.js";
+import { runSmoke } from "../src/smoke.js";
+import type {
+  PreparedIssueWorkspace,
+  PrepareIssueWorkspaceInput
+} from "../src/workspace.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-smoke-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("runSmoke", () => {
+  it("reports skipReason when no eligible issue exists in the configured project", async () => {
+    const root = await makeTempRoot();
+    await writeBootstrapProject(root);
+
+    const githubApi = successfulGitHubApi();
+    const githubIssuesApi: GitHubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([])
+    };
+
+    const report = await runSmoke({
+      agentProviders: { codex: fakeCodexProvider() },
+      configPath: path.join(root, "symphonika.yml"),
+      cwd: root,
+      env: { GITHUB_TOKEN: "test-token" },
+      githubApi,
+      githubIssuesApi
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.dispatched).toBe(false);
+    expect(report.skipReason).toBeDefined();
+    expect(report.skipReason).toMatch(/no eligible/i);
+    expect(report.errors).toEqual([]);
+  });
+
+  it("short-circuits with doctor errors when operational labels are missing and never dispatches", async () => {
+    const root = await makeTempRoot();
+    await writeBootstrapProject(root);
+
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn().mockResolvedValue(undefined),
+      // No operational labels exist on the repo.
+      listLabels: () => Promise.resolve([]),
+      validateRepositoryAccess: () => Promise.resolve({ ok: true })
+    };
+    const githubIssuesApi: GitHubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([])
+    };
+    const codex = fakeCodexProvider();
+
+    const report = await runSmoke({
+      agentProviders: { codex },
+      configPath: path.join(root, "symphonika.yml"),
+      cwd: root,
+      env: { GITHUB_TOKEN: "test-token" },
+      githubApi,
+      githubIssuesApi
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.dispatched).toBe(false);
+    expect(report.errors.some((e) => e.includes("missing operational labels"))).toBe(
+      true
+    );
+    // Smoke must never auto-create labels (AC#7).
+    expect(githubApi.createLabel).not.toHaveBeenCalled();
+    // No provider attempt should be launched on doctor failure.
+    expect(codex.runAttempt).not.toHaveBeenCalled();
+  });
+
+  it("dispatches one eligible issue, captures evidence, and reports succeeded", async () => {
+    const root = await makeTempRoot();
+    await writeBootstrapProject(root);
+
+    const issueNumber = 42;
+    const issueTitle = "Wire bootstrap smoke test";
+    const issueDirectory = `${issueNumber}-wire-bootstrap-smoke-test`;
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      issueDirectory
+    );
+    await mkdir(workspacePath, { recursive: true });
+
+    const githubApi = successfulGitHubApi();
+    const githubIssuesApi: GitHubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        {
+          body: "Body of issue 42",
+          created_at: "2026-04-20T10:00:00Z",
+          html_url: `https://github.com/pmatos/symphonika/issues/${issueNumber}`,
+          id: 5042,
+          labels: [{ name: "agent-ready" }],
+          number: issueNumber,
+          state: "open",
+          title: issueTitle,
+          updated_at: "2026-04-21T11:00:00Z"
+        }
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codex: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: { sessionId: "fake-session", type: "session_started" },
+          raw: { id: "fake-session", kind: "session" }
+        };
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
+        void input;
+        return Promise.resolve({
+          branchName: `sym/symphonika/${issueDirectory}`,
+          branchRef: `refs/heads/sym/symphonika/${issueDirectory}`,
+          cachePath: path.join(
+            root,
+            ".symphonika",
+            "workspaces",
+            "symphonika",
+            ".cache",
+            "repo.git"
+          ),
+          issueDirectoryName: issueDirectory,
+          reused: false,
+          workspacePath
+        });
+      }
+    );
+
+    const report = await runSmoke({
+      agentProviders: { codex },
+      configPath: path.join(root, "symphonika.yml"),
+      cwd: root,
+      env: { GITHUB_TOKEN: "test-token" },
+      githubApi,
+      githubIssuesApi,
+      prepareIssueWorkspace
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.dispatched).toBe(true);
+    expect(report.runId).toBeDefined();
+    expect(report.runDetail).toMatchObject({
+      branchName: `sym/symphonika/${issueDirectory}`,
+      issueNumber,
+      project: "symphonika",
+      provider: "codex",
+      state: "succeeded",
+      workspacePath
+    });
+    expect(githubIssuesApi.addLabelsToIssue).toHaveBeenCalled();
+    expect(prepareIssueWorkspace).toHaveBeenCalledOnce();
+
+    expect(report.runDetail).toBeDefined();
+    const detail = report.runDetail!;
+    await expect(readFile(detail.promptPath, "utf8")).resolves.toContain(
+      "Autonomous run instructions"
+    );
+    await expect(readFile(detail.promptPath, "utf8")).resolves.toContain(
+      issueTitle
+    );
+  });
+
+  it("surfaces a failed terminal run state when the provider exits non-zero", async () => {
+    const root = await makeTempRoot();
+    await writeBootstrapProject(root);
+
+    const issueNumber = 99;
+    const issueDirectory = `${issueNumber}-provider-failure`;
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      issueDirectory
+    );
+    await mkdir(workspacePath, { recursive: true });
+
+    const githubApi = successfulGitHubApi();
+    const githubIssuesApi: GitHubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        {
+          body: "This run will fail.",
+          created_at: "2026-04-20T10:00:00Z",
+          html_url: `https://github.com/pmatos/symphonika/issues/${issueNumber}`,
+          id: 6000 + issueNumber,
+          labels: [{ name: "agent-ready" }],
+          number: issueNumber,
+          state: "open",
+          title: "Provider terminal failure",
+          updated_at: "2026-04-21T11:00:00Z"
+        }
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codex: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: { exitCode: 1, type: "process_exit" },
+          raw: { code: 1, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve({
+          branchName: `sym/symphonika/${issueDirectory}`,
+          branchRef: `refs/heads/sym/symphonika/${issueDirectory}`,
+          cachePath: path.join(
+            root,
+            ".symphonika",
+            "workspaces",
+            "symphonika",
+            ".cache",
+            "repo.git"
+          ),
+          issueDirectoryName: issueDirectory,
+          reused: false,
+          workspacePath
+        })
+    );
+
+    const report = await runSmoke({
+      agentProviders: { codex },
+      configPath: path.join(root, "symphonika.yml"),
+      cwd: root,
+      env: { GITHUB_TOKEN: "test-token" },
+      githubApi,
+      githubIssuesApi,
+      prepareIssueWorkspace
+    });
+
+    expect(report.dispatched).toBe(true);
+    expect(report.runDetail?.state).toBe("failed");
+    expect(report.ok).toBe(false);
+  });
+});
+
+async function writeBootstrapProject(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      '    command: "codex --dangerously-bypass-approvals-and-sandbox app-server"',
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked"]',
+      "    priority:",
+      "      labels:",
+      '        "priority:high": 1',
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "WORKFLOW.md"),
+    [
+      "Work on #{{issue.number}}: {{issue.title}}.",
+      "Use {{workspace.path}} on {{branch.name}}.",
+      "Provider {{provider.name}} runs {{provider.command}}.",
+      ""
+    ].join("\n")
+  );
+}
+
+function successfulGitHubApi(): GitHubApi {
+  return {
+    createLabel: () => Promise.resolve(),
+    listLabels: () => Promise.resolve([...REQUIRED_OPERATIONAL_LABELS]),
+    validateRepositoryAccess: () => Promise.resolve({ ok: true })
+  };
+}
+
+function fakeCodexProvider(): AgentProvider {
+  return {
+    cancel: vi.fn().mockResolvedValue(undefined),
+    name: "codex",
+    runAttempt: vi.fn(async function* () {
+      await Promise.resolve();
+      yield* [];
+    }),
+    validate: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+// Re-export to satisfy ts module shape; not a runtime use.
+export type { AgentProviderRegistry };


### PR DESCRIPTION
Closes #14.

## Summary

- Add the non-secret bootstrap `symphonika.yml` and the repository `WORKFLOW.md` so this repo can be run as a real Symphonika Project.
- Add a one-shot `symphonika smoke` CLI command that validates config via `doctor`, polls once, dispatches one eligible issue through the configured provider, persists evidence, and exits.
- Add an opt-in CI `smoke` job that is skipped by default unless `vars.SYMPHONIKA_SMOKE_ENABLED == 'true'` (or `workflow_dispatch`) and a `SYMPHONIKA_SMOKE_GITHUB_TOKEN` secret is configured.
- `runSmoke` reuses `dispatchOneEligibleIssue` (built with `schedule: () => undefined`) so smoke performs exactly one attempt with no retries or continuations. Smoke never auto-creates GitHub labels — operators must run `init-project --yes` separately to create the `sym:*` operational labels.

## Acceptance criteria

- [x] Repository includes a non-secret bootstrap `symphonika.yml` for the `pmatos/symphonika` Project.
- [x] Repository includes a `WORKFLOW.md` suitable for autonomous full-permission Symphonika implementation issues.
- [x] `.symphonika/` and workspace/runtime artifacts are gitignored (already covered by existing `.gitignore`).
- [x] `doctor` passes for the bootstrap Project when required credentials, labels, provider binaries, and workflow files are available.
- [x] A documented opt-in smoke command can claim one `agent-ready` issue, prepare its worktree and branch, run the configured Codex or Claude provider, and show logs/state afterward.
- [x] The smoke path is skipped by default in CI unless credentials and provider binaries are explicitly available.
- [x] Any GitHub label creation required for the smoke path still requires explicit confirmation (smoke calls only `runDoctor`, never `runInitProject`).

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 161/161 across 28 files, including 4 new smoke cases (no-eligible-issue, doctor-failure short-circuit, happy path with evidence persistence, provider terminal failure → `ok: false`) and 3 new CLI assertions (dispatched/skipped/failed exit codes).
- [x] `npm run build` produces a `dist/cli.js` exposing the new `smoke` subcommand alongside `daemon`/`doctor`/`init-project`.
- [ ] Operator-side end-to-end smoke against a live `agent-ready` issue (requires real `GITHUB_TOKEN` and a provider binary on `PATH`; documented in `docs/smoke.md`).