### PR TITLE
Add operator CLI and web run views

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -312,6 +312,7 @@ Recommended layout:
 
 ```text
 .symphonika/
+  daemon.json
   symphonika.db
   logs/
     runs/
@@ -320,9 +321,13 @@ Recommended layout:
         provider.normalized.jsonl
         stderr.log
         prompt.md
+        prompt-metadata.json
+        issue-snapshot.json
 ```
 
 Agents may modify workspaces, so orchestrator evidence must stay outside the Git worktree.
+When the daemon is running, `daemon.json` records the local API endpoint for the same state root so
+operator CLI commands can discover it without targeting an unrelated daemon.
 
 ### 7.4 Prompt Evidence
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 import { InvalidArgumentError, Command } from "commander";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { DaemonHandle, StartDaemonOptions } from "./daemon.js";
 import { startDaemon } from "./daemon.js";
+import { readDaemonEndpoint } from "./daemon-endpoint.js";
 import type {
   ClearStaleOptions,
   ClearStaleReport,
@@ -14,6 +16,7 @@ import type {
   InitProjectReport
 } from "./doctor.js";
 import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
+import type { ProjectIssuePollReport } from "./issue-polling.js";
 import type {
   ListRunsFilter,
   OpenRunStoreOptions,
@@ -27,6 +30,7 @@ import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
 
 export type CliDependencies = {
+  fetch?: FetchFn;
   openRunStore?: (options: OpenRunStoreOptions) => RunStore;
   registerSignalHandlers?: boolean;
   runClearStale?: (options: ClearStaleOptions) => Promise<ClearStaleReport>;
@@ -36,6 +40,20 @@ export type CliDependencies = {
   startDaemon?: (options: StartDaemonOptions) => Promise<DaemonHandle>;
 };
 
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+type DaemonStatusResponse = {
+  candidateIssues?: unknown[];
+  filteredIssues?: unknown[];
+  issuePolling?: {
+    errors?: string[];
+    projects?: ProjectIssuePollReport[];
+  };
+  staleIssues?: unknown[];
+  state?: string;
+  stateRoot?: string;
+};
+
 export function buildCli(dependencies: CliDependencies = {}): Command {
   const doctor = dependencies.runDoctor ?? runDoctor;
   const initProject = dependencies.runInitProject ?? runInitProject;
@@ -43,6 +61,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
   const smoke = dependencies.runSmoke ?? runSmoke;
   const start = dependencies.startDaemon ?? startDaemon;
   const openRunStore = dependencies.openRunStore ?? openRunStoreReal;
+  const fetcher = dependencies.fetch ?? fetch;
   const registerSignalHandlers = dependencies.registerSignalHandlers ?? true;
   const program = new Command();
 
@@ -231,11 +250,11 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         writeOut(program, `provider:     ${detail.provider}\n`);
         writeOut(program, `branch:       ${formatPath(detail.branchName)}\n`);
         writeOut(program, `workspace:    ${formatPath(detail.workspacePath)}\n`);
-        writeOut(program, `prompt:       ${formatPath(detail.promptPath)}\n`);
-        writeOut(program, `raw log:      ${formatPath(detail.rawLogPath)}\n`);
-        writeOut(program, `normalized:   ${formatPath(detail.normalizedLogPath)}\n`);
-        writeOut(program, `metadata:     ${formatPath(detail.metadataPath)}\n`);
-        writeOut(program, `issue snap:   ${formatPath(detail.issueSnapshotPath)}\n`);
+        writeOut(program, `prompt.md:                 ${formatEvidencePath(detail.promptPath)}\n`);
+        writeOut(program, `provider.raw.jsonl:        ${formatEvidencePath(detail.rawLogPath)}\n`);
+        writeOut(program, `provider.normalized.jsonl: ${formatEvidencePath(detail.normalizedLogPath)}\n`);
+        writeOut(program, `issue-snapshot.json:       ${formatEvidencePath(detail.issueSnapshotPath)}\n`);
+        writeOut(program, `prompt-metadata.json:      ${formatEvidencePath(detail.metadataPath)}\n`);
         if (detail.terminalReason !== null) {
           writeOut(program, `terminal:     ${detail.terminalReason}\n`);
         }
@@ -244,18 +263,61 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
 
   program
     .command("status")
-    .description("print run store summary grouped by lifecycle state")
+    .description("print project validation, issue polling, and run summaries")
     .option("--config <path>", "service config path", "symphonika.yml")
-    .action(async (options: { config: string }) => {
-      const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
+    .option("--daemon-url <url>", "local daemon base URL")
+    .action(async (options: { config: string; daemonUrl?: string }) => {
+      const state = resolveStateRoot({ configPath: options.config });
+      const stateRoot = state.stateRoot;
       const store = openRunStore({ stateRoot });
       try {
+        const report = await doctor({ configPath: options.config });
+        const daemonUrl = await resolveDaemonUrl(stateRoot, options.daemonUrl);
+        const daemonStatus = await fetchDaemonStatus(fetcher, daemonUrl, stateRoot);
         const all = store.listRuns();
         const byState = new Map<string, number>();
         for (const run of all) {
           byState.set(run.state, (byState.get(run.state) ?? 0) + 1);
         }
         writeOut(program, `state root: ${stateRoot}\n`);
+        writeOut(program, `daemon: ${formatDaemonAvailability(daemonStatus, daemonUrl)}\n`);
+        writeOut(program, "\nProjects:\n");
+        if (report.projects.length === 0) {
+          writeOut(program, "  (no projects validated)\n");
+        }
+        for (const project of report.projects) {
+          writeOut(
+            program,
+            `  ${project.name}: ${project.validForDispatch ? "valid" : "invalid"}\n`
+          );
+          writeOut(program, `    workflow: ${project.workflowPath}\n`);
+          writeOut(
+            program,
+            `    missing operational labels: ${formatList(project.missingOperationalLabels)}\n`
+          );
+        }
+        if (report.errors.length > 0) {
+          writeOut(program, "validation errors:\n");
+          for (const error of report.errors) {
+            writeOut(program, `  - ${error}\n`);
+          }
+        }
+        const issueCounts = issueCountsFromStatus(
+          daemonStatus,
+          report.projects,
+          byState
+        );
+        writeOut(program, "\nIssue counts:\n");
+        writeOut(program, `  candidate: ${issueCounts.candidate}\n`);
+        writeOut(program, `  filtered:  ${issueCounts.filtered}\n`);
+        writeOut(program, `  running:   ${issueCounts.running}\n`);
+        writeOut(program, `  failed:    ${issueCounts.failed}\n`);
+        writeOut(program, `  stale:     ${issueCounts.stale}\n`);
+        writeOut(
+          program,
+          `last poll outcome: ${formatLastPollOutcome(daemonStatus)}\n`
+        );
+        writeOut(program, "\nRun state counts:\n");
         writeOut(program, `total runs: ${all.length}\n`);
         for (const [state, count] of [...byState.entries()].sort()) {
           writeOut(program, `${state}: ${count}\n`);
@@ -265,11 +327,10 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
           for (const run of all.slice(0, 25)) {
             writeOut(
               program,
-              `  ${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}\n`
+              `  ${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}  ${run.createdAt}  ${run.updatedAt}\n`
             );
           }
         }
-        const report = await doctor({ configPath: options.config });
         printStaleSection(program, report.projects);
       } finally {
         store.close();
@@ -308,10 +369,11 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
             writeOut(program, "(no runs)\n");
             return;
           }
+          writeOut(program, "id  project  issue  state  started  updated\n");
           for (const run of runs) {
             writeOut(
               program,
-              `${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}\n`
+              `${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.createdAt}  ${run.updatedAt}\n`
             );
           }
         } finally {
@@ -341,13 +403,15 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         writeOut(program, `issue:        #${detail.issueNumber} ${detail.issueTitle}\n`);
         writeOut(program, `state:        ${detail.state}\n`);
         writeOut(program, `provider:     ${detail.provider}\n`);
+        writeOut(program, `started:      ${detail.createdAt}\n`);
+        writeOut(program, `updated:      ${detail.updatedAt}\n`);
         writeOut(program, `branch:       ${formatPath(detail.branchName)}\n`);
         writeOut(program, `workspace:    ${formatPath(detail.workspacePath)}\n`);
-        writeOut(program, `prompt:       ${formatPath(detail.promptPath)}\n`);
-        writeOut(program, `raw log:      ${formatPath(detail.rawLogPath)}\n`);
-        writeOut(program, `normalized:   ${formatPath(detail.normalizedLogPath)}\n`);
-        writeOut(program, `metadata:     ${formatPath(detail.metadataPath)}\n`);
-        writeOut(program, `issue snap:   ${formatPath(detail.issueSnapshotPath)}\n`);
+        writeOut(program, `prompt.md:                 ${formatEvidencePath(detail.promptPath)}\n`);
+        writeOut(program, `provider.raw.jsonl:        ${formatEvidencePath(detail.rawLogPath)}\n`);
+        writeOut(program, `provider.normalized.jsonl: ${formatEvidencePath(detail.normalizedLogPath)}\n`);
+        writeOut(program, `issue-snapshot.json:       ${formatEvidencePath(detail.issueSnapshotPath)}\n`);
+        writeOut(program, `prompt-metadata.json:      ${formatEvidencePath(detail.metadataPath)}\n`);
         writeOut(program, `retries:      ${detail.retryCount}${detail.isContinuation ? " (continuation)" : ""}\n`);
         if (detail.terminalReason !== null) {
           writeOut(program, `terminal:     ${detail.terminalReason}\n`);
@@ -377,18 +441,16 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
           }
         }
         const events = store.listProviderEvents(id, { limit: options.events });
-        if (events.length > 0) {
-          writeOut(program, `\nrecent events (last ${events.length}):\n`);
-          for (const event of events) {
-            const message =
-              typeof event.normalized.message === "string"
-                ? event.normalized.message
-                : JSON.stringify(event.normalized);
-            writeOut(
-              program,
-              `  ${event.sequence}. ${event.type}  ${message}\n`
-            );
-          }
+        writeOut(program, `\nnormalized events (last ${events.length}):\n`);
+        if (events.length === 0) {
+          writeOut(program, "  (no events recorded)\n");
+        }
+        for (const event of events) {
+          const message =
+            typeof event.normalized.message === "string"
+              ? event.normalized.message
+              : JSON.stringify(event.normalized);
+          writeOut(program, `  ${event.sequence}. ${event.type}  ${message}\n`);
         }
       } finally {
         store.close();
@@ -397,38 +459,30 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
 
   program
     .command("cancel")
-    .description("request cancellation of an active run via the run store")
+    .description("request cancellation of an active run via the daemon")
     .argument("<id>", "run id")
     .option("--config <path>", "service config path", "symphonika.yml")
-    .action((id: string, options: { config: string }) => {
+    .option("--daemon-url <url>", "local daemon base URL")
+    .action(async (id: string, options: { config: string; daemonUrl?: string }) => {
       const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
-      const store = openRunStore({ stateRoot });
-      try {
-        const detail = store.getRun(id);
-        if (detail === undefined) {
-          writeErr(program, `run ${id} not found\n`);
-          program.error(`run ${id} not found`, { exitCode: 1 });
-          return;
-        }
-        if (
-          detail.state === "cancelled" ||
-          detail.state === "failed" ||
-          detail.state === "stale" ||
-          detail.state === "succeeded"
-        ) {
-          writeErr(program, `run ${id} already ${detail.state}\n`);
-          program.error(`run ${id} already ${detail.state}`, { exitCode: 1 });
-          return;
-        }
-        store.markCancelRequested(id, "operator");
-        writeOut(program, `cancel requested for ${id}\n`);
-        writeOut(
-          program,
-          "the running daemon will pick up the request on its next iteration; if no daemon is running, the request will be honored on next startup.\n"
-        );
-      } finally {
-        store.close();
+      const daemonUrl = await resolveDaemonUrl(stateRoot, options.daemonUrl);
+      const outcome = await postCancel(fetcher, daemonUrl, id);
+      if (outcome.kind === "cancelled") {
+        writeOut(program, `cancelled ${id}\n`);
+        return;
       }
+      if (outcome.kind === "not-found") {
+        writeErr(program, `run ${id} not found\n`);
+        program.error(`run ${id} not found`, { exitCode: 1 });
+        return;
+      }
+      if (outcome.kind === "already-terminal") {
+        writeErr(program, `run ${id} already ${outcome.state}\n`);
+        program.error(`run ${id} already ${outcome.state}`, { exitCode: 1 });
+        return;
+      }
+      writeErr(program, `cancel failed: ${outcome.error}\n`);
+      program.error(`cancel failed: ${outcome.error}`, { exitCode: 1 });
     });
 
   return program;
@@ -436,6 +490,285 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
 
 export async function runCli(argv = process.argv): Promise<void> {
   await buildCli().parseAsync(argv);
+}
+
+async function resolveDaemonUrl(
+  stateRoot: string,
+  explicitUrl: string | undefined
+): Promise<string> {
+  if (explicitUrl !== undefined) {
+    return trimTrailingSlash(explicitUrl);
+  }
+  const endpoint = await readDaemonEndpoint(stateRoot);
+  return trimTrailingSlash(endpoint?.url ?? "http://127.0.0.1:3000");
+}
+
+async function fetchDaemonStatus(
+  fetcher: FetchFn,
+  daemonUrl: string,
+  expectedStateRoot: string
+): Promise<
+  | { kind: "available"; status: DaemonStatusResponse }
+  | { kind: "unavailable"; error: string }
+> {
+  try {
+    const response = await fetcher(`${daemonUrl}/api/status`);
+    if (!response.ok) {
+      return {
+        error: `HTTP ${response.status}`,
+        kind: "unavailable"
+      };
+    }
+    const status = (await response.json()) as DaemonStatusResponse;
+    if (
+      typeof status.stateRoot === "string" &&
+      path.resolve(status.stateRoot) !== path.resolve(expectedStateRoot)
+    ) {
+      return {
+        error: `state root mismatch (${status.stateRoot})`,
+        kind: "unavailable"
+      };
+    }
+    return {
+      kind: "available",
+      status
+    };
+  } catch (error) {
+    return {
+      error: errorMessage(error),
+      kind: "unavailable"
+    };
+  }
+}
+
+async function postCancel(
+  fetcher: FetchFn,
+  daemonUrl: string,
+  runId: string
+): Promise<
+  | { kind: "cancelled" }
+  | { kind: "not-found" }
+  | { kind: "already-terminal"; state: RunState }
+  | { kind: "error"; error: string }
+> {
+  let response: Response;
+  try {
+    response = await fetcher(
+      `${daemonUrl}/api/runs/${encodeURIComponent(runId)}/cancel`,
+      { method: "POST" }
+    );
+  } catch (error) {
+    return {
+      error: errorMessage(error),
+      kind: "error"
+    };
+  }
+
+  if (response.status === 404) {
+    return { kind: "not-found" };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+
+  if (response.status === 409) {
+    const state = readRunState(body);
+    return state === undefined
+      ? { error: "daemon returned terminal conflict without a run state", kind: "error" }
+      : { kind: "already-terminal", state };
+  }
+  if (!response.ok) {
+    return {
+      error: `daemon returned HTTP ${response.status}`,
+      kind: "error"
+    };
+  }
+  if (isObject(body) && body.kind === "cancelled") {
+    return { kind: "cancelled" };
+  }
+  return {
+    error: "daemon returned an unexpected cancellation response",
+    kind: "error"
+  };
+}
+
+function issueCountsFromStatus(
+  daemonStatus:
+    | { kind: "available"; status: DaemonStatusResponse }
+    | { kind: "unavailable"; error: string },
+  projects: DoctorProjectReport[],
+  byState: Map<string, number>
+): {
+  candidate: number;
+  failed: number;
+  filtered: number;
+  running: number;
+  stale: number;
+} {
+  if (daemonStatus.kind === "available") {
+    const filteredIssues = daemonStatus.status.filteredIssues;
+    return {
+      candidate: arrayLength(daemonStatus.status.candidateIssues),
+      failed: Math.max(
+        countIssuesWithLabel(filteredIssues, "sym:failed"),
+        (byState.get("failed") ?? 0) + (byState.get("input_required") ?? 0)
+      ),
+      filtered: arrayLength(filteredIssues),
+      running: Math.max(
+        countIssuesWithLabel(filteredIssues, "sym:running"),
+        byState.get("running") ?? 0
+      ),
+      stale: Math.max(
+        projects.reduce((count, project) => count + project.staleIssues.length, 0),
+        countIssuesWithLabel(filteredIssues, "sym:stale"),
+        arrayLength(daemonStatus.status.staleIssues),
+        byState.get("stale") ?? 0
+      )
+    };
+  }
+  return {
+    candidate: 0,
+    failed: (byState.get("failed") ?? 0) + (byState.get("input_required") ?? 0),
+    filtered: 0,
+    running: byState.get("running") ?? 0,
+    stale: Math.max(
+      projects.reduce((count, project) => count + project.staleIssues.length, 0),
+      byState.get("stale") ?? 0
+    )
+  };
+}
+
+function countIssuesWithLabel(
+  entries: unknown[] | undefined,
+  label: string
+): number {
+  if (!Array.isArray(entries)) {
+    return 0;
+  }
+
+  const seen = new Set<string>();
+  let anonymous = 0;
+  for (const entry of entries) {
+    const labels = labelsFromPollEntry(entry);
+    if (!labels.has(label)) {
+      continue;
+    }
+    const key = pollEntryKey(entry);
+    if (key === undefined) {
+      anonymous += 1;
+      continue;
+    }
+    seen.add(key);
+  }
+  return seen.size + anonymous;
+}
+
+function labelsFromPollEntry(entry: unknown): Set<string> {
+  if (!isObject(entry) || !isObject(entry.issue)) {
+    return new Set();
+  }
+  const labels = entry.issue.labels;
+  if (!Array.isArray(labels)) {
+    return new Set();
+  }
+  return new Set(labels.filter((label): label is string => typeof label === "string"));
+}
+
+function pollEntryKey(entry: unknown): string | undefined {
+  if (!isObject(entry) || !isObject(entry.issue)) {
+    return undefined;
+  }
+  const project = typeof entry.project === "string" ? entry.project : "";
+  const id = entry.issue.id;
+  if (typeof id === "number" || typeof id === "string") {
+    return `${project}:id:${id}`;
+  }
+  const number = entry.issue.number;
+  if (typeof number === "number" || typeof number === "string") {
+    return `${project}:number:${number}`;
+  }
+  return undefined;
+}
+
+function formatDaemonAvailability(
+  daemonStatus:
+    | { kind: "available"; status: DaemonStatusResponse }
+    | { kind: "unavailable"; error: string },
+  daemonUrl: string
+): string {
+  if (daemonStatus.kind === "available") {
+    return `${daemonStatus.status.state ?? "unknown"} at ${daemonUrl}`;
+  }
+  return `unavailable at ${daemonUrl} (${daemonStatus.error})`;
+}
+
+function formatLastPollOutcome(
+  daemonStatus:
+    | { kind: "available"; status: DaemonStatusResponse }
+    | { kind: "unavailable"; error: string }
+): string {
+  if (daemonStatus.kind === "unavailable") {
+    return `unknown (${daemonStatus.error})`;
+  }
+  const issuePolling = daemonStatus.status.issuePolling;
+  if (issuePolling === undefined) {
+    return "unknown";
+  }
+  const errors = issuePolling.errors ?? [];
+  if (errors.length > 0) {
+    return `failed: ${errors.join("; ")}`;
+  }
+  const projects = issuePolling.projects ?? [];
+  if (projects.length === 0) {
+    return "not yet polled";
+  }
+  return projects
+    .map((project) =>
+      project.ok
+        ? `${project.name} ok (${project.fetchedIssues} fetched)`
+        : `${project.name} failed (${project.error ?? "unknown error"})`
+    )
+    .join("; ");
+}
+
+function readRunState(value: unknown): RunState | undefined {
+  if (!isObject(value) || typeof value.state !== "string") {
+    return undefined;
+  }
+  return isRunState(value.state) ? value.state : undefined;
+}
+
+function isRunState(value: string): value is RunState {
+  return (
+    value === "queued" ||
+    value === "preparing_workspace" ||
+    value === "running" ||
+    value === "input_required" ||
+    value === "failed" ||
+    value === "succeeded" ||
+    value === "cancelled" ||
+    value === "stale"
+  );
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function arrayLength(value: unknown[] | undefined): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function formatList(values: string[]): string {
+  return values.length === 0 ? "(none)" : values.join(", ");
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 function parsePositiveInt(value: string): number {
@@ -448,6 +781,14 @@ function parsePositiveInt(value: string): number {
 
 function formatPath(value: string): string {
   return value.length === 0 ? "<not yet recorded>" : value;
+}
+
+function formatEvidencePath(value: string): string {
+  return value.length === 0 ? "<not yet recorded>" : path.resolve(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function parsePort(value: string): number {

--- a/src/daemon-endpoint.ts
+++ b/src/daemon-endpoint.ts
@@ -1,0 +1,67 @@
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type DaemonEndpoint = {
+  host: string;
+  pid: number;
+  port: number;
+  startedAt: string;
+  url: string;
+};
+
+export function daemonEndpointPath(stateRoot: string): string {
+  return path.join(stateRoot, "daemon.json");
+}
+
+export async function writeDaemonEndpoint(
+  stateRoot: string,
+  endpoint: DaemonEndpoint
+): Promise<void> {
+  await writeFile(
+    daemonEndpointPath(stateRoot),
+    `${JSON.stringify(endpoint, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+export async function readDaemonEndpoint(
+  stateRoot: string
+): Promise<DaemonEndpoint | undefined> {
+  let raw: string;
+  try {
+    raw = await readFile(daemonEndpointPath(stateRoot), "utf8");
+  } catch {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+
+  if (!isDaemonEndpoint(parsed)) {
+    return undefined;
+  }
+  return parsed;
+}
+
+export async function removeDaemonEndpoint(stateRoot: string): Promise<void> {
+  await rm(daemonEndpointPath(stateRoot), { force: true });
+}
+
+function isDaemonEndpoint(value: unknown): value is DaemonEndpoint {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.host === "string" &&
+    typeof candidate.pid === "number" &&
+    typeof candidate.port === "number" &&
+    typeof candidate.startedAt === "string" &&
+    typeof candidate.url === "string"
+  );
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5,6 +5,10 @@ import type { Logger } from "pino";
 import pino from "pino";
 import { parse } from "yaml";
 
+import {
+  removeDaemonEndpoint,
+  writeDaemonEndpoint
+} from "./daemon-endpoint.js";
 import { createHttpApp } from "./http/app.js";
 import type {
   GitHubIssuesApi,
@@ -69,9 +73,11 @@ export type DaemonHandle = {
 export async function startDaemon(
   options: StartDaemonOptions = {}
 ): Promise<DaemonHandle> {
-  const logger = options.logger ?? pino();
+  const env = options.env ?? process.env;
+  const logger = options.logger ?? pino({ level: resolveLogLevel(env) });
   const host = options.host ?? "127.0.0.1";
   const requestedPort = options.port ?? 3000;
+  const startedAtMs = Date.now();
   const stateRootOptions: Parameters<typeof resolveStateRoot>[0] = {};
   if (options.configPath !== undefined) {
     stateRootOptions.configPath = options.configPath;
@@ -93,7 +99,6 @@ export async function startDaemon(
   }
   const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;
   const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
-  const env = options.env ?? process.env;
   const activeRuns = new ActiveRunRegistry();
   const dispatchMutex = createAsyncMutex();
   const dispatchRuntime = {
@@ -287,6 +292,7 @@ export async function startDaemon(
   const TERMINAL_STATES = new Set<RunState>([
     "cancelled",
     "failed",
+    "input_required",
     "stale",
     "succeeded"
   ]);
@@ -306,6 +312,8 @@ export async function startDaemon(
     }
     runStore.markCancelRequested(runId, "operator");
     await activeRuns.requestCancel(runId, "operator");
+    runStore.recordTerminalReason(runId, "operator_cancelled");
+    runStore.updateRunState(runId, "cancelled");
     return { kind: "cancelled" };
   };
   const app = createHttpApp({
@@ -321,14 +329,19 @@ export async function startDaemon(
       })),
     getRuns: () => runStore.listRuns(),
     getScheduled: () => activeRuns.peekDelayed(),
+    getStatusSnapshot: () =>
+      buildStatusSnapshot({
+        configPath: state.configPath,
+        issuePollStatus,
+        runStore,
+        stateRoot: state.stateRoot
+      }),
     issuePollStatus,
     runStore,
+    startedAtMs,
     stateRoot: state.stateRoot,
     version: VERSION
   });
-  // Reference buildStatusSnapshot so eslint/tsc don't strip the import; it's
-  // exported for CLI use and may be wired into HTTP pages later.
-  void buildStatusSnapshot;
 
   const server = serve({
     fetch: app.fetch,
@@ -338,6 +351,13 @@ export async function startDaemon(
   await waitForListening(server);
   const port = resolveListeningPort(server, requestedPort);
   const url = `http://${host}:${port}`;
+  await writeDaemonEndpoint(state.stateRoot, {
+    host,
+    pid: process.pid,
+    port,
+    startedAt: new Date(startedAtMs).toISOString(),
+    url
+  });
   if (state.configExists) {
     await reconcile();
     if (issuePollStatus.candidateIssues.length > 0) {
@@ -372,6 +392,7 @@ export async function startDaemon(
       await scheduledWork;
       await Promise.allSettled(Array.from(inflightDispatches));
       await stopServer(server, logger);
+      await removeDaemonEndpoint(state.stateRoot);
       runStore.close();
     }
   };
@@ -543,6 +564,10 @@ function defaultProvidersConfig(): RunControllerProvidersConfig {
         "codex -p symphonika --dangerously-bypass-approvals-and-sandbox app-server"
     }
   };
+}
+
+export function resolveLogLevel(env: NodeJS.ProcessEnv): string {
+  return env["PINO_LOG_LEVEL"] ?? env["LOG_LEVEL"] ?? "info";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -14,6 +14,7 @@ import type {
   RunStatus,
   RunStore
 } from "../run-store.js";
+import type { StatusSnapshot } from "../status.js";
 import { registerPages } from "./pages.js";
 
 export type CancelRunFn = (
@@ -47,6 +48,7 @@ export type HttpAppOptions = {
     kind: "retry" | "continuation";
     runId: string;
   }>;
+  getStatusSnapshot?: () => StatusSnapshot;
   issuePollStatus?: IssuePollStatus;
   now?: () => number;
   runStore?: RunStore;
@@ -98,6 +100,40 @@ const FILE_DESCRIPTORS: Record<
     contentType: "application/x-ndjson"
   }
 };
+
+const LOG_FILE_DESCRIPTORS: Record<
+  string,
+  { column: FileColumn; contentType: string }
+> = {
+  "issue-snapshot.json": {
+    column: "issueSnapshotPath",
+    contentType: "application/json; charset=utf-8"
+  },
+  "prompt-metadata.json": {
+    column: "metadataPath",
+    contentType: "application/json; charset=utf-8"
+  },
+  "prompt.md": {
+    column: "promptPath",
+    contentType: "text/markdown; charset=utf-8"
+  },
+  "provider.normalized.jsonl": {
+    column: "normalizedLogPath",
+    contentType: "application/x-ndjson"
+  },
+  "provider.raw.jsonl": {
+    column: "rawLogPath",
+    contentType: "application/x-ndjson"
+  }
+};
+
+const TERMINAL_STATES: ReadonlySet<RunState> = new Set([
+  "cancelled",
+  "failed",
+  "input_required",
+  "stale",
+  "succeeded"
+]);
 
 export function createHttpApp(options: HttpAppOptions): Hono {
   const app = new Hono();
@@ -231,20 +267,35 @@ export function createHttpApp(options: HttpAppOptions): Hono {
       });
     });
 
+    app.get("/logs/runs/:id/:fileName", async (context) => {
+      const id = context.req.param("id");
+      const detail = runStore.getRun(id);
+      if (detail === undefined) {
+        return context.json({ error: "run not found" }, 404);
+      }
+      const fileName = context.req.param("fileName");
+      const descriptor = LOG_FILE_DESCRIPTORS[fileName];
+      if (descriptor === undefined) {
+        return context.json({ error: "unknown log file" }, 404);
+      }
+      return serveRunEvidenceFile({
+        contentType: descriptor.contentType,
+        filePath: detail[descriptor.column],
+        id,
+        stateRoot: options.stateRoot
+      });
+    });
+
     app.post("/api/runs/:id/cancel", async (context) => {
       const id = context.req.param("id");
       const wantsRedirect = (
         context.req.header("content-type") ?? ""
       ).startsWith("application/x-www-form-urlencoded");
 
-      if (cancelRun === undefined) {
-        if (wantsRedirect) {
-          return context.redirect(`/runs/${encodeURIComponent(id)}`, 303);
-        }
-        return context.json({ kind: "unavailable" }, 503);
-      }
-
-      const outcome = await Promise.resolve(cancelRun(id, "ui"));
+      const outcome =
+        cancelRun === undefined
+          ? cancelRunInStore(runStore, id)
+          : await Promise.resolve(cancelRun(id, "ui"));
       if (outcome.kind === "not-found") {
         if (wantsRedirect) {
           return context.redirect("/", 303);
@@ -266,12 +317,66 @@ export function createHttpApp(options: HttpAppOptions): Hono {
     registerPages({
       app,
       issuePollStatus,
-      ...(options.runStore !== undefined ? { runStore: options.runStore } : {}),
+      runStore,
+      ...(options.getStatusSnapshot === undefined
+        ? {}
+        : { getStatusSnapshot: options.getStatusSnapshot }),
       version: options.version
-    } as Parameters<typeof registerPages>[0]);
+    });
   }
 
   return app;
+}
+
+async function serveRunEvidenceFile(input: {
+  contentType: string;
+  filePath: string;
+  id: string;
+  stateRoot: string;
+}): Promise<Response> {
+  if (typeof input.filePath !== "string" || input.filePath.length === 0) {
+    return Response.json({ error: "file not yet recorded" }, { status: 404 });
+  }
+  const evidenceRoot = path.join(
+    path.resolve(input.stateRoot),
+    "logs",
+    "runs",
+    input.id
+  );
+  if (!isPathInside(input.filePath, evidenceRoot)) {
+    return Response.json({ error: "file not available" }, { status: 404 });
+  }
+  try {
+    await access(input.filePath);
+  } catch {
+    return Response.json({ error: "file not found" }, { status: 404 });
+  }
+  const stream: ReadStream = createReadStream(input.filePath);
+  return new Response(Readable.toWeb(stream) as ReadableStream, {
+    headers: { "content-type": input.contentType },
+    status: 200
+  });
+}
+
+function cancelRunInStore(
+  runStore: RunStore,
+  runId: string
+):
+  | { kind: "cancelled" }
+  | { kind: "not-found" }
+  | { kind: "already-terminal"; state: RunState } {
+  const detail = runStore.getRun(runId);
+  if (detail === undefined) {
+    return { kind: "not-found" };
+  }
+  if (TERMINAL_STATES.has(detail.state)) {
+    return { kind: "already-terminal", state: detail.state };
+  }
+
+  runStore.markCancelRequested(runId, "operator");
+  runStore.recordTerminalReason(runId, "operator_cancelled");
+  runStore.updateRunState(runId, "cancelled");
+  return { kind: "cancelled" };
 }
 
 function parsePositiveInt(value: string | undefined): number | undefined {

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -23,6 +23,7 @@ export type RegisterPagesOptions = {
 const TERMINAL_STATES: ReadonlySet<RunState> = new Set([
   "cancelled",
   "failed",
+  "input_required",
   "stale",
   "succeeded"
 ]);
@@ -46,7 +47,7 @@ export function registerPages(options: RegisterPagesOptions): void {
       "Symphonika",
       [
         renderHeader(options.version, snapshot),
-        renderProjectsCard(snapshot),
+        renderProjectsCard(snapshot, options.issuePollStatus),
         renderStaleIssuesCard(options.issuePollStatus?.filteredIssues ?? []),
         renderRunsTable("Recent runs", recentRuns)
       ].join("")
@@ -139,23 +140,38 @@ function renderHeader(version: string, snapshot: StatusSnapshot | undefined): st
 </section>`;
 }
 
-function renderProjectsCard(snapshot: StatusSnapshot | undefined): string {
-  if (snapshot === undefined || snapshot.projects.length === 0) {
+function renderProjectsCard(
+  snapshot: StatusSnapshot | undefined,
+  issuePollStatus: IssuePollStatus | undefined
+): string {
+  if (snapshot !== undefined && snapshot.projects.length > 0) {
+    const rows = snapshot.projects
+      .map((project) => {
+        const missing =
+          project.missingOperationalLabels.length === 0
+            ? "&mdash;"
+            : escapeHtml(project.missingOperationalLabels.join(", "));
+        const valid = project.validForDispatch ? "valid" : "invalid";
+        return `<tr><td>${escapeHtml(project.name)}</td><td>${escapeHtml(valid)}</td><td><code>${escapeHtml(project.workflowPath)}</code></td><td>${missing}</td></tr>`;
+      })
+      .join("");
+    return `<section><h2>Projects</h2>
+<table><thead><tr><th>Name</th><th>Validation</th><th>Workflow</th><th>Missing operational labels</th></tr></thead>
+<tbody>${rows}</tbody></table></section>`;
+  }
+
+  if (issuePollStatus === undefined || issuePollStatus.projects.length === 0) {
     return "";
   }
 
-  const rows = snapshot.projects
-    .map((project) => {
-      const missing =
-        project.missingOperationalLabels.length === 0
-          ? "&mdash;"
-          : escapeHtml(project.missingOperationalLabels.join(", "));
-      const valid = project.validForDispatch ? "valid" : "invalid";
-      return `<tr><td>${escapeHtml(project.name)}</td><td>${escapeHtml(valid)}</td><td><code>${escapeHtml(project.workflowPath)}</code></td><td>${missing}</td></tr>`;
-    })
+  const rows = issuePollStatus.projects
+    .map(
+      (project) =>
+        `<tr><td>${escapeHtml(project.name)}</td><td>${project.ok ? "poll ok" : "poll failed"}</td><td>${project.fetchedIssues}</td><td>${escapeHtml(project.error ?? "")}</td></tr>`
+    )
     .join("");
   return `<section><h2>Projects</h2>
-<table><thead><tr><th>Name</th><th>Validation</th><th>Workflow</th><th>Missing operational labels</th></tr></thead>
+<table><thead><tr><th>Name</th><th>Last poll</th><th>Fetched issues</th><th>Error</th></tr></thead>
 <tbody>${rows}</tbody></table></section>`;
 }
 
@@ -188,11 +204,11 @@ function renderRunsTable(title: string, runs: RunStatus[]): string {
   const rows = runs
     .map(
       (run) =>
-        `<tr><td><a href="/runs/${encodeURIComponent(run.id)}"><code>${escapeHtml(run.id)}</code></a></td><td>${escapeHtml(run.project)}</td><td>#${run.issueNumber} ${escapeHtml(run.issueTitle)}</td><td><span class="state-${escapeHtml(run.state)}">${escapeHtml(run.state)}</span></td><td>${escapeHtml(run.provider)}</td><td><code>${escapeHtml(run.branchName)}</code></td></tr>`
+        `<tr><td><a href="/runs/${encodeURIComponent(run.id)}"><code>${escapeHtml(run.id)}</code></a></td><td>${escapeHtml(run.project)}</td><td>#${run.issueNumber} ${escapeHtml(run.issueTitle)}</td><td><span class="state-${escapeHtml(run.state)}">${escapeHtml(run.state)}</span></td><td>${escapeHtml(run.provider)}</td><td>${escapeHtml(run.createdAt)}</td><td>${escapeHtml(run.updatedAt)}</td></tr>`
     )
     .join("");
   return `<section><h2>${escapeHtml(title)}</h2>
-<table><thead><tr><th>Run id</th><th>Project</th><th>Issue</th><th>State</th><th>Provider</th><th>Branch</th></tr></thead>
+<table><thead><tr><th>Run id</th><th>Project</th><th>Issue</th><th>State</th><th>Provider</th><th>Started</th><th>Updated</th></tr></thead>
 <tbody>${rows}</tbody></table></section>`;
 }
 
@@ -202,6 +218,8 @@ function renderRunSummary(detail: RunStatus): string {
   <p><strong>Issue:</strong> #${detail.issueNumber} ${escapeHtml(detail.issueTitle)}</p>
   <p><strong>State:</strong> <span class="state-${escapeHtml(detail.state)}">${escapeHtml(detail.state)}</span></p>
   <p><strong>Provider:</strong> ${escapeHtml(detail.provider)}</p>
+  <p><strong>Started:</strong> ${escapeHtml(detail.createdAt)}</p>
+  <p><strong>Updated:</strong> ${escapeHtml(detail.updatedAt)}</p>
   <p><strong>Branch:</strong> <code>${escapeHtml(detail.branchName)}</code></p>
   <p><strong>Workspace:</strong> <code>${escapeHtml(detail.workspacePath)}</code></p>
   <p><strong>Retries:</strong> ${detail.retryCount}${detail.isContinuation ? " (continuation)" : ""}</p>
@@ -284,14 +302,18 @@ function renderRunFileLinks(detail: RunStatus): string {
       return;
     }
     items.push(
-      `<li><a href="/api/runs/${encodeURIComponent(detail.id)}/files/${kind}">${escapeHtml(label)}</a></li>`
+      `<li><a href="/logs/runs/${encodeURIComponent(detail.id)}/${encodeURIComponent(kind)}">${escapeHtml(label)}</a></li>`
     );
   };
-  linkIfPresent("Rendered prompt", "prompt", detail.promptPath);
-  linkIfPresent("Provider raw log", "raw-log", detail.rawLogPath);
-  linkIfPresent("Normalized log", "normalized-log", detail.normalizedLogPath);
-  linkIfPresent("Issue snapshot", "issue-snapshot", detail.issueSnapshotPath);
-  linkIfPresent("Prompt metadata", "metadata", detail.metadataPath);
+  linkIfPresent("Rendered prompt", "prompt.md", detail.promptPath);
+  linkIfPresent("Provider raw log", "provider.raw.jsonl", detail.rawLogPath);
+  linkIfPresent(
+    "Normalized log",
+    "provider.normalized.jsonl",
+    detail.normalizedLogPath
+  );
+  linkIfPresent("Issue snapshot", "issue-snapshot.json", detail.issueSnapshotPath);
+  linkIfPresent("Prompt metadata", "prompt-metadata.json", detail.metadataPath);
   if (items.length === 0) {
     return "";
   }

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -25,6 +25,7 @@ export type RunStatus = {
   cancelReason: CancelReason | null;
   cancelRequested: boolean;
   continuationParentRunId: string | null;
+  createdAt: string;
   failureClassification: FailureClassification | null;
   id: string;
   isContinuation: boolean;
@@ -40,12 +41,14 @@ export type RunStatus = {
   retryCount: number;
   state: RunState;
   terminalReason: string | null;
+  updatedAt: string;
   workspacePath: string;
 };
 
 export type AttemptStatus = {
   attemptNumber: number;
   branchName: string;
+  createdAt: string;
   id: string;
   issueSnapshotPath: string;
   normalizedLogPath: string;
@@ -55,6 +58,7 @@ export type AttemptStatus = {
   rawLogPath: string;
   runId: string;
   state: RunState;
+  updatedAt: string;
   workspacePath: string;
 };
 
@@ -136,6 +140,7 @@ type RunRow = {
   cancel_reason: string | null;
   cancel_requested: number;
   continuation_parent_run_id: string | null;
+  created_at: string;
   failure_classification: string | null;
   id: string;
   is_continuation: number;
@@ -151,12 +156,14 @@ type RunRow = {
   retry_count: number;
   state: RunState;
   terminal_reason: string | null;
+  updated_at: string;
   workspace_path: string | null;
 };
 
 type AttemptRow = {
   attempt_number: number;
   branch_name: string;
+  created_at: string;
   id: string;
   issue_snapshot_path: string;
   normalized_log_path: string;
@@ -166,6 +173,7 @@ type AttemptRow = {
   raw_log_path: string;
   run_id: string;
   state: RunState;
+  updated_at: string;
   workspace_path: string;
 };
 
@@ -345,6 +353,18 @@ export class RunStore {
 
   updateRunState(runId: string, state: RunState): void {
     const now = timestamp();
+    const existing = this.database
+      .prepare("select state from runs where id = ?")
+      .get(runId) as { state: RunState } | undefined;
+    if (existing === undefined) {
+      return;
+    }
+    if (existing.state === state) {
+      this.database
+        .prepare("update runs set updated_at = ? where id = ?")
+        .run(now, runId);
+      return;
+    }
     this.database
       .prepare("update runs set state = ?, updated_at = ? where id = ?")
       .run(state, now, runId);
@@ -472,7 +492,8 @@ export class RunStore {
           "workspace_path, branch_name, prompt_path, metadata_path,",
           "issue_snapshot_path, raw_log_path, normalized_log_path,",
           "is_continuation, continuation_parent_run_id, retry_count,",
-          "failure_classification, terminal_reason, cancel_requested, cancel_reason",
+          "failure_classification, terminal_reason, cancel_requested, cancel_reason,",
+          "created_at, updated_at",
           "from runs",
           where,
           "order by created_at desc, id desc",
@@ -494,7 +515,8 @@ export class RunStore {
           "workspace_path, branch_name, prompt_path, metadata_path,",
           "issue_snapshot_path, raw_log_path, normalized_log_path,",
           "is_continuation, continuation_parent_run_id, retry_count,",
-          "failure_classification, terminal_reason, cancel_requested, cancel_reason",
+          "failure_classification, terminal_reason, cancel_requested, cancel_reason,",
+          "created_at, updated_at",
           "from runs where id = ?"
         ].join(" ")
       )
@@ -517,7 +539,7 @@ export class RunStore {
         [
           "select id, run_id, attempt_number, state, provider_name, provider_command,",
           "workspace_path, branch_name, prompt_path, issue_snapshot_path,",
-          "raw_log_path, normalized_log_path",
+          "raw_log_path, normalized_log_path, created_at, updated_at",
           "from attempts where run_id = ? order by attempt_number asc, id asc"
         ].join(" ")
       )
@@ -526,6 +548,7 @@ export class RunStore {
     return rows.map((row) => ({
       attemptNumber: row.attempt_number,
       branchName: row.branch_name,
+      createdAt: row.created_at,
       id: row.id,
       issueSnapshotPath: row.issue_snapshot_path,
       normalizedLogPath: row.normalized_log_path,
@@ -535,6 +558,7 @@ export class RunStore {
       rawLogPath: row.raw_log_path,
       runId: row.run_id,
       state: row.state,
+      updatedAt: row.updated_at,
       workspacePath: row.workspace_path
     }));
   }
@@ -757,6 +781,7 @@ function mapRunRow(row: RunRow): RunStatus {
     cancelReason: (row.cancel_reason as CancelReason | null) ?? null,
     cancelRequested: row.cancel_requested === 1,
     continuationParentRunId: row.continuation_parent_run_id ?? null,
+    createdAt: row.created_at,
     failureClassification:
       (row.failure_classification as FailureClassification | null) ?? null,
     id: row.id,
@@ -773,6 +798,7 @@ function mapRunRow(row: RunRow): RunStatus {
     retryCount: row.retry_count ?? 0,
     state: row.state,
     terminalReason: row.terminal_reason ?? null,
+    updatedAt: row.updated_at,
     workspacePath: row.workspace_path ?? ""
   };
 }

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -87,7 +87,48 @@ describe("CLI run commands", () => {
     store.updateRunState("r-failed", "failed");
     store.close();
 
-    const { output, program } = captureProgram(stateRoot);
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: () =>
+        Promise.resolve(
+          Response.json({
+            candidateIssues: [{ issue: { number: 1 }, project: "alpha" }],
+            filteredIssues: [
+              {
+                issue: { labels: ["sym:running"], number: 2 },
+                project: "alpha"
+              },
+              {
+                issue: { labels: ["sym:running"], number: 20 },
+                project: "alpha"
+              },
+              {
+                issue: { labels: ["sym:failed"], number: 3 },
+                project: "alpha"
+              },
+              {
+                issue: { labels: ["sym:failed"], number: 30 },
+                project: "alpha"
+              },
+              {
+                issue: { labels: ["sym:stale"], number: 4 },
+                project: "alpha"
+              }
+            ],
+            issuePolling: {
+              errors: [],
+              projects: [{ fetchedIssues: 2, name: "alpha", ok: true }]
+            },
+            stateRoot: path.join(stateRoot, ".symphonika"),
+            staleIssues: [
+              {
+                issue: { labels: ["sym:stale"], number: 4 },
+                project: "alpha"
+              }
+            ],
+            state: "idle"
+          })
+        )
+    });
     await program.parseAsync([
       "node",
       "symphonika",
@@ -97,10 +138,48 @@ describe("CLI run commands", () => {
     ]);
 
     expect(output.stdout).toContain("state root");
-    expect(output.stdout).toContain("running: 1");
-    expect(output.stdout).toContain("failed: 1");
+    expect(output.stdout).toContain("daemon: idle");
+    expect(output.stdout).toContain("Issue counts");
+    expect(output.stdout).toContain("candidate: 1");
+    expect(output.stdout).toContain("filtered:  5");
+    expect(output.stdout).toContain("last poll outcome: alpha ok (2 fetched)");
+    expect(output.stdout).toContain("running:   2");
+    expect(output.stdout).toContain("failed:    2");
+    expect(output.stdout).toContain("stale:     1");
     expect(output.stdout).toContain("r-running");
     expect(output.stdout).toContain("r-failed");
+  });
+
+  it("status ignores daemon snapshots for another state root", async () => {
+    const stateRoot = await makeTempRoot();
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: () =>
+        Promise.resolve(
+          Response.json({
+            candidateIssues: [{ issue: { number: 123 }, project: "other" }],
+            filteredIssues: [{ issue: { labels: ["sym:running"], number: 123 } }],
+            issuePolling: {
+              errors: [],
+              projects: [{ fetchedIssues: 1, name: "other", ok: true }]
+            },
+            state: "dispatching",
+            stateRoot: path.join(stateRoot, "..", "other-state")
+          })
+        )
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml")
+    ]);
+
+    expect(output.stdout).toContain("daemon: unavailable");
+    expect(output.stdout).toContain("state root mismatch");
+    expect(output.stdout).toContain("candidate: 0");
+    expect(output.stdout).toContain("running:   0");
   });
 
   it("status prints stale GitHub issues by project and issue number", async () => {
@@ -139,6 +218,7 @@ describe("CLI run commands", () => {
 
     expect(output.stdout).toContain("project: alpha");
     expect(output.stdout).toContain("stale issues: 1");
+    expect(output.stdout).toContain("stale:     1");
     expect(output.stdout).toContain("#44  Stale claim");
   });
 
@@ -180,6 +260,8 @@ describe("CLI run commands", () => {
       "failed"
     ]);
     expect(failed.output.stdout).toContain("r-only-failed");
+    expect(failed.output.stdout).toContain("started");
+    expect(failed.output.stdout).toContain("updated");
   });
 
   it("show-run errors when the run is missing and prints detail when present", async () => {
@@ -191,6 +273,29 @@ describe("CLI run commands", () => {
       projectName: "alpha",
       providerCommand: "x",
       providerName: "codex"
+    });
+    store.createAttempt({
+      attemptNumber: 1,
+      branchName: "sym/alpha/7-detail",
+      branchRef: "refs/heads/sym/alpha/7-detail",
+      id: "show-1-attempt-1",
+      issueSnapshotPath: "",
+      metadataPath: "",
+      normalizedLogPath: "",
+      promptPath: "",
+      providerCommand: "x",
+      providerName: "codex",
+      rawLogPath: "",
+      runId: "show-1",
+      state: "running",
+      workspacePath: stateRoot
+    });
+    store.recordProviderEvent({
+      attemptId: "show-1-attempt-1",
+      normalized: { message: "hello from provider", type: "message" },
+      raw: { message: "hello from provider" },
+      runId: "show-1",
+      sequence: 1
     });
     store.close();
 
@@ -219,10 +324,15 @@ describe("CLI run commands", () => {
     ]);
     expect(present.output.stdout).toContain("show-1");
     expect(present.output.stdout).toContain("Detail");
+    expect(present.output.stdout).toContain("prompt.md");
+    expect(present.output.stdout).toContain("attempts");
+    expect(present.output.stdout).toContain("show-1-attempt-1");
+    expect(present.output.stdout).toContain("normalized events");
+    expect(present.output.stdout).toContain("hello from provider");
     expect(present.output.stdout).toContain("<not yet recorded>");
   });
 
-  it("cancel writes markCancelRequested for non-terminal runs and errors otherwise", async () => {
+  it("cancel posts to the daemon endpoint and errors for terminal or missing runs", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });
     store.createRun({
@@ -244,7 +354,19 @@ describe("CLI run commands", () => {
     store.close();
 
     const cfg = path.join(stateRoot, "symphonika.yml");
-    const live = captureProgram(stateRoot);
+    const requests: string[] = [];
+    const live = captureProgram(stateRoot, {
+      fetch: (input, init) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        requests.push(`${url} ${init?.method ?? "GET"}`);
+        return Promise.resolve(Response.json({ kind: "cancelled" }));
+      }
+    });
     await live.program.parseAsync([
       "node",
       "symphonika",
@@ -253,14 +375,21 @@ describe("CLI run commands", () => {
       "--config",
       cfg
     ]);
-    expect(live.output.stdout).toContain("cancel requested for cancel-live");
+    expect(live.output.stdout).toContain("cancelled cancel-live");
+    expect(requests).toEqual([
+      "http://127.0.0.1:3000/api/runs/cancel-live/cancel POST"
+    ]);
 
     const verifyStore = openRunStore({ stateRoot });
-    expect(verifyStore.getRun("cancel-live")?.cancelRequested).toBe(true);
-    expect(verifyStore.getRun("cancel-live")?.cancelReason).toBe("operator");
+    expect(verifyStore.getRun("cancel-live")?.cancelRequested).toBe(false);
     verifyStore.close();
 
-    const done = captureProgram(stateRoot);
+    const done = captureProgram(stateRoot, {
+      fetch: () =>
+        Promise.resolve(
+          Response.json({ kind: "already-terminal", state: "succeeded" }, { status: 409 })
+        )
+    });
     await expect(
       done.program.parseAsync([
         "node",
@@ -273,7 +402,10 @@ describe("CLI run commands", () => {
     ).rejects.toThrow();
     expect(done.output.stderr).toContain("already succeeded");
 
-    const missing = captureProgram(stateRoot);
+    const missing = captureProgram(stateRoot, {
+      fetch: () =>
+        Promise.resolve(Response.json({ kind: "not-found" }, { status: 404 }))
+    });
     await expect(
       missing.program.parseAsync([
         "node",

--- a/tests/http-app-runs.test.ts
+++ b/tests/http-app-runs.test.ts
@@ -200,11 +200,30 @@ describe("HTTP app — runs API and pages", () => {
       expect(ok.headers.get("content-type")).toContain("application/x-ndjson");
       expect(await ok.text()).toContain('{"x":1}');
 
+      const logLink = await app.request("/logs/runs/run-files/provider.raw.jsonl");
+      expect(logLink.status).toBe(200);
+      expect(logLink.headers.get("content-type")).toContain("application/x-ndjson");
+      expect(await logLink.text()).toContain('{"x":1}');
+
+      const detail = await app.request("/runs/run-files");
+      expect(detail.status).toBe(200);
+      const detailBody = await detail.text();
+      expect(detailBody).toContain("Run run-files");
+      expect(detailBody).toContain("Project:");
+      expect(detailBody).toContain("State:");
+      expect(detailBody).toContain("/logs/runs/run-files/provider.raw.jsonl");
+
       expect(
         (await app.request("/api/runs/run-empty/files/raw-log")).status
       ).toBe(404);
       expect(
+        (await app.request("/logs/runs/run-empty/provider.raw.jsonl")).status
+      ).toBe(404);
+      expect(
         (await app.request("/api/runs/run-escape/files/raw-log")).status
+      ).toBe(404);
+      expect(
+        (await app.request("/logs/runs/run-escape/provider.raw.jsonl")).status
       ).toBe(404);
     } finally {
       test.cleanup();
@@ -246,6 +265,66 @@ describe("HTTP app — runs API and pages", () => {
       });
       expect(form.status).toBe(303);
       expect(form.headers.get("location")).toBe("/runs/live");
+
+      test.runStore.createRun({
+        id: "default-live",
+        issue: sampleIssue({ number: 12 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("default-live", "running");
+      test.runStore.createRun({
+        id: "done",
+        issue: sampleIssue({ number: 13 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("done", "succeeded");
+      test.runStore.createRun({
+        id: "input-needed",
+        issue: sampleIssue({ number: 14 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("input-needed", "input_required");
+
+      const defaultApp = createHttpApp({
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+      const defaultOk = await defaultApp.request("/api/runs/default-live/cancel", {
+        method: "POST"
+      });
+      expect(defaultOk.status).toBe(200);
+      expect(test.runStore.getRun("default-live")).toMatchObject({
+        cancelReason: "operator",
+        cancelRequested: true,
+        state: "cancelled"
+      });
+      expect(
+        test.runStore
+          .getRun("default-live")
+          ?.transitions.map((transition) => transition.state)
+      ).toContain("cancelled");
+      expect(
+        (await defaultApp.request("/api/runs/done/cancel", { method: "POST" }))
+          .status
+      ).toBe(409);
+      expect(
+        (
+          await defaultApp.request("/api/runs/input-needed/cancel", {
+            method: "POST"
+          })
+        ).status
+      ).toBe(409);
+      expect(
+        (await defaultApp.request("/api/runs/missing/cancel", { method: "POST" }))
+          .status
+      ).toBe(404);
     } finally {
       test.cleanup();
     }
@@ -264,6 +343,12 @@ describe("HTTP app — runs API and pages", () => {
       test.runStore.updateRunState("<script>x</script>", "running");
 
       const app = createHttpApp({
+        issuePollStatus: {
+          candidateIssues: [],
+          errors: [],
+          filteredIssues: [],
+          projects: [{ fetchedIssues: 0, name: "alpha", ok: true }]
+        },
         runStore: test.runStore,
         stateRoot: test.stateRoot,
         version: "0.1.0"
@@ -274,6 +359,8 @@ describe("HTTP app — runs API and pages", () => {
       expect(dashboard.headers.get("content-type")).toContain("text/html");
       const body = await dashboard.text();
       expect(body).not.toContain("<script>x</script>");
+      expect(body).toContain("Projects");
+      expect(body).toContain("poll ok");
       expect(body).toContain("&lt;script&gt;x&lt;/script&gt;");
       expect(body).not.toContain("<img src=x>");
       expect(body).toContain("&lt;img src=x&gt;");


### PR DESCRIPTION
Summary

- add status/runs/show-run/cancel CLI surfaces backed by the run store and daemon cancel endpoint
- add server-rendered dashboard and run-detail pages with evidence log links
- document the state-root daemon endpoint descriptor and cover CLI/Hono behavior in Vitest

Validation

- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #45