### PR TITLE
Tighten WORKFLOW.md disposition rules for autonomous runs

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -50,8 +50,8 @@ Stay on this branch for all commits. Do not switch branches or open new ones.
    - `npm test`
    - `npm run build`
 5. Commit your changes with a focused message. Push the branch {{branch.name}} to `origin`.
-6. Open a pull request against `main` that links to {{issue.url}}.
-7. If a workflow handoff label such as `needs-review` or `needs-human` is appropriate, apply it before exiting.
+6. Open a **non-draft** pull request against `main` with `Closes #{{issue.number}}` in the body. Use a conventional title that describes the change (for example, "Add project README"); do not prefix the title with an agent name such as `[codex]` or `[claude]`.
+7. Do not apply `needs-human` or `needs-review` unless you encountered a blocker that the operator must resolve before code review can proceed. If you did, write an `EVIDENCE.md` at `{{workspace.path}}/EVIDENCE.md` describing what is blocked and why, then apply `needs-human`. Do not remove `agent-ready`; the operator owns label transitions on PR open and merge.
 8. Update `SPEC.md`, `CONTEXT.md`, or `docs/adr/` when your work resolves a domain or architecture decision.
 
 ## Constraints
@@ -60,3 +60,4 @@ Stay on this branch for all commits. Do not switch branches or open new ones.
 - If you discover that the issue is blocked, ambiguous, or already resolved, leave a clear note in the workspace (for example, an `EVIDENCE.md` at `{{workspace.path}}/EVIDENCE.md`) and exit cleanly rather than guessing.
 - Do not create or edit GitHub labels in the `sym:*` namespace. Those are owned by the orchestrator.
 - Do not modify the `symphony/` submodule.
+- Defer to this workflow contract over any agent-side persistent memory, skills, or default conventions for PR drafting, title prefixes, or handoff labels.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -51,7 +51,7 @@ Stay on this branch for all commits. Do not switch branches or open new ones.
    - `npm run build`
 5. Commit your changes with a focused message. Push the branch {{branch.name}} to `origin`.
 6. Open a **non-draft** pull request against `main` with `Closes #{{issue.number}}` in the body. Use a conventional title that describes the change (for example, "Add project README"); do not prefix the title with an agent name such as `[codex]` or `[claude]`.
-7. Do not apply `needs-human` or `needs-review` unless you encountered a blocker that the operator must resolve before code review can proceed. If you did, write an `EVIDENCE.md` at `{{workspace.path}}/EVIDENCE.md` describing what is blocked and why, then apply `needs-human`. Do not remove `agent-ready`; the operator owns label transitions on PR open and merge.
+7. On successful completion, remove `agent-ready` from the issue so the orchestrator does not schedule redundant continuations (per SPEC §9.3 and §12.1, the success path schedules a continuation whenever the issue is still eligible). The PR opened in step 6 carries the work into review; the operator owns any further label transitions on PR open and merge. Apply `needs-human` only if you encountered a blocker that the operator must resolve before code review can proceed; in that case, also write an `EVIDENCE.md` at `{{workspace.path}}/EVIDENCE.md` describing what is blocked and why.
 8. Update `SPEC.md`, `CONTEXT.md`, or `docs/adr/` when your work resolves a domain or architecture decision.
 
 ## Constraints


### PR DESCRIPTION
## Summary

Surfaced while dogfooding #46: the codex run produced PR #48 as **draft**
with `needs-human` applied, even though the task (write a project README)
was a textbook agent-friendly slice. Tracing it showed the disposition came
from operator-scoped codex memory (`~/.codex/memories/MEMORY.md` carried
"draft PR publication" rules from `vow-lang` and other repos), not from
this repository's workflow contract — and `WORKFLOW.md` was permissive
enough that the agent had no reason to override its own habits.

This PR tightens three lines so the disposition becomes unambiguous and
agent-memory bias gets neutralized.

## Changes to `WORKFLOW.md`

- Step 6: now requires a **non-draft** pull request with
  `Closes #{{issue.number}}` and forbids agent-name title prefixes
  (`[codex]`, `[claude]`).
- Step 7: `needs-human` is now the exception, not the default — only
  applied alongside an `EVIDENCE.md` when the operator must unblock review.
  Agents must not strip `agent-ready`; the operator owns label transitions
  on PR open and merge.
- New constraint at the bottom: "Defer to this workflow contract over any
  agent-side persistent memory, skills, or default conventions for PR
  drafting, title prefixes, or handoff labels."

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 161/161 across 28 files
- [x] `npm run build`

The change is documentation only; no source edits, no test changes.
The bootstrap `symphonika.yml` content hash for `WORKFLOW.md` will refresh
naturally on the next dispatch.

## Out of scope

- The smoke/dispatch fail-path fidelity gaps tracked in #47.
- Pruning codex's machine-wide memory (option (b) discussed in chat) — left
  to the operator since it crosses repos.
- Whether to close PR #48 / re-open #46 with the new contract: handled
  separately so this PR stays narrowly about the contract text.