### PR TITLE
Tighten run lifecycle controls

### DIFF
--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -396,11 +396,36 @@ export class RunController {
       token
     };
 
+    // Re-check issue state at the moment the continuation fires. The success
+    // path already checks before scheduling, but operators may remove
+    // agent-ready or add needs-human during the short continuation delay.
+    const refreshed = await this.refreshIssue({
+      project,
+      issueNumber: payload.issue.number,
+      repository
+    });
+    if (refreshed === undefined) {
+      this.logger?.warn(
+        { projectName: payload.projectName, parentRunId: payload.parentRunId },
+        "symphonika continuation dropped: issue refresh unavailable"
+      );
+      return;
+    }
+    if (refreshed === null || refreshed.state !== "open") {
+      return;
+    }
+    const eligibility = evaluateProjectEligibility(refreshed, project, {
+      ignoreOperationalLabels: true
+    });
+    if (!eligibility.eligible) {
+      return;
+    }
+
     const runId = this.createRunId();
     await this.runFreshLifecycle({
       attemptNumber: 1,
       isContinuation: true,
-      issue: payload.issue,
+      issue: refreshed,
       parentRunId: payload.parentRunId,
       project,
       provider,

--- a/tests/dispatch-continuation.test.ts
+++ b/tests/dispatch-continuation.test.ts
@@ -322,4 +322,78 @@ describe("dispatch continuation cap", () => {
       await daemon.stop();
     }
   });
+
+  it("does not start scheduled continuation when issue loses eligibility during delay", async () => {
+    const root = await makeTempRoot();
+    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    await writeProject(root);
+
+    let runAttemptCount = 0;
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        runAttemptCount += 1;
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi
+        .fn()
+        // First refresh schedules the continuation.
+        .mockResolvedValueOnce({ ...baseIssue, labels: ["agent-ready"] })
+        // Second refresh happens when the scheduled continuation fires.
+        .mockResolvedValue({
+          ...baseIssue,
+          labels: ["agent-ready", "needs-human"]
+        }),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(preparedWorkspaceFixture(root))
+    );
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => `run-cont-loss-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastContinuationPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "succeeded")
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 80));
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) => r.json())) as {
+        runs: Array<Record<string, unknown>>;
+      };
+      expect(status.runs).toHaveLength(1);
+      expect(status.runs[0]?.["isContinuation"]).toBe(false);
+      expect(runAttemptCount).toBe(1);
+      expect(prepareIssueWorkspace).toHaveBeenCalledTimes(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
 });

--- a/tests/dispatch-project-disable.test.ts
+++ b/tests/dispatch-project-disable.test.ts
@@ -64,7 +64,7 @@ function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
 
 async function writeProject(
   root: string,
-  overrides: { disabled?: boolean } = {}
+  overrides: { disabled?: boolean; name?: string } = {}
 ): Promise<void> {
   await writeFile(
     path.join(root, "symphonika.yml"),
@@ -79,7 +79,7 @@ async function writeProject(
       "  claude:",
       '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
       "projects:",
-      "  - name: symphonika",
+      `  - name: ${overrides.name ?? "symphonika"}`,
       `    disabled: ${overrides.disabled ?? false}`,
       "    weight: 1",
       "    tracker:",
@@ -277,6 +277,81 @@ describe("dispatch project disable", () => {
       };
       expect(status.runs).toHaveLength(0);
       expect(provider.validate).not.toHaveBeenCalled();
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("removing a project mid-flight does not interrupt the active run; no continuation is scheduled afterwards", async () => {
+    const root = await makeTempRoot();
+    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    await writeProject(root);
+
+    let runAttemptCount = 0;
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        runAttemptCount += 1;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue({ ...baseIssue, labels: ["agent-ready"] }),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve(preparedWorkspaceFixture(root))
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => `run-removal-${runAttemptCount + 1}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastContinuationPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "running")
+      );
+
+      // The original Project disappears from config while another valid Project remains.
+      await writeProject(root, { name: "other-project" });
+
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "succeeded")
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) => r.json())) as {
+        runs: Array<Record<string, unknown>>;
+      };
+      const continuations = status.runs.filter(
+        (run) => run["isContinuation"] === true
+      );
+      expect(continuations).toHaveLength(0);
+      expect(status.runs).toHaveLength(1);
+      expect(status.runs[0]?.["state"]).toBe("succeeded");
+      expect(provider.cancel).not.toHaveBeenCalled();
     } finally {
       await daemon.stop();
     }


### PR DESCRIPTION
## Summary

- Re-check issue state and eligibility when a scheduled continuation fires before claiming and launching a provider.
- Add daemon coverage for continuation delay eligibility loss and Project removal during an active run.

## Validation

- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #43