### PR TITLE
[codex] Add project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Symphonika
+
+Symphonika is a TypeScript/Node orchestrator that turns eligible GitHub issues into autonomous coding-agent runs. It prepares deterministic workspaces and issue branches, dispatches Codex or Claude under operator control, and records enough evidence for debugging, continuation, and review.
+
+## Documentation
+
+- [SPEC.md](SPEC.md) is the implementation contract.
+- [CONTEXT.md](CONTEXT.md) defines the project language and domain boundaries.
+- [AGENTS.md](AGENTS.md) gives repository instructions for coding agents.
+- [docs/adr/](docs/adr/) records accepted architecture decisions.
+
+## Quick Start
+
+```sh
+git clone https://github.com/pmatos/symphonika.git
+cd symphonika
+npm ci
+```
+
+Run the local quality gate:
+
+```sh
+npm run lint
+npm run typecheck
+npm test
+npm run build
+```
+
+## Self-Hosting
+
+The bootstrap dogfooding path is documented in [docs/smoke.md](docs/smoke.md). The repository includes a bootstrap [symphonika.yml](symphonika.yml) service config and [WORKFLOW.md](WORKFLOW.md) workflow contract for running Symphonika against its own issues.
+
+## Status and License
+
+This repository is private and experimental, built for a single-operator workflow. No public license is currently declared.

--- a/tests/readme.test.ts
+++ b/tests/readme.test.ts
@@ -1,0 +1,60 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const readmePath = path.join(repoRoot, "README.md");
+
+describe("README", () => {
+  it("orients visitors with valid relative documentation links", async () => {
+    const readme = await readFile(readmePath, "utf8");
+
+    expect(readme).toContain("Symphonika is a TypeScript/Node orchestrator");
+    expect(readme).toContain("[SPEC.md](SPEC.md)");
+    expect(readme).toContain("[CONTEXT.md](CONTEXT.md)");
+    expect(readme).toContain("[AGENTS.md](AGENTS.md)");
+    expect(readme).toContain("[docs/adr/](docs/adr/)");
+
+    for (const href of extractMarkdownLinks(readme)) {
+      if (isExternalOrAnchorLink(href)) {
+        continue;
+      }
+
+      const target = href.split("#")[0] ?? "";
+      expect(target).not.toBe("");
+      await expect(access(path.join(repoRoot, target))).resolves.toBeUndefined();
+    }
+  });
+
+  it("documents the quality gate and avoids local operator details", async () => {
+    const readme = await readFile(readmePath, "utf8");
+
+    expect(readme).toContain("npm ci");
+    expect(readme).toContain("npm run lint");
+    expect(readme).toContain("npm run typecheck");
+    expect(readme).toContain("npm test");
+    expect(readme).toContain("npm run build");
+    expect(readme).toContain("[docs/smoke.md](docs/smoke.md)");
+    expect(readme).toContain("[WORKFLOW.md](WORKFLOW.md)");
+    expect(readme).toContain("[symphonika.yml](symphonika.yml)");
+    expect(readme).toContain("private and experimental");
+    expect(readme).toContain("single-operator workflow");
+
+    expect(readme).not.toMatch(/\/home\/|\/Users\/|GITHUB_TOKEN|gh[pousr]_[A-Za-z0-9_]+/);
+  });
+});
+
+function extractMarkdownLinks(markdown: string): string[] {
+  return [...markdown.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)]
+    .map((match) => match[1])
+    .filter((href): href is string => href !== undefined);
+}
+
+function isExternalOrAnchorLink(href: string): boolean {
+  return (
+    href.startsWith("#") ||
+    href.startsWith("http://") ||
+    href.startsWith("https://") ||
+    href.startsWith("mailto:")
+  );
+}

--- a/tests/readme.test.ts
+++ b/tests/readme.test.ts
@@ -40,7 +40,9 @@ describe("README", () => {
     expect(readme).toContain("private and experimental");
     expect(readme).toContain("single-operator workflow");
 
-    expect(readme).not.toMatch(/\/home\/|\/Users\/|GITHUB_TOKEN|gh[pousr]_[A-Za-z0-9_]+/);
+    expect(readme).not.toMatch(
+      /\/home\/|\/Users\/|GITHUB_TOKEN|gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Add a top-level README that orients visitors to Symphonika and links the source-of-truth docs.
- Include quick-start quality-gate commands and the self-hosting smoke/workflow pointers.
- Add README coverage for relative links, expected commands, and accidental local/token leakage.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

Closes #46