### PR TITLE
Encode commit/PR context in cap-reached terminal_reason

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,10 @@ import type {
 import { openRunStore as openRunStoreReal } from "./run-store.js";
 import type { SmokeOptions, SmokeReport } from "./smoke.js";
 import { runSmoke } from "./smoke.js";
+import {
+  formatCapReachedReason,
+  parseCapReachedReason
+} from "./lifecycle/terminal-reason.js";
 import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
 
@@ -263,9 +267,10 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         if (all.length > 0) {
           writeOut(program, "\nrecent runs:\n");
           for (const run of all.slice(0, 25)) {
+            const suffix = formatRecentRunSuffix(run, store);
             writeOut(
               program,
-              `  ${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}\n`
+              `  ${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}${suffix}\n`
             );
           }
         }
@@ -351,6 +356,17 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         writeOut(program, `retries:      ${detail.retryCount}${detail.isContinuation ? " (continuation)" : ""}\n`);
         if (detail.terminalReason !== null) {
           writeOut(program, `terminal:     ${detail.terminalReason}\n`);
+          const capKind = parseCapReachedReason(detail.terminalReason);
+          if (capKind !== null) {
+            const count = store.countSucceededContinuations(
+              detail.project,
+              detail.issueNumber
+            );
+            writeOut(
+              program,
+              `cap context:  ${formatCapReachedReason(capKind, count)}\n`
+            );
+          }
         }
         if (detail.cancelRequested) {
           writeOut(
@@ -448,6 +464,21 @@ function parsePositiveInt(value: string): number {
 
 function formatPath(value: string): string {
   return value.length === 0 ? "<not yet recorded>" : value;
+}
+
+function formatRecentRunSuffix(
+  run: { issueNumber: number; project: string; state: RunState; terminalReason: string | null },
+  store: RunStore
+): string {
+  if (run.terminalReason === null || run.state !== "failed") {
+    return "";
+  }
+  const capKind = parseCapReachedReason(run.terminalReason);
+  if (capKind === null) {
+    return `  — ${run.terminalReason}`;
+  }
+  const count = store.countSucceededContinuations(run.project, run.issueNumber);
+  return `  — ${formatCapReachedReason(capKind, count)}`;
 }
 
 function parsePort(value: string): number {

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -4,6 +4,10 @@ import type {
   FilteredProjectIssueSnapshot,
   IssuePollStatus
 } from "../issue-polling.js";
+import {
+  formatCapReachedReason,
+  parseCapReachedReason
+} from "../lifecycle/terminal-reason.js";
 import type {
   ListRunsFilter,
   RunState,
@@ -81,9 +85,20 @@ export function registerPages(options: RegisterPagesOptions): void {
     }
 
     const events = options.runStore.listProviderEvents(id, { limit: 100 });
+    const capKind = parseCapReachedReason(detail.terminalReason);
+    const capContext =
+      capKind === null
+        ? null
+        : {
+            count: options.runStore.countSucceededContinuations(
+              detail.project,
+              detail.issueNumber
+            ),
+            kind: capKind
+          };
     const sections = [
       `<h1>Run ${escapeHtml(detail.id)}</h1>`,
-      renderRunSummary(detail),
+      renderRunSummary(detail, capContext),
       renderCancelForm(detail),
       renderAttemptsTable(detail.attempts),
       renderTransitionsTable(detail.transitions),
@@ -196,7 +211,16 @@ function renderRunsTable(title: string, runs: RunStatus[]): string {
 <tbody>${rows}</tbody></table></section>`;
 }
 
-function renderRunSummary(detail: RunStatus): string {
+type CapContext = {
+  count: number;
+  kind: ReturnType<typeof parseCapReachedReason>;
+};
+
+function renderRunSummary(detail: RunStatus, capContext: CapContext | null): string {
+  const capContextLine =
+    capContext !== null && capContext.kind !== null
+      ? `<p><strong>Cap context:</strong> ${escapeHtml(formatCapReachedReason(capContext.kind, capContext.count))}</p>`
+      : "";
   return `<section>
   <p><strong>Project:</strong> ${escapeHtml(detail.project)}</p>
   <p><strong>Issue:</strong> #${detail.issueNumber} ${escapeHtml(detail.issueTitle)}</p>
@@ -206,6 +230,7 @@ function renderRunSummary(detail: RunStatus): string {
   <p><strong>Workspace:</strong> <code>${escapeHtml(detail.workspacePath)}</code></p>
   <p><strong>Retries:</strong> ${detail.retryCount}${detail.isContinuation ? " (continuation)" : ""}</p>
   ${detail.terminalReason !== null ? `<p><strong>Terminal reason:</strong> ${escapeHtml(detail.terminalReason)}</p>` : ""}
+  ${capContextLine}
   ${detail.cancelRequested ? `<p><strong>Cancel requested</strong> (reason: ${escapeHtml(detail.cancelReason ?? "unknown")})</p>` : ""}
 </section>`;
 }

--- a/src/issue-polling.ts
+++ b/src/issue-polling.ts
@@ -30,14 +30,40 @@ export type RawGitHubIssue = {
   url?: string | null;
 };
 
+export type RawGitHubCommit = {
+  sha?: string;
+};
+
+export type RawGitHubPullRequest = {
+  head?: { ref?: string };
+  merged_at?: string | null;
+  number?: number;
+  state?: string;
+};
+
+export type GitHubBranchCommitsInput = GitHubIssueRepositoryInput & {
+  branch: string;
+  perPage?: number;
+};
+
+export type GitHubBranchPullRequestsInput = GitHubIssueRepositoryInput & {
+  branch: string;
+};
+
 export type GitHubIssuesApi = {
   addLabelsToIssue?: (input: GitHubIssueLabelInput) => Promise<void>;
   getIssue?: (
     input: GitHubIssueRepositoryInput & { issueNumber: number }
   ) => Promise<RawGitHubIssue | null>;
+  listBranchCommits?: (
+    input: GitHubBranchCommitsInput
+  ) => Promise<RawGitHubCommit[] | null>;
   listOpenIssues: (
     input: GitHubIssueRepositoryInput
   ) => Promise<RawGitHubIssue[]>;
+  listPullRequestsForBranch?: (
+    input: GitHubBranchPullRequestsInput
+  ) => Promise<RawGitHubPullRequest[]>;
   removeLabelsFromIssue?: (input: GitHubIssueLabelInput) => Promise<void>;
 };
 
@@ -175,6 +201,26 @@ class OctokitGitHubIssuesApi implements GitHubIssuesApi {
     }
   }
 
+  async listBranchCommits(
+    input: GitHubBranchCommitsInput
+  ): Promise<RawGitHubCommit[] | null> {
+    const octokit = this.octokit(input.token);
+    try {
+      const response = await octokit.rest.repos.listCommits({
+        owner: input.owner,
+        per_page: input.perPage ?? 1,
+        repo: input.repo,
+        sha: input.branch
+      });
+      return response.data;
+    } catch (error) {
+      if (isOctokitNotFound(error)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
   async listOpenIssues(
     input: GitHubIssueRepositoryInput
   ): Promise<RawGitHubIssue[]> {
@@ -187,6 +233,20 @@ class OctokitGitHubIssuesApi implements GitHubIssuesApi {
     });
 
     return issues;
+  }
+
+  async listPullRequestsForBranch(
+    input: GitHubBranchPullRequestsInput
+  ): Promise<RawGitHubPullRequest[]> {
+    const octokit = this.octokit(input.token);
+    const response = await octokit.rest.pulls.list({
+      head: `${input.owner}:${input.branch}`,
+      owner: input.owner,
+      per_page: 100,
+      repo: input.repo,
+      state: "all"
+    });
+    return response.data;
   }
 
   async removeLabelsFromIssue(input: GitHubIssueLabelInput): Promise<void> {
@@ -236,6 +296,26 @@ export async function tryGetIssue(
     return undefined;
   }
   return api.getIssue(input);
+}
+
+export async function tryListBranchCommits(
+  api: GitHubIssuesApi,
+  input: GitHubBranchCommitsInput
+): Promise<RawGitHubCommit[] | null | undefined> {
+  if (api.listBranchCommits === undefined) {
+    return undefined;
+  }
+  return api.listBranchCommits(input);
+}
+
+export async function tryListPullRequestsForBranch(
+  api: GitHubIssuesApi,
+  input: GitHubBranchPullRequestsInput
+): Promise<RawGitHubPullRequest[] | undefined> {
+  if (api.listPullRequestsForBranch === undefined) {
+    return undefined;
+  }
+  return api.listPullRequestsForBranch(input);
 }
 
 export function emptyIssuePollStatus(): IssuePollStatus {

--- a/src/lifecycle/cap-reached-context.ts
+++ b/src/lifecycle/cap-reached-context.ts
@@ -35,7 +35,8 @@ export async function classifyCapReachedOutcome(
       );
       return "unknown";
     }
-    if (commits === null || commits.length === 0) {
+    const branchMissing = commits === null;
+    if (!branchMissing && commits.length === 0) {
       return "no_commits";
     }
 
@@ -48,15 +49,12 @@ export async function classifyCapReachedOutcome(
         { branch: input.branch },
         "cap-reached classifier: listPullRequestsForBranch unavailable; classifying as unknown"
       );
-      return "unknown";
-    }
-    if (prs.length === 0) {
-      return "no_pr";
+      return branchMissing ? "no_commits" : "unknown";
     }
     if (prs.some((pr) => pr.merged_at != null)) {
       return "work_landed";
     }
-    return "no_pr";
+    return branchMissing ? "no_commits" : "no_pr";
   } catch (error) {
     input.logger?.warn(
       { branch: input.branch, err: error },

--- a/src/lifecycle/cap-reached-context.ts
+++ b/src/lifecycle/cap-reached-context.ts
@@ -1,0 +1,67 @@
+import type { Logger } from "pino";
+
+import {
+  tryListBranchCommits,
+  tryListPullRequestsForBranch,
+  type GitHubIssueRepositoryInput,
+  type GitHubIssuesApi
+} from "../issue-polling.js";
+import type { CapReachedKind } from "./terminal-reason.js";
+
+export type ClassifyCapReachedOutcomeInput = {
+  api: GitHubIssuesApi;
+  branch: string;
+  logger?: Logger | undefined;
+  repository: GitHubIssueRepositoryInput;
+};
+
+export async function classifyCapReachedOutcome(
+  input: ClassifyCapReachedOutcomeInput
+): Promise<CapReachedKind> {
+  if (input.branch === "") {
+    return "no_commits";
+  }
+
+  try {
+    const commits = await tryListBranchCommits(input.api, {
+      ...input.repository,
+      branch: input.branch,
+      perPage: 1
+    });
+    if (commits === undefined) {
+      input.logger?.warn(
+        { branch: input.branch },
+        "cap-reached classifier: listBranchCommits unavailable; classifying as unknown"
+      );
+      return "unknown";
+    }
+    if (commits === null || commits.length === 0) {
+      return "no_commits";
+    }
+
+    const prs = await tryListPullRequestsForBranch(input.api, {
+      ...input.repository,
+      branch: input.branch
+    });
+    if (prs === undefined) {
+      input.logger?.warn(
+        { branch: input.branch },
+        "cap-reached classifier: listPullRequestsForBranch unavailable; classifying as unknown"
+      );
+      return "unknown";
+    }
+    if (prs.length === 0) {
+      return "no_pr";
+    }
+    if (prs.some((pr) => pr.merged_at != null)) {
+      return "work_landed";
+    }
+    return "no_pr";
+  } catch (error) {
+    input.logger?.warn(
+      { branch: input.branch, err: error },
+      "cap-reached classifier: GitHub call failed; classifying as unknown"
+    );
+    return "unknown";
+  }
+}

--- a/src/lifecycle/cap-reached-context.ts
+++ b/src/lifecycle/cap-reached-context.ts
@@ -49,7 +49,7 @@ export async function classifyCapReachedOutcome(
         { branch: input.branch },
         "cap-reached classifier: listPullRequestsForBranch unavailable; classifying as unknown"
       );
-      return branchMissing ? "no_commits" : "unknown";
+      return "unknown";
     }
     if (prs.some((pr) => pr.merged_at != null)) {
       return "work_landed";

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -39,7 +39,9 @@ import {
   LIFECYCLE_POLICY,
   type LifecyclePolicy
 } from "./active-runs.js";
+import { classifyCapReachedOutcome } from "./cap-reached-context.js";
 import { classifyFailure, type ClassifiedTerminal } from "./classify-failure.js";
+import { buildCapReachedReason } from "./terminal-reason.js";
 
 export type RunControllerProjectConfig = PollingProjectConfig & {
   workflow: string;
@@ -968,13 +970,20 @@ export class RunController {
       input.issue.number
     );
     if (succeededContinuations >= this.lifecyclePolicy.continuation.cap) {
+      const parent = this.runStore.getRun(input.runId);
+      const kind = await classifyCapReachedOutcome({
+        api: this.githubIssuesApi,
+        branch: parent?.branchName ?? "",
+        logger: this.logger,
+        repository: input.repository
+      });
       const capId = this.createRunId();
       this.runStore.createCapReachedFailureRun({
         id: capId,
         issue: refreshed,
         parentRunId: input.runId,
         projectName: input.project.name,
-        reason: "continuation cap reached"
+        reason: buildCapReachedReason(kind)
       });
       await this.markIssueFailed({
         issueNumber: input.issue.number,

--- a/src/lifecycle/terminal-reason.ts
+++ b/src/lifecycle/terminal-reason.ts
@@ -1,0 +1,43 @@
+export type CapReachedKind =
+  | "no_commits"
+  | "no_pr"
+  | "work_landed"
+  | "unknown";
+
+export const CAP_REACHED_PREFIX = "cap_reached:";
+
+const CAP_REACHED_KINDS: ReadonlySet<CapReachedKind> = new Set([
+  "no_commits",
+  "no_pr",
+  "work_landed",
+  "unknown"
+]);
+
+export function buildCapReachedReason(kind: CapReachedKind): string {
+  return `${CAP_REACHED_PREFIX}${kind}`;
+}
+
+export function parseCapReachedReason(reason: string | null): CapReachedKind | null {
+  if (reason === null || !reason.startsWith(CAP_REACHED_PREFIX)) {
+    return null;
+  }
+  const suffix = reason.slice(CAP_REACHED_PREFIX.length);
+  return CAP_REACHED_KINDS.has(suffix as CapReachedKind)
+    ? (suffix as CapReachedKind)
+    : null;
+}
+
+const CAP_REACHED_LABELS: Readonly<Record<CapReachedKind, string>> = {
+  no_commits: "no commits on issue branch",
+  no_pr: "commits exist but no pull request",
+  work_landed: "a pull request was merged (issue should normally have closed)",
+  unknown: "branch state could not be determined"
+};
+
+export function formatCapReachedReason(
+  kind: CapReachedKind,
+  continuationCount: number
+): string {
+  const noun = continuationCount === 1 ? "continuation" : "continuations";
+  return `continuation cap reached after ${continuationCount} ${noun}: ${CAP_REACHED_LABELS[kind]}`;
+}

--- a/tests/cap-reached-context.test.ts
+++ b/tests/cap-reached-context.test.ts
@@ -37,6 +37,20 @@ describe("classifyCapReachedOutcome", () => {
     expect(kind).toBe("no_commits");
   });
 
+  it("returns unknown when the branch is missing and listPullRequestsForBranch is unavailable", async () => {
+    const api: GitHubIssuesApi = {
+      ...baseApi,
+      listBranchCommits: vi.fn().mockResolvedValue(null)
+      // listPullRequestsForBranch intentionally absent
+    };
+    const kind = await classifyCapReachedOutcome({
+      api,
+      branch: "feature/x",
+      repository
+    });
+    expect(kind).toBe("unknown");
+  });
+
   it("returns work_landed when the branch is missing (auto-deleted) but a merged PR still exists", async () => {
     const api: GitHubIssuesApi = {
       ...baseApi,

--- a/tests/cap-reached-context.test.ts
+++ b/tests/cap-reached-context.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { GitHubIssuesApi } from "../src/issue-polling.js";
+import { classifyCapReachedOutcome } from "../src/lifecycle/cap-reached-context.js";
+
+const repository = {
+  owner: "pmatos",
+  repo: "symphonika",
+  token: "secret"
+};
+
+const baseApi: GitHubIssuesApi = {
+  listOpenIssues: () => Promise.resolve([])
+};
+
+describe("classifyCapReachedOutcome", () => {
+  it("returns no_commits when the branch is empty", async () => {
+    const kind = await classifyCapReachedOutcome({
+      api: baseApi,
+      branch: "",
+      repository
+    });
+    expect(kind).toBe("no_commits");
+  });
+
+  it("returns no_commits when listBranchCommits reports the branch missing (404)", async () => {
+    const api: GitHubIssuesApi = {
+      ...baseApi,
+      listBranchCommits: vi.fn().mockResolvedValue(null),
+      listPullRequestsForBranch: vi.fn().mockResolvedValue([])
+    };
+    const kind = await classifyCapReachedOutcome({
+      api,
+      branch: "feature/x",
+      repository
+    });
+    expect(kind).toBe("no_commits");
+  });
+
+  it("returns no_commits when the branch reports zero commits", async () => {
+    const api: GitHubIssuesApi = {
+      ...baseApi,
+      listBranchCommits: vi.fn().mockResolvedValue([]),
+      listPullRequestsForBranch: vi.fn().mockResolvedValue([])
+    };
+    const kind = await classifyCapReachedOutcome({
+      api,
+      branch: "feature/x",
+      repository
+    });
+    expect(kind).toBe("no_commits");
+  });
+
+  it("returns unknown when listBranchCommits is not implemented on the API", async () => {
+    const kind = await classifyCapReachedOutcome({
+      api: baseApi,
+      branch: "feature/x",
+      repository
+    });
+    expect(kind).toBe("unknown");
+  });
+
+  it("returns no_pr when commits exist but no pull requests are open or closed", async () => {
+    const api: GitHubIssuesApi = {
+      ...baseApi,
+      listBranchCommits: vi.fn().mockResolvedValue([{ sha: "abc" }]),
+      listPullRequestsForBranch: vi.fn().mockResolvedValue([])
+    };
+    const kind = await classifyCapReachedOutcome({
+      api,
+      branch: "feature/x",
+      repository
+    });
+    expect(kind).toBe("no_pr");
+  });
+
+  it("returns no_pr when PRs exist but none have merged_at set", async () => {
+    const api: GitHubIssuesApi = {
+      ...baseApi,
+      listBranchCommits: vi.fn().mockResolvedValue([{ sha: "abc" }]),
+      listPullRequestsForBranch: vi
+        .fn()
+        .mockResolvedValue([
+          { merged_at: null, number: 7, state: "open" },
+          { merged_at: null, number: 8, state: "closed" }
+        ])
+    };
+    const kind = await classifyCapReachedOutcome({
+      api,
+      branch: "feature/x",
+      repository
+    });
+    expect(kind).toBe("no_pr");
+  });
+
+  it("returns unknown when listBranchCommits throws (never rethrows)", async () => {
+    const warn = vi.fn();
+    const api: GitHubIssuesApi = {
+      ...baseApi,
+      listBranchCommits: vi.fn().mockRejectedValue(new Error("boom")),
+      listPullRequestsForBranch: vi.fn().mockResolvedValue([])
+    };
+    const logger = { warn } as unknown as Parameters<
+      typeof classifyCapReachedOutcome
+    >[0]["logger"];
+    const kind = await classifyCapReachedOutcome({
+      api,
+      branch: "feature/x",
+      logger,
+      repository
+    });
+    expect(kind).toBe("unknown");
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("returns work_landed when at least one PR has a merged_at timestamp", async () => {
+    const api: GitHubIssuesApi = {
+      ...baseApi,
+      listBranchCommits: vi.fn().mockResolvedValue([{ sha: "abc" }]),
+      listPullRequestsForBranch: vi
+        .fn()
+        .mockResolvedValue([
+          { merged_at: null, number: 7, state: "closed" },
+          { merged_at: "2026-05-04T00:00:00Z", number: 8, state: "closed" }
+        ])
+    };
+    const kind = await classifyCapReachedOutcome({
+      api,
+      branch: "feature/x",
+      repository
+    });
+    expect(kind).toBe("work_landed");
+  });
+});

--- a/tests/cap-reached-context.test.ts
+++ b/tests/cap-reached-context.test.ts
@@ -23,7 +23,7 @@ describe("classifyCapReachedOutcome", () => {
     expect(kind).toBe("no_commits");
   });
 
-  it("returns no_commits when listBranchCommits reports the branch missing (404)", async () => {
+  it("returns no_commits when listBranchCommits reports the branch missing (404) and no PR exists", async () => {
     const api: GitHubIssuesApi = {
       ...baseApi,
       listBranchCommits: vi.fn().mockResolvedValue(null),
@@ -35,6 +35,24 @@ describe("classifyCapReachedOutcome", () => {
       repository
     });
     expect(kind).toBe("no_commits");
+  });
+
+  it("returns work_landed when the branch is missing (auto-deleted) but a merged PR still exists", async () => {
+    const api: GitHubIssuesApi = {
+      ...baseApi,
+      listBranchCommits: vi.fn().mockResolvedValue(null),
+      listPullRequestsForBranch: vi
+        .fn()
+        .mockResolvedValue([
+          { merged_at: "2026-05-04T00:00:00Z", number: 9, state: "closed" }
+        ])
+    };
+    const kind = await classifyCapReachedOutcome({
+      api,
+      branch: "feature/x",
+      repository
+    });
+    expect(kind).toBe("work_landed");
   });
 
   it("returns no_commits when the branch reports zero commits", async () => {

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -286,4 +286,106 @@ describe("CLI run commands", () => {
     ).rejects.toThrow();
     expect(missing.output.stderr).toContain("not found");
   });
+
+  it("show-run renders cap context for a cap_reached:no_commits run", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    const issue = sampleIssue({ number: 65, title: "Capped issue" });
+    store.createRun({
+      id: "fresh",
+      issue,
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("fresh", "succeeded");
+    store.createContinuationRun({
+      id: "cont-1",
+      issue,
+      parentRunId: "fresh",
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("cont-1", "succeeded");
+    store.createContinuationRun({
+      id: "cont-2",
+      issue,
+      parentRunId: "cont-1",
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("cont-2", "succeeded");
+    store.createCapReachedFailureRun({
+      id: "cap",
+      issue,
+      parentRunId: "cont-2",
+      projectName: "alpha",
+      reason: "cap_reached:no_commits"
+    });
+    store.close();
+
+    const { output, program } = captureProgram(stateRoot);
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "show-run",
+      "cap",
+      "--config",
+      path.join(stateRoot, "symphonika.yml")
+    ]);
+
+    expect(output.stdout).toContain("terminal:     cap_reached:no_commits");
+    expect(output.stdout).toContain(
+      "cap context:  continuation cap reached after 2 continuations: no commits on issue branch"
+    );
+  });
+
+  it("status appends decoded cap context to recent-run lines for failed cap-reached runs", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    const issue = sampleIssue({ number: 65, title: "Capped" });
+    store.createRun({
+      id: "fresh",
+      issue,
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("fresh", "succeeded");
+    store.createContinuationRun({
+      id: "cont-1",
+      issue,
+      parentRunId: "fresh",
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("cont-1", "succeeded");
+    store.createCapReachedFailureRun({
+      id: "cap",
+      issue,
+      parentRunId: "cont-1",
+      projectName: "alpha",
+      reason: "cap_reached:no_pr"
+    });
+    store.close();
+
+    const { output, program } = captureProgram(stateRoot);
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml")
+    ]);
+
+    expect(output.stdout).toContain(
+      "cap  alpha  #65  failed"
+    );
+    expect(output.stdout).toContain(
+      "— continuation cap reached after 1 continuation: commits exist but no pull request"
+    );
+  });
 });

--- a/tests/dispatch-continuation.test.ts
+++ b/tests/dispatch-continuation.test.ts
@@ -124,7 +124,7 @@ async function waitForCondition(
   options: { intervalMs?: number; timeoutMs?: number } = {}
 ): Promise<{ runs: Array<Record<string, unknown>> }> {
   const intervalMs = options.intervalMs ?? 10;
-  const timeoutMs = options.timeoutMs ?? 4_000;
+  const timeoutMs = options.timeoutMs ?? 10_000;
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {

--- a/tests/dispatch-continuation.test.ts
+++ b/tests/dispatch-continuation.test.ts
@@ -164,10 +164,12 @@ describe("dispatch continuation cap", () => {
       addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
       // every refresh returns the issue still eligible
       getIssue: vi.fn().mockResolvedValue({ ...baseIssue, labels: ["agent-ready"] }),
+      listBranchCommits: vi.fn().mockResolvedValue([]),
       listOpenIssues: vi
         .fn()
         .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
         .mockResolvedValue([]),
+      listPullRequestsForBranch: vi.fn().mockResolvedValue([]),
       removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
     };
     let createCount = 0;
@@ -201,7 +203,7 @@ describe("dispatch continuation cap", () => {
         runs.some(
           (run) =>
             run["state"] === "failed" &&
-            run["terminalReason"] === "continuation cap reached"
+            run["terminalReason"] === "cap_reached:no_commits"
         )
       );
 
@@ -225,7 +227,7 @@ describe("dispatch continuation cap", () => {
 
       // Cap-reached failure row visible
       const capRow = status.runs.find(
-        (run) => run["terminalReason"] === "continuation cap reached"
+        (run) => run["terminalReason"] === "cap_reached:no_commits"
       );
       expect(capRow).toMatchObject({
         state: "failed",

--- a/tests/dispatch-mutex.test.ts
+++ b/tests/dispatch-mutex.test.ts
@@ -114,7 +114,7 @@ async function waitForCondition(
   options: { intervalMs?: number; timeoutMs?: number } = {}
 ): Promise<void> {
   const intervalMs = options.intervalMs ?? 10;
-  const timeoutMs = options.timeoutMs ?? 4_000;
+  const timeoutMs = options.timeoutMs ?? 10_000;
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {

--- a/tests/dispatch-mutex.test.ts
+++ b/tests/dispatch-mutex.test.ts
@@ -164,10 +164,12 @@ describe("dispatch mutex", () => {
     const githubIssuesApi = {
       addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
       getIssue: vi.fn().mockResolvedValue({ ...baseIssue, labels: ["agent-ready"] }),
+      listBranchCommits: vi.fn().mockResolvedValue([]),
       listOpenIssues: vi
         .fn()
         .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
         .mockResolvedValue([]),
+      listPullRequestsForBranch: vi.fn().mockResolvedValue([]),
       removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
     };
     const prepareIssueWorkspace = vi.fn(
@@ -194,7 +196,7 @@ describe("dispatch mutex", () => {
         runs.some(
           (run) =>
             run["state"] === "failed" &&
-            run["terminalReason"] === "continuation cap reached"
+            run["terminalReason"] === "cap_reached:no_commits"
         )
       );
 
@@ -228,10 +230,12 @@ describe("dispatch mutex", () => {
     const githubIssuesApi = {
       addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
       getIssue: vi.fn().mockResolvedValue({ ...baseIssue, labels: ["agent-ready"] }),
+      listBranchCommits: vi.fn().mockResolvedValue([]),
       listOpenIssues: vi
         .fn()
         .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
         .mockResolvedValue([]),
+      listPullRequestsForBranch: vi.fn().mockResolvedValue([]),
       removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
     };
     const prepareIssueWorkspace = vi.fn(
@@ -258,7 +262,7 @@ describe("dispatch mutex", () => {
         runs.some(
           (run) =>
             run["state"] === "failed" &&
-            run["terminalReason"] === "continuation cap reached"
+            run["terminalReason"] === "cap_reached:no_commits"
         )
       );
 

--- a/tests/http-app-runs.test.ts
+++ b/tests/http-app-runs.test.ts
@@ -100,6 +100,52 @@ describe("HTTP app — runs API and pages", () => {
     }
   });
 
+  it("renders Cap context on the /runs/:id HTML page for cap_reached:* runs", async () => {
+    const test = await setup();
+    try {
+      const issue = sampleIssue({ number: 65, title: "Capped" });
+      test.runStore.createRun({
+        id: "fresh",
+        issue,
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("fresh", "succeeded");
+      test.runStore.createContinuationRun({
+        id: "cont-1",
+        issue,
+        parentRunId: "fresh",
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("cont-1", "succeeded");
+      test.runStore.createCapReachedFailureRun({
+        id: "cap",
+        issue,
+        parentRunId: "cont-1",
+        projectName: "alpha",
+        reason: "cap_reached:no_commits"
+      });
+
+      const app = createHttpApp({
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+      const response = await app.request("/runs/cap");
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("<strong>Terminal reason:</strong> cap_reached:no_commits");
+      expect(html).toContain(
+        "<strong>Cap context:</strong> continuation cap reached after 1 continuation: no commits on issue branch"
+      );
+    } finally {
+      test.cleanup();
+    }
+  });
+
   it("returns 404 for /api/runs/:id when missing and detail otherwise", async () => {
     const test = await setup();
     try {

--- a/tests/issue-polling-helpers.test.ts
+++ b/tests/issue-polling-helpers.test.ts
@@ -3,10 +3,14 @@ import { describe, expect, it } from "vitest";
 import {
   tryAddLabelsToIssue,
   tryGetIssue,
+  tryListBranchCommits,
+  tryListPullRequestsForBranch,
   type GitHubIssueLabelInput,
   type GitHubIssueRepositoryInput,
   type GitHubIssuesApi,
-  type RawGitHubIssue
+  type RawGitHubCommit,
+  type RawGitHubIssue,
+  type RawGitHubPullRequest
 } from "../src/issue-polling.js";
 
 const labelInput: GitHubIssueLabelInput = {
@@ -89,5 +93,76 @@ describe("tryGetIssue", () => {
       listOpenIssues: () => Promise.resolve([])
     };
     expect(await tryGetIssue(api, fetchInput)).toBeNull();
+  });
+});
+
+const branchInput: GitHubIssueRepositoryInput & { branch: string } = {
+  branch: "symphonika/issue65",
+  owner: "pmatos",
+  repo: "symphonika",
+  token: "secret"
+};
+
+describe("tryListBranchCommits", () => {
+  it("preserves `this` when invoking a class-based implementation", async () => {
+    class Api {
+      readonly received: string[] = [];
+      listOpenIssues(): Promise<never[]> {
+        return Promise.resolve([]);
+      }
+      listBranchCommits(
+        input: GitHubIssueRepositoryInput & { branch: string }
+      ): Promise<RawGitHubCommit[] | null> {
+        this.received.push(input.branch);
+        return Promise.resolve([{ sha: "abc" }]);
+      }
+    }
+    const api = new Api();
+    const result = await tryListBranchCommits(api, branchInput);
+    expect(api.received).toEqual(["symphonika/issue65"]);
+    expect(result).toEqual([{ sha: "abc" }]);
+  });
+
+  it("returns undefined when the implementation does not provide listBranchCommits", async () => {
+    const api: GitHubIssuesApi = {
+      listOpenIssues: () => Promise.resolve([])
+    };
+    expect(await tryListBranchCommits(api, branchInput)).toBeUndefined();
+  });
+
+  it("propagates null when the branch is missing", async () => {
+    const api: GitHubIssuesApi = {
+      listBranchCommits: () => Promise.resolve(null),
+      listOpenIssues: () => Promise.resolve([])
+    };
+    expect(await tryListBranchCommits(api, branchInput)).toBeNull();
+  });
+});
+
+describe("tryListPullRequestsForBranch", () => {
+  it("preserves `this` when invoking a class-based implementation", async () => {
+    class Api {
+      readonly received: string[] = [];
+      listOpenIssues(): Promise<never[]> {
+        return Promise.resolve([]);
+      }
+      listPullRequestsForBranch(
+        input: GitHubIssueRepositoryInput & { branch: string }
+      ): Promise<RawGitHubPullRequest[]> {
+        this.received.push(input.branch);
+        return Promise.resolve([{ number: 7, merged_at: null }]);
+      }
+    }
+    const api = new Api();
+    const result = await tryListPullRequestsForBranch(api, branchInput);
+    expect(api.received).toEqual(["symphonika/issue65"]);
+    expect(result).toEqual([{ number: 7, merged_at: null }]);
+  });
+
+  it("returns undefined when the implementation does not provide listPullRequestsForBranch", async () => {
+    const api: GitHubIssuesApi = {
+      listOpenIssues: () => Promise.resolve([])
+    };
+    expect(await tryListPullRequestsForBranch(api, branchInput)).toBeUndefined();
   });
 });

--- a/tests/run-store-lifecycle.test.ts
+++ b/tests/run-store-lifecycle.test.ts
@@ -238,7 +238,7 @@ describe("run-store lifecycle CRUD", () => {
         },
         parentRunId: "parent",
         projectName: "symphonika",
-        reason: "continuation cap reached"
+        reason: "cap_reached:no_commits"
       });
 
       const cap = store
@@ -248,7 +248,7 @@ describe("run-store lifecycle CRUD", () => {
         state: "failed",
         isContinuation: true,
         continuationParentRunId: "parent",
-        terminalReason: "continuation cap reached",
+        terminalReason: "cap_reached:no_commits",
         failureClassification: "deterministic",
         issueNumber: 8
       });

--- a/tests/terminal-reason.test.ts
+++ b/tests/terminal-reason.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCapReachedReason,
+  formatCapReachedReason,
+  parseCapReachedReason
+} from "../src/lifecycle/terminal-reason.js";
+
+describe("buildCapReachedReason", () => {
+  it("encodes no_commits as cap_reached:no_commits", () => {
+    expect(buildCapReachedReason("no_commits")).toBe("cap_reached:no_commits");
+  });
+
+  it("encodes every kind with the cap_reached: prefix", () => {
+    expect(buildCapReachedReason("no_pr")).toBe("cap_reached:no_pr");
+    expect(buildCapReachedReason("work_landed")).toBe("cap_reached:work_landed");
+    expect(buildCapReachedReason("unknown")).toBe("cap_reached:unknown");
+  });
+});
+
+describe("parseCapReachedReason", () => {
+  it("returns the kind for a recognized cap_reached:* string", () => {
+    expect(parseCapReachedReason("cap_reached:no_commits")).toBe("no_commits");
+    expect(parseCapReachedReason("cap_reached:no_pr")).toBe("no_pr");
+    expect(parseCapReachedReason("cap_reached:work_landed")).toBe("work_landed");
+    expect(parseCapReachedReason("cap_reached:unknown")).toBe("unknown");
+  });
+
+  it("returns null for non-cap reasons, null input, and unknown suffixes", () => {
+    expect(parseCapReachedReason(null)).toBeNull();
+    expect(parseCapReachedReason("")).toBeNull();
+    expect(parseCapReachedReason("continuation cap reached")).toBeNull();
+    expect(parseCapReachedReason("cap_reached:bogus")).toBeNull();
+    expect(parseCapReachedReason("workspace_branch_conflict")).toBeNull();
+  });
+});
+
+describe("formatCapReachedReason", () => {
+  it("renders no_commits with continuation count", () => {
+    expect(formatCapReachedReason("no_commits", 3)).toBe(
+      "continuation cap reached after 3 continuations: no commits on issue branch"
+    );
+  });
+
+  it("uses singular 'continuation' for count of 1", () => {
+    expect(formatCapReachedReason("no_pr", 1)).toBe(
+      "continuation cap reached after 1 continuation: commits exist but no pull request"
+    );
+  });
+
+  it("renders work_landed", () => {
+    expect(formatCapReachedReason("work_landed", 2)).toBe(
+      "continuation cap reached after 2 continuations: a pull request was merged (issue should normally have closed)"
+    );
+  });
+
+  it("renders unknown", () => {
+    expect(formatCapReachedReason("unknown", 4)).toBe(
+      "continuation cap reached after 4 continuations: branch state could not be determined"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- When the continuation cap is reached, classify the issue branch's state (commits / PR / merged PR) and encode it in `terminal_reason` as `cap_reached:{no_commits|no_pr|work_landed|unknown}`.
- Surface the decoded outcome plus the number of successful continuations in `symphonika show-run`, `symphonika status`, and the web `/runs/:id` page.
- Extend `GitHubIssuesApi` with optional `listBranchCommits` and `listPullRequestsForBranch` methods (and `try*` wrappers that preserve `this`); failures are swallowed so the cap-reached failure run is always recorded.

Closes #65

## Test plan
- [x] `npx vitest run` — 207/207 tests pass (3 new behavior tests + 16 new unit tests on encoding/classifier; 6 fixture sites refreshed)
- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [x] `npx eslint .` clean
- [x] `npm run build` clean
- [x] Classifier covers every branch: empty branch, missing branch (404), zero commits, commits + no PR, commits + PR with `merged_at: null`, commits + merged PR, GitHub call throws, optional method missing on the API