### PR TITLE
Read PINO_LOG_LEVEL when constructing the daemon logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ npm link && symphonika daemon    # link the bin once, then run from anywhere
 
 `npx symphonika daemon` does **not** work from inside this repo: a package's `bin` is only linked into a *consuming* project's `node_modules/.bin`, not its own, so npx silently finds nothing and exits.
 
+Set `PINO_LOG_LEVEL=debug` (or the alias `LOG_LEVEL=debug`) to raise daemon log verbosity for per-tick visibility, e.g. `PINO_LOG_LEVEL=debug npm run dev -- daemon`. Accepted values match pino's level set: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `silent`.
+
 The `symphony/` directory in the tree is a git submodule of an unrelated upstream project (`openai/symphony`) used as a reference — it is not a launcher for Symphonika.
 
 ## Self-Hosting

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -69,7 +69,8 @@ export type DaemonHandle = {
 export async function startDaemon(
   options: StartDaemonOptions = {}
 ): Promise<DaemonHandle> {
-  const logger = options.logger ?? pino();
+  const env = options.env ?? process.env;
+  const logger = options.logger ?? pino({ level: resolveLogLevel(env) });
   const host = options.host ?? "127.0.0.1";
   const requestedPort = options.port ?? 3000;
   const stateRootOptions: Parameters<typeof resolveStateRoot>[0] = {};
@@ -93,7 +94,6 @@ export async function startDaemon(
   }
   const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;
   const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
-  const env = options.env ?? process.env;
   const activeRuns = new ActiveRunRegistry();
   const dispatchMutex = createAsyncMutex();
   const dispatchRuntime = {
@@ -543,6 +543,10 @@ function defaultProvidersConfig(): RunControllerProvidersConfig {
         "codex -p symphonika --dangerously-bypass-approvals-and-sandbox app-server"
     }
   };
+}
+
+export function resolveLogLevel(env: NodeJS.ProcessEnv): string {
+  return env["PINO_LOG_LEVEL"] ?? env["LOG_LEVEL"] ?? "info";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import pino from "pino";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { startDaemon } from "../src/daemon.js";
+import { resolveLogLevel, startDaemon } from "../src/daemon.js";
 
 const tempRoots: string[] = [];
 
@@ -48,6 +48,26 @@ describe("startDaemon", () => {
     } finally {
       await daemon.stop();
     }
+  });
+});
+
+describe("resolveLogLevel", () => {
+  it("defaults to info when no env var is set", () => {
+    expect(resolveLogLevel({})).toBe("info");
+  });
+
+  it("honours PINO_LOG_LEVEL", () => {
+    expect(resolveLogLevel({ PINO_LOG_LEVEL: "debug" })).toBe("debug");
+  });
+
+  it("honours LOG_LEVEL as an alias", () => {
+    expect(resolveLogLevel({ LOG_LEVEL: "warn" })).toBe("warn");
+  });
+
+  it("prefers PINO_LOG_LEVEL over LOG_LEVEL when both are set", () => {
+    expect(
+      resolveLogLevel({ PINO_LOG_LEVEL: "trace", LOG_LEVEL: "warn" }),
+    ).toBe("trace");
   });
 });
 


### PR DESCRIPTION
## Summary
- `startDaemon()` previously called `pino()` with no options, so `PINO_LOG_LEVEL=debug npm run dev -- daemon` produced the same output as running with no env at all. Pino does not auto-read env vars.
- Add an exported `resolveLogLevel(env)` helper that returns `env.PINO_LOG_LEVEL ?? env.LOG_LEVEL ?? "info"`, and pass its result via `pino({ level })`. `PINO_LOG_LEVEL` is the de-facto convention; `LOG_LEVEL` is the friendlier alias.
- Document the knob in the README "Running the daemon" section, listing pino's accepted level set so a typo'd value (which pino throws on) is discoverable.

Other CLI commands (`doctor`, `smoke`, `init-project`, `clear-stale`, `status`, `runs`, `show-run`, `cancel`) write to stdout/stderr via commander and do not construct loggers, so no other entry points need this wiring.

Closes #58

## Test plan
- [x] `npm test` — 182/182 pass, including four new `resolveLogLevel` cases (default, `PINO_LOG_LEVEL`, `LOG_LEVEL` alias, precedence)
- [x] `npm run lint`
- [x] `npm run typecheck`