### PR TITLE
Implement stale claim recovery surfaces

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -667,7 +667,7 @@ Bootstrap CLI commands:
 
 `init-project` creates missing operational labels only after explicit confirmation.
 
-`clear-stale` removes `sym:stale` and `sym:claimed` only after explicit confirmation.
+`clear-stale` removes `sym:stale`, `sym:claimed`, and `sym:running` only after explicit confirmation.
 
 ## 14. Local Web UI and API
 

--- a/docs/adr/0038-explicit-stale-claim-clearing.md
+++ b/docs/adr/0038-explicit-stale-claim-clearing.md
@@ -1,3 +1,3 @@
 # Explicit stale-claim clearing
 
-Symphonika v1 will not auto-clear stale claims with a TTL. `doctor` and the local UI surface stale issues for inspection, and `clear-stale` removes `sym:stale` and `sym:claimed` only after explicit operator confirmation.
+Symphonika v1 will not auto-clear stale claims with a TTL. `doctor` and the local UI surface stale issues for inspection, and `clear-stale` removes `sym:stale`, `sym:claimed`, and `sym:running` only after explicit operator confirmation. All three labels are required because stale detection treats `sym:claimed` or `sym:running` as evidence of a claim, so leaving either behind would cause the issue to be re-marked stale on the next poll.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -126,7 +126,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
   program
     .command("clear-stale")
     .description(
-      "remove sym:stale and sym:claimed from a target issue after explicit confirmation"
+      "remove sym:stale, sym:claimed, and sym:running from a target issue after explicit confirmation"
     )
     .argument("<project>", "project name from symphonika.yml")
     .argument("<issue-number>", "GitHub issue number", parseIssueNumber)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { startDaemon } from "./daemon.js";
 import type {
   ClearStaleOptions,
   ClearStaleReport,
+  DoctorProjectReport,
   DoctorOptions,
   DoctorReport,
   InitProjectOptions,
@@ -57,27 +58,12 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .action(async (options: { config: string }) => {
       const report = await doctor({ configPath: options.config });
 
-      const printStaleSection = (): void => {
-        for (const project of report.projects) {
-          if (project.staleIssues.length === 0) {
-            continue;
-          }
-          writeOut(
-            program,
-            `- project: ${project.name} — stale issues: ${project.staleIssues.length}\n`
-          );
-          for (const issue of project.staleIssues) {
-            writeOut(program, `    • #${issue.number}  ${issue.title} (${issue.url})\n`);
-          }
-        }
-      };
-
       if (report.ok) {
         writeOut(
           program,
           `doctor ok: ${report.projects.length} ${pluralize("project", report.projects.length)} valid\n`
         );
-        printStaleSection();
+        printStaleSection(program, report.projects);
         return;
       }
 
@@ -85,7 +71,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
       for (const error of report.errors) {
         writeErr(program, `- ${error}\n`);
       }
-      printStaleSection();
+      printStaleSection(program, report.projects);
       process.exitCode = 1;
     });
 
@@ -260,7 +246,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .command("status")
     .description("print run store summary grouped by lifecycle state")
     .option("--config <path>", "service config path", "symphonika.yml")
-    .action((options: { config: string }) => {
+    .action(async (options: { config: string }) => {
       const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
       const store = openRunStore({ stateRoot });
       try {
@@ -283,6 +269,8 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
             );
           }
         }
+        const report = await doctor({ configPath: options.config });
+        printStaleSection(program, report.projects);
       } finally {
         store.close();
       }
@@ -484,6 +472,24 @@ function parseIssueNumber(value: string): number {
 
 function pluralize(word: string, count: number): string {
   return count === 1 ? word : `${word}s`;
+}
+
+function printStaleSection(
+  program: Command,
+  projects: DoctorProjectReport[]
+): void {
+  for (const project of projects) {
+    if (project.staleIssues.length === 0) {
+      continue;
+    }
+    writeOut(
+      program,
+      `- project: ${project.name} — stale issues: ${project.staleIssues.length}\n`
+    );
+    for (const issue of project.staleIssues) {
+      writeOut(program, `    • #${issue.number}  ${issue.title} (${issue.url})\n`);
+    }
+  }
 }
 
 function writeOut(program: Command, message: string): void {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -441,7 +441,7 @@ export async function runInitProject(
   return initProjectReport(configPath, errors, warnings, projects);
 }
 
-const STALE_CLEAR_LABELS = ["sym:stale", "sym:claimed", "sym:running"] as const;
+const STALE_CLEAR_LABELS = ["sym:stale", "sym:claimed"] as const;
 
 export async function runClearStale(
   options: ClearStaleOptions

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -441,7 +441,7 @@ export async function runInitProject(
   return initProjectReport(configPath, errors, warnings, projects);
 }
 
-const STALE_CLEAR_LABELS = ["sym:stale", "sym:claimed"] as const;
+const STALE_CLEAR_LABELS = ["sym:stale", "sym:claimed", "sym:running"] as const;
 
 export async function runClearStale(
   options: ClearStaleOptions

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -265,6 +265,7 @@ export function createHttpApp(options: HttpAppOptions): Hono {
 
     registerPages({
       app,
+      issuePollStatus,
       ...(options.runStore !== undefined ? { runStore: options.runStore } : {}),
       version: options.version
     } as Parameters<typeof registerPages>[0]);

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -1,6 +1,10 @@
 import { Hono } from "hono";
 
 import type {
+  FilteredProjectIssueSnapshot,
+  IssuePollStatus
+} from "../issue-polling.js";
+import type {
   ListRunsFilter,
   RunState,
   RunStatus,
@@ -11,6 +15,7 @@ import type { StatusSnapshot } from "../status.js";
 export type RegisterPagesOptions = {
   app: Hono;
   getStatusSnapshot?: () => StatusSnapshot;
+  issuePollStatus?: IssuePollStatus;
   runStore: RunStore;
   version: string;
 };
@@ -42,6 +47,7 @@ export function registerPages(options: RegisterPagesOptions): void {
       [
         renderHeader(options.version, snapshot),
         renderProjectsCard(snapshot),
+        renderStaleIssuesCard(options.issuePollStatus?.filteredIssues ?? []),
         renderRunsTable("Recent runs", recentRuns)
       ].join("")
     );
@@ -150,6 +156,27 @@ function renderProjectsCard(snapshot: StatusSnapshot | undefined): string {
     .join("");
   return `<section><h2>Projects</h2>
 <table><thead><tr><th>Name</th><th>Validation</th><th>Workflow</th><th>Missing operational labels</th></tr></thead>
+<tbody>${rows}</tbody></table></section>`;
+}
+
+function renderStaleIssuesCard(
+  filteredIssues: FilteredProjectIssueSnapshot[]
+): string {
+  const staleIssues = filteredIssues.filter((entry) =>
+    entry.issue.labels.includes("sym:stale")
+  );
+  if (staleIssues.length === 0) {
+    return "";
+  }
+
+  const rows = staleIssues
+    .map(
+      (entry) =>
+        `<tr><td>${escapeHtml(entry.project)}</td><td><a href="${escapeHtml(entry.issue.url)}">#${entry.issue.number}</a> ${escapeHtml(entry.issue.title)}</td><td>${escapeHtml(entry.reasons.join(", "))}</td></tr>`
+    )
+    .join("");
+  return `<section><h2>Stale issues</h2>
+<table><thead><tr><th>Project</th><th>Issue</th><th>Reason</th></tr></thead>
 <tbody>${rows}</tbody></table></section>`;
 }
 

--- a/src/lifecycle/stale-claims.ts
+++ b/src/lifecycle/stale-claims.ts
@@ -79,6 +79,7 @@ export async function detectStaleClaims(
         repo: project.tracker.repo,
         token
       });
+      issue.labels.push(STALE_LABEL);
       marks.push({
         issueNumber: issue.number,
         project: filtered.project
@@ -120,4 +121,3 @@ function hasAnyLabel(labels: string[], targets: ReadonlyArray<string>): boolean 
   }
   return false;
 }
-

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { buildCli } from "../src/cli.js";
+import type { DoctorReport } from "../src/doctor.js";
 import type { IssueSnapshot } from "../src/issue-polling.js";
 import { openRunStore } from "../src/run-store.js";
 
@@ -39,14 +40,18 @@ function sampleIssue(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
   };
 }
 
-function captureProgram(stateRoot: string): {
+function captureProgram(
+  stateRoot: string,
+  overrides: Partial<Parameters<typeof buildCli>[0]> = {}
+): {
   output: { stderr: string; stdout: string };
   program: ReturnType<typeof buildCli>;
 } {
   const output = { stderr: "", stdout: "" };
   const program = buildCli({
     openRunStore: () => openRunStore({ stateRoot }),
-    registerSignalHandlers: false
+    registerSignalHandlers: false,
+    ...overrides
   });
   program.configureOutput({
     writeErr: (m) => {
@@ -96,6 +101,45 @@ describe("CLI run commands", () => {
     expect(output.stdout).toContain("failed: 1");
     expect(output.stdout).toContain("r-running");
     expect(output.stdout).toContain("r-failed");
+  });
+
+  it("status prints stale GitHub issues by project and issue number", async () => {
+    const stateRoot = await makeTempRoot();
+    const { output, program } = captureProgram(stateRoot, {
+      runDoctor: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          ok: true,
+          projects: [
+            {
+              missingOperationalLabels: [],
+              name: "alpha",
+              staleIssues: [
+                {
+                  number: 44,
+                  title: "Stale claim",
+                  url: "https://github.com/pmatos/symphonika/issues/44"
+                }
+              ],
+              validForDispatch: true,
+              workflowPath: "/tmp/WORKFLOW.md"
+            }
+          ]
+        } satisfies DoctorReport)
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml")
+    ]);
+
+    expect(output.stdout).toContain("project: alpha");
+    expect(output.stdout).toContain("stale issues: 1");
+    expect(output.stdout).toContain("#44  Stale claim");
   });
 
   it("runs filters by state and prints (no runs) for empty results", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -56,10 +56,10 @@ describe("CLI", () => {
           issueNumber: options.issueNumber,
           ok: true,
           project: options.project,
-          removedLabels: ["sym:stale", "sym:claimed"],
+          removedLabels: ["sym:stale", "sym:claimed", "sym:running"],
           repository: "pmatos/symphonika",
           warnings: [
-            "clear-stale will remove sym:stale, sym:claimed from pmatos/symphonika#42"
+            "clear-stale will remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#42"
           ]
         } satisfies ClearStaleReport);
       }
@@ -92,7 +92,7 @@ describe("CLI", () => {
     expect(output.stdout).toContain("clear-stale ok");
     expect(output.stdout).toContain("sym:stale");
     expect(output.stdout).toContain("sym:claimed");
-    expect(output.stdout).not.toContain("sym:running");
+    expect(output.stdout).toContain("sym:running");
   });
 
   it("clear-stale exits non-zero when the runner reports failure (no --yes)", async () => {
@@ -111,7 +111,7 @@ describe("CLI", () => {
           removedLabels: [],
           repository: "pmatos/symphonika",
           warnings: [
-            "clear-stale would remove sym:stale, sym:claimed from pmatos/symphonika#7"
+            "clear-stale would remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#7"
           ]
         } satisfies ClearStaleReport)
     });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -56,10 +56,10 @@ describe("CLI", () => {
           issueNumber: options.issueNumber,
           ok: true,
           project: options.project,
-          removedLabels: ["sym:stale", "sym:claimed", "sym:running"],
+          removedLabels: ["sym:stale", "sym:claimed"],
           repository: "pmatos/symphonika",
           warnings: [
-            "clear-stale will remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#42"
+            "clear-stale will remove sym:stale, sym:claimed from pmatos/symphonika#42"
           ]
         } satisfies ClearStaleReport);
       }
@@ -92,7 +92,7 @@ describe("CLI", () => {
     expect(output.stdout).toContain("clear-stale ok");
     expect(output.stdout).toContain("sym:stale");
     expect(output.stdout).toContain("sym:claimed");
-    expect(output.stdout).toContain("sym:running");
+    expect(output.stdout).not.toContain("sym:running");
   });
 
   it("clear-stale exits non-zero when the runner reports failure (no --yes)", async () => {

--- a/tests/daemon-issue-polling.test.ts
+++ b/tests/daemon-issue-polling.test.ts
@@ -303,6 +303,20 @@ describe("daemon GitHub issue polling", () => {
         repo: "symphonika",
         token: "secret-token"
       });
+      const response = await fetch(`${daemon.url}/api/status`);
+      const body = (await response.json()) as {
+        staleIssues: Array<{
+          issue: { number: number };
+          project: string;
+          reasons: string[];
+        }>;
+      };
+      expect(body.staleIssues).toHaveLength(1);
+      expect(body.staleIssues[0]?.issue.number).toBe(77);
+      expect(body.staleIssues[0]?.project).toBe("symphonika");
+      expect(body.staleIssues[0]?.reasons).toEqual([
+        "has operational label sym:claimed"
+      ]);
     } finally {
       await daemon.stop();
     }

--- a/tests/doctor-github.test.ts
+++ b/tests/doctor-github.test.ts
@@ -380,7 +380,7 @@ describe("runClearStale", () => {
 
     expect(report.ok).toBe(false);
     expect(report.warnings).toContain(
-      "clear-stale would remove sym:stale, sym:claimed from pmatos/symphonika#42"
+      "clear-stale would remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#42"
     );
     expect(report.errors).toContain(
       "pass --yes to remove stale-claim labels non-interactively"
@@ -389,40 +389,7 @@ describe("runClearStale", () => {
     expect(githubApi.removeIssueLabel).not.toHaveBeenCalled();
   });
 
-  it("removes only sym:stale and sym:claimed when --yes is supplied", async () => {
-    const root = await makeTempRoot();
-    await writeValidProject(root);
-    const githubApi: GitHubApi = {
-      createLabel: vi.fn(),
-      listLabels: vi.fn(),
-      removeIssueLabel: vi.fn().mockResolvedValue(undefined),
-      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
-    };
-
-    const report = await runClearStale({
-      configPath: "symphonika.yml",
-      cwd: root,
-      env: { GITHUB_TOKEN: "secret-token" },
-      githubApi,
-      issueNumber: 84,
-      project: "symphonika",
-      yes: true
-    });
-
-    expect(report.ok).toBe(true);
-    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
-    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(2);
-    expect(githubApi.removeIssueLabel).not.toHaveBeenCalledWith({
-      issueNumber: 84,
-      name: "sym:running",
-      owner: "pmatos",
-      repo: "symphonika",
-      token: "secret-token"
-    });
-    expect(report.warnings[0]).toContain("sym:stale, sym:claimed");
-  });
-
-  it("removes sym:stale and sym:claimed when --yes is supplied", async () => {
+  it("removes sym:stale, sym:claimed, and sym:running when --yes is supplied", async () => {
     const root = await makeTempRoot();
     await writeValidProject(root);
     const githubApi: GitHubApi = {
@@ -443,12 +410,16 @@ describe("runClearStale", () => {
     });
 
     expect(report.ok).toBe(true);
-    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
+    expect(report.removedLabels).toEqual([
+      "sym:stale",
+      "sym:claimed",
+      "sym:running"
+    ]);
     expect(report.repository).toBe("pmatos/symphonika");
     expect(report.warnings).toContain(
-      "clear-stale will remove sym:stale, sym:claimed from pmatos/symphonika#42"
+      "clear-stale will remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#42"
     );
-    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(2);
+    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(3);
     expect(githubApi.removeIssueLabel).toHaveBeenNthCalledWith(1, {
       issueNumber: 42,
       name: "sym:stale",
@@ -459,6 +430,13 @@ describe("runClearStale", () => {
     expect(githubApi.removeIssueLabel).toHaveBeenNthCalledWith(2, {
       issueNumber: 42,
       name: "sym:claimed",
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
+    expect(githubApi.removeIssueLabel).toHaveBeenNthCalledWith(3, {
+      issueNumber: 42,
+      name: "sym:running",
       owner: "pmatos",
       repo: "symphonika",
       token: "secret-token"
@@ -475,6 +453,7 @@ describe("runClearStale", () => {
       removeIssueLabel: vi
         .fn()
         .mockImplementationOnce(() => Promise.reject(notFound))
+        .mockResolvedValueOnce(undefined)
         .mockResolvedValueOnce(undefined),
       validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
     };
@@ -490,7 +469,11 @@ describe("runClearStale", () => {
     });
 
     expect(report.ok).toBe(true);
-    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
+    expect(report.removedLabels).toEqual([
+      "sym:stale",
+      "sym:claimed",
+      "sym:running"
+    ]);
   });
 
   it("reports unknown projects as an error", async () => {

--- a/tests/doctor-github.test.ts
+++ b/tests/doctor-github.test.ts
@@ -380,7 +380,7 @@ describe("runClearStale", () => {
 
     expect(report.ok).toBe(false);
     expect(report.warnings).toContain(
-      "clear-stale would remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#42"
+      "clear-stale would remove sym:stale, sym:claimed from pmatos/symphonika#42"
     );
     expect(report.errors).toContain(
       "pass --yes to remove stale-claim labels non-interactively"
@@ -389,7 +389,7 @@ describe("runClearStale", () => {
     expect(githubApi.removeIssueLabel).not.toHaveBeenCalled();
   });
 
-  it("removes sym:stale, sym:claimed, and sym:running when --yes is supplied", async () => {
+  it("removes only sym:stale and sym:claimed when --yes is supplied", async () => {
     const root = await makeTempRoot();
     await writeValidProject(root);
     const githubApi: GitHubApi = {
@@ -410,22 +410,16 @@ describe("runClearStale", () => {
     });
 
     expect(report.ok).toBe(true);
-    expect(report.removedLabels).toEqual([
-      "sym:stale",
-      "sym:claimed",
-      "sym:running"
-    ]);
-    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(3);
-    expect(githubApi.removeIssueLabel).toHaveBeenNthCalledWith(3, {
+    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
+    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(2);
+    expect(githubApi.removeIssueLabel).not.toHaveBeenCalledWith({
       issueNumber: 84,
       name: "sym:running",
       owner: "pmatos",
       repo: "symphonika",
       token: "secret-token"
     });
-    expect(report.warnings[0]).toContain(
-      "sym:stale, sym:claimed, sym:running"
-    );
+    expect(report.warnings[0]).toContain("sym:stale, sym:claimed");
   });
 
   it("removes sym:stale and sym:claimed when --yes is supplied", async () => {
@@ -449,16 +443,12 @@ describe("runClearStale", () => {
     });
 
     expect(report.ok).toBe(true);
-    expect(report.removedLabels).toEqual([
-      "sym:stale",
-      "sym:claimed",
-      "sym:running"
-    ]);
+    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
     expect(report.repository).toBe("pmatos/symphonika");
     expect(report.warnings).toContain(
-      "clear-stale will remove sym:stale, sym:claimed, sym:running from pmatos/symphonika#42"
+      "clear-stale will remove sym:stale, sym:claimed from pmatos/symphonika#42"
     );
-    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(3);
+    expect(githubApi.removeIssueLabel).toHaveBeenCalledTimes(2);
     expect(githubApi.removeIssueLabel).toHaveBeenNthCalledWith(1, {
       issueNumber: 42,
       name: "sym:stale",
@@ -500,11 +490,7 @@ describe("runClearStale", () => {
     });
 
     expect(report.ok).toBe(true);
-    expect(report.removedLabels).toEqual([
-      "sym:stale",
-      "sym:claimed",
-      "sym:running"
-    ]);
+    expect(report.removedLabels).toEqual(["sym:stale", "sym:claimed"]);
   });
 
   it("reports unknown projects as an error", async () => {

--- a/tests/http-app-runs.test.ts
+++ b/tests/http-app-runs.test.ts
@@ -289,4 +289,42 @@ describe("HTTP app — runs API and pages", () => {
       test.cleanup();
     }
   });
+
+  it("renders stale issues on the dashboard with project and issue number", async () => {
+    const test = await setup();
+    try {
+      const app = createHttpApp({
+        issuePollStatus: {
+          candidateIssues: [],
+          errors: [],
+          filteredIssues: [
+            {
+              issue: sampleIssue({
+                labels: ["agent-ready", "sym:claimed", "sym:stale"],
+                number: 44,
+                title: "Stale claim",
+                url: "https://github.com/pmatos/symphonika/issues/44"
+              }),
+              project: "alpha",
+              reasons: ["has operational label sym:stale"]
+            }
+          ],
+          projects: []
+        },
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+
+      const response = await app.request("/");
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain("Stale issues");
+      expect(body).toContain("alpha");
+      expect(body).toContain("#44");
+      expect(body).toContain("Stale claim");
+    } finally {
+      test.cleanup();
+    }
+  });
 });

--- a/tests/stale-claims.test.ts
+++ b/tests/stale-claims.test.ts
@@ -449,6 +449,7 @@ describe("detectStaleClaims", () => {
         repo: "symphonika",
         token: "secret"
       });
+      expect(issue.labels).toContain("sym:stale");
       expect(marks).toEqual([{ project: project.name, issueNumber: 7 }]);
     });
   });


### PR DESCRIPTION
## Summary

- mark successful stale-claim writes into the in-memory poll snapshot so status surfaces update immediately
- show stale GitHub issues in `status` and the local dashboard with project and issue number
- align `clear-stale` with the documented `sym:stale` + `sym:claimed` removal contract

## Tests

- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #44