### PR TITLE
Preserve `this` when calling optional GitHubIssuesApi methods

### DIFF
--- a/src/issue-polling.ts
+++ b/src/issue-polling.ts
@@ -212,6 +212,32 @@ class OctokitGitHubIssuesApi implements GitHubIssuesApi {
 export const DEFAULT_GITHUB_ISSUES_API = new OctokitGitHubIssuesApi();
 export const DEFAULT_POLLING_INTERVAL_MS = 30_000;
 
+// Invoke optional GitHubIssuesApi methods through the property accessor so the
+// implementation's `this` binding is preserved. Extracting `api.method` into a
+// local variable strips `this` and breaks class-based implementations like
+// OctokitGitHubIssuesApi (see issue-polling.ts:148).
+
+export async function tryAddLabelsToIssue(
+  api: GitHubIssuesApi,
+  input: GitHubIssueLabelInput
+): Promise<boolean> {
+  if (api.addLabelsToIssue === undefined) {
+    return false;
+  }
+  await api.addLabelsToIssue(input);
+  return true;
+}
+
+export async function tryGetIssue(
+  api: GitHubIssuesApi,
+  input: GitHubIssueRepositoryInput & { issueNumber: number }
+): Promise<RawGitHubIssue | null | undefined> {
+  if (api.getIssue === undefined) {
+    return undefined;
+  }
+  return api.getIssue(input);
+}
+
 export function emptyIssuePollStatus(): IssuePollStatus {
   return {
     candidateIssues: [],

--- a/src/lifecycle/reconcile.ts
+++ b/src/lifecycle/reconcile.ts
@@ -2,11 +2,11 @@ import type { Logger } from "pino";
 
 import {
   evaluateProjectEligibility,
+  tryGetIssue,
   type GitHubIssuesApi,
   type IssuePollStatus,
   type IssueSnapshot,
-  type PollingProjectConfig,
-  type RawGitHubIssue
+  type PollingProjectConfig
 } from "../issue-polling.js";
 import type { RunStore } from "../run-store.js";
 
@@ -70,18 +70,9 @@ async function handleMissingFromPoll(input: ReconcileInput & {
     return;
   }
 
-  const fetcher = input.githubIssuesApi.getIssue;
-  if (fetcher === undefined) {
-    input.logger.warn(
-      { runId: input.entry.runId },
-      "symphonika reconcile skipped: githubIssuesApi.getIssue not available"
-    );
-    return;
-  }
-
-  let raw: RawGitHubIssue | null;
+  let raw;
   try {
-    raw = await fetcher({
+    raw = await tryGetIssue(input.githubIssuesApi, {
       issueNumber: input.entry.issueNumber,
       owner: input.project.tracker.owner,
       repo: input.project.tracker.repo,
@@ -91,6 +82,14 @@ async function handleMissingFromPoll(input: ReconcileInput & {
     input.logger.warn(
       { err: error, runId: input.entry.runId },
       "symphonika reconcile getIssue failed"
+    );
+    return;
+  }
+
+  if (raw === undefined) {
+    input.logger.warn(
+      { runId: input.entry.runId },
+      "symphonika reconcile skipped: githubIssuesApi.getIssue not available"
     );
     return;
   }

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -12,7 +12,7 @@ import type {
   IssueSnapshot,
   PollingProjectConfig
 } from "../issue-polling.js";
-import { evaluateProjectEligibility } from "../issue-polling.js";
+import { evaluateProjectEligibility, tryGetIssue } from "../issue-polling.js";
 import type {
   AgentProvider,
   AgentProviderName,
@@ -984,13 +984,9 @@ export class RunController {
     issueNumber: number;
     repository: GitHubIssueRepositoryInput;
   }): Promise<IssueSnapshot | null | undefined> {
-    const fetcher = this.githubIssuesApi.getIssue;
-    if (fetcher === undefined) {
-      return undefined;
-    }
     let raw;
     try {
-      raw = await fetcher({
+      raw = await tryGetIssue(this.githubIssuesApi, {
         issueNumber: input.issueNumber,
         owner: input.repository.owner,
         repo: input.repository.repo,
@@ -1001,6 +997,9 @@ export class RunController {
         { err: error },
         "symphonika continuation refresh failed"
       );
+      return undefined;
+    }
+    if (raw === undefined) {
       return undefined;
     }
     if (raw === null) {

--- a/src/lifecycle/stale-claims.ts
+++ b/src/lifecycle/stale-claims.ts
@@ -1,9 +1,10 @@
 import type { Logger } from "pino";
 
-import type {
-  GitHubIssuesApi,
-  IssuePollStatus,
-  PollingProjectConfig
+import {
+  tryAddLabelsToIssue,
+  type GitHubIssuesApi,
+  type IssuePollStatus,
+  type PollingProjectConfig
 } from "../issue-polling.js";
 import type { RunStore } from "../run-store.js";
 
@@ -62,23 +63,21 @@ export async function detectStaleClaims(
       continue;
     }
 
-    const addLabelsToIssue = input.githubIssuesApi.addLabelsToIssue;
-    if (addLabelsToIssue === undefined) {
-      input.logger.warn(
-        { project: filtered.project, issueNumber: issue.number },
-        "symphonika stale-claim detection skipped: addLabelsToIssue not available"
-      );
-      continue;
-    }
-
     try {
-      await addLabelsToIssue({
+      const called = await tryAddLabelsToIssue(input.githubIssuesApi, {
         issueNumber: issue.number,
         labels: [STALE_LABEL],
         owner: project.tracker.owner,
         repo: project.tracker.repo,
         token
       });
+      if (!called) {
+        input.logger.warn(
+          { project: filtered.project, issueNumber: issue.number },
+          "symphonika stale-claim detection skipped: addLabelsToIssue not available"
+        );
+        continue;
+      }
       issue.labels.push(STALE_LABEL);
       marks.push({
         issueNumber: issue.number,

--- a/tests/issue-polling-helpers.test.ts
+++ b/tests/issue-polling-helpers.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  tryAddLabelsToIssue,
+  tryGetIssue,
+  type GitHubIssueLabelInput,
+  type GitHubIssueRepositoryInput,
+  type GitHubIssuesApi,
+  type RawGitHubIssue
+} from "../src/issue-polling.js";
+
+const labelInput: GitHubIssueLabelInput = {
+  issueNumber: 1,
+  labels: ["sym:stale"],
+  owner: "pmatos",
+  repo: "symphonika",
+  token: "secret"
+};
+
+const fetchInput: GitHubIssueRepositoryInput & { issueNumber: number } = {
+  issueNumber: 1,
+  owner: "pmatos",
+  repo: "symphonika",
+  token: "secret"
+};
+
+describe("tryAddLabelsToIssue", () => {
+  it("preserves `this` when invoking a class-based implementation", async () => {
+    class Api {
+      readonly received: GitHubIssueLabelInput[] = [];
+      addLabelsToIssue(input: GitHubIssueLabelInput): Promise<void> {
+        this.received.push(input);
+        return Promise.resolve();
+      }
+      listOpenIssues(): Promise<never[]> {
+        return Promise.resolve([]);
+      }
+    }
+    const api = new Api();
+    const called = await tryAddLabelsToIssue(api, labelInput);
+    expect(called).toBe(true);
+    expect(api.received).toEqual([labelInput]);
+  });
+
+  it("returns false when the implementation does not provide addLabelsToIssue", async () => {
+    const api: GitHubIssuesApi = {
+      listOpenIssues: () => Promise.resolve([])
+    };
+    expect(await tryAddLabelsToIssue(api, labelInput)).toBe(false);
+  });
+
+  it("propagates errors thrown by the implementation", async () => {
+    const api: GitHubIssuesApi = {
+      addLabelsToIssue: () => Promise.reject(new Error("boom")),
+      listOpenIssues: () => Promise.resolve([])
+    };
+    await expect(tryAddLabelsToIssue(api, labelInput)).rejects.toThrow("boom");
+  });
+});
+
+describe("tryGetIssue", () => {
+  it("preserves `this` when invoking a class-based implementation", async () => {
+    class Api {
+      readonly received: Array<{ issueNumber: number }> = [];
+      getIssue(input: GitHubIssueRepositoryInput & { issueNumber: number }): Promise<RawGitHubIssue> {
+        this.received.push({ issueNumber: input.issueNumber });
+        return Promise.resolve({ number: input.issueNumber, state: "open" });
+      }
+      listOpenIssues(): Promise<never[]> {
+        return Promise.resolve([]);
+      }
+    }
+    const api = new Api();
+    const result = await tryGetIssue(api, fetchInput);
+    expect(api.received).toEqual([{ issueNumber: 1 }]);
+    expect(result).toEqual({ number: 1, state: "open" });
+  });
+
+  it("returns undefined when the implementation does not provide getIssue", async () => {
+    const api: GitHubIssuesApi = {
+      listOpenIssues: () => Promise.resolve([])
+    };
+    expect(await tryGetIssue(api, fetchInput)).toBeUndefined();
+  });
+
+  it("returns null when the implementation reports the issue is missing", async () => {
+    const api: GitHubIssuesApi = {
+      getIssue: () => Promise.resolve(null),
+      listOpenIssues: () => Promise.resolve([])
+    };
+    expect(await tryGetIssue(api, fetchInput)).toBeNull();
+  });
+});

--- a/tests/reconcile.test.ts
+++ b/tests/reconcile.test.ts
@@ -227,4 +227,55 @@ describe("reconcileActiveRuns", () => {
       expect(cancel).not.toHaveBeenCalled();
     });
   });
+
+  it("preserves `this` when calling getIssue on a class-based API", async () => {
+    await withRunStore(async (store) => {
+      store.createRun({
+        id: "run-a",
+        issue: snapshot(),
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const registry = new ActiveRunRegistry();
+      registry.register({
+        cancel,
+        issueNumber: 7,
+        projectName: project.name,
+        runId: "run-a"
+      });
+
+      class StubApi {
+        readonly calls: Array<{ issueNumber: number }> = [];
+        getIssue(input: {
+          issueNumber: number;
+          owner: string;
+          repo: string;
+          token: string;
+        }): Promise<null> {
+          this.calls.push({ issueNumber: input.issueNumber });
+          return Promise.resolve(null);
+        }
+        listOpenIssues(): Promise<never[]> {
+          return Promise.resolve([]);
+        }
+      }
+      const api = new StubApi();
+
+      await reconcileActiveRuns({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: api,
+        logger,
+        pollStatus: pollStatus([]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(api.calls).toEqual([{ issueNumber: 7 }]);
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(registry.get("run-a")?.cancelReason).toBe(CANCEL_REASONS.CLOSED_ISSUE);
+    });
+  });
 });

--- a/tests/stale-claims.test.ts
+++ b/tests/stale-claims.test.ts
@@ -453,4 +453,41 @@ describe("detectStaleClaims", () => {
       expect(marks).toEqual([{ project: project.name, issueNumber: 7 }]);
     });
   });
+
+  it("preserves `this` when calling addLabelsToIssue on a class-based API", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({ labels: ["agent-ready", "sym:claimed"] });
+
+      class StubApi {
+        readonly calls: Array<{ issueNumber: number; labels: string[] }> = [];
+        addLabelsToIssue(input: {
+          issueNumber: number;
+          labels: string[];
+          owner: string;
+          repo: string;
+          token: string;
+        }): Promise<void> {
+          this.calls.push({ issueNumber: input.issueNumber, labels: input.labels });
+          return Promise.resolve();
+        }
+        listOpenIssues(): Promise<never[]> {
+          return Promise.resolve([]);
+        }
+      }
+      const api = new StubApi();
+
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: api,
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(api.calls).toEqual([{ issueNumber: 7, labels: ["sym:stale"] }]);
+      expect(marks).toEqual([{ project: project.name, issueNumber: 7 }]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Three lifecycle modules (`stale-claims`, `reconcile`, `run-controller.refreshIssue`) extracted optional `GitHubIssuesApi` methods into local variables before invoking them, stripping the `this` binding. With the default `OctokitGitHubIssuesApi` (whose methods call `this.octokit(...)`), every invocation threw `TypeError: Cannot read properties of undefined (reading 'octokit')`.
- The bug surfaced in stale-claim detection on issue 45: every reconcile tick logged the same `TypeError`, and `sym:stale` was never applied. Reconcile and continuation-refresh would have hit the same wall the next time their paths fired against the real Octokit-backed API.
- Centralize the call pattern behind two helpers in `src/issue-polling.ts` — `tryAddLabelsToIssue` and `tryGetIssue` — that invoke the optional method through the property accessor (preserving `this`) and surface "method not supported" via the return value. Update all three affected sites to use them.

## Why the existing tests didn't catch it

The mocks were built from `vi.fn()`, which produces standalone arrow functions that don't depend on `this`. Calling them with or without their host object behaves identically, so the binding loss was invisible. The new regression tests use small class-based stubs whose methods touch `this`, which is exactly the shape the production `OctokitGitHubIssuesApi` has.

## Recovery for issue 45

Issue 45 still carries `sym:claimed` (and `sym:failed`) with no live run. Once this lands, the next daemon tick will add `sym:stale`; alternatively, `symphonika clear-stale 45` clears the operational labels on demand.

## Test plan

- [x] `npm test` — 178 / 178 pass (3 new tests: helper contract + integration regression in `stale-claims` and `reconcile`)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] Manually verified the new helper-contract tests fail against the pre-fix code (the integration tests were authored RED-first against the bug)