### PR TITLE
Add structured logs at lifecycle boundaries

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -104,6 +104,7 @@ export async function startDaemon(
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let polling = false;
   let scheduledWork = Promise.resolve();
+  let lastPollErrorsKey = "";
   const inflightDispatches = new Set<Promise<void>>();
   const projectsLoader = async (): Promise<
     Map<string, RunControllerProjectConfig>
@@ -204,6 +205,18 @@ export async function startDaemon(
     } finally {
       polling = false;
     }
+    const errorsKey = issuePollStatus.errors.join("\n");
+    if (errorsKey !== lastPollErrorsKey) {
+      if (issuePollStatus.errors.length > 0) {
+        logger.warn(
+          { errors: issuePollStatus.errors },
+          "symphonika polling has errors; no issues will be dispatched"
+        );
+      } else {
+        logger.info("symphonika polling errors cleared");
+      }
+      lastPollErrorsKey = errorsKey;
+    }
   };
   const reconcile = async (): Promise<void> => {
     if (!state.configExists) {
@@ -257,7 +270,13 @@ export async function startDaemon(
     }
     const promise = (async () => {
       try {
-        await runController.dispatchOneFresh(issuePollStatus);
+        const result = await runController.dispatchOneFresh(issuePollStatus);
+        if (result.dispatched === false) {
+          logger.debug(
+            { reason: result.reason },
+            "symphonika dispatch skipped"
+          );
+        }
       } catch (error) {
         issuePollStatus.errors.push(errorMessage(error));
         logger.error({ err: error }, "symphonika dispatch failed");
@@ -274,6 +293,16 @@ export async function startDaemon(
     await refreshIssuePollStatus();
     await reconcile();
     launchDispatch();
+    logger.debug(
+      {
+        candidates: issuePollStatus.candidateIssues.length,
+        dispatching: dispatchMutex.held,
+        errors: issuePollStatus.errors.length,
+        filtered: issuePollStatus.filteredIssues.length,
+        projects: issuePollStatus.projects.length
+      },
+      "symphonika tick"
+    );
   };
   const scheduleTick = (): void => {
     enqueueScheduledWork(tick);

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -326,12 +326,20 @@ export class RunController {
     }
 
     // Re-assert sym:claimed best-effort in case operator clear-stale ran between attempts.
-    await this.bestEffort(() =>
-      this.githubIssuesApi.addLabelsToIssue!({
-        ...repository,
+    await this.bestEffort(
+      () =>
+        this.githubIssuesApi.addLabelsToIssue!({
+          ...repository,
+          issueNumber: refreshed.number,
+          labels: ["sym:claimed"]
+        }),
+      {
         issueNumber: refreshed.number,
-        labels: ["sym:claimed"]
-      })
+        label: "sym:claimed",
+        operation: "addLabel",
+        project: project.name,
+        runId: payload.runId
+      }
     );
 
     await this.runAttemptLifecycle({
@@ -482,6 +490,17 @@ export class RunController {
         labels: ["sym:claimed"]
       });
       claimed = true;
+      this.logger?.info(
+        {
+          issueNumber: input.issue.number,
+          isContinuation: input.isContinuation,
+          parentRunId: input.parentRunId,
+          project: input.project.name,
+          provider: input.providerName,
+          runId: input.runId
+        },
+        "symphonika claimed issue and starting run"
+      );
       const createInput = {
         id: input.runId,
         issue: input.issue,
@@ -627,6 +646,24 @@ export class RunController {
         terminal.kind === "failed" &&
         terminal.classification === "transient" &&
         this.runStore.runRetryCount(input.runId) < this.lifecyclePolicy.retry.cap;
+
+      this.logger?.info(
+        {
+          attemptNumber: input.attemptNumber,
+          cancelReason,
+          cancelRequested,
+          classification: terminal.classification,
+          isContinuation: input.isContinuation,
+          issueNumber: input.issue.number,
+          kind: terminal.kind,
+          project: input.project.name,
+          runId: input.runId,
+          state: outcomeState,
+          terminalReason: terminal.reason,
+          willRetry
+        },
+        "symphonika run terminated"
+      );
 
       const labelInput: ApplyLabelsInput = {
         issueNumber: input.issue.number,
@@ -841,15 +878,29 @@ export class RunController {
         issueNumber: input.issueNumber,
         labels: ["sym:failed"]
       });
-    } catch {
+    } catch (err) {
+      this.logger?.warn(
+        { err, issueNumber: input.issueNumber },
+        "symphonika failed to add sym:failed label; sym:claimed left in place"
+      );
       return;
     }
-    await this.bestEffort(() =>
-      api.removeLabelsFromIssue({
-        ...input.repository,
+    this.logger?.info(
+      { issueNumber: input.issueNumber },
+      "symphonika marked issue sym:failed"
+    );
+    await this.bestEffort(
+      () =>
+        api.removeLabelsFromIssue({
+          ...input.repository,
+          issueNumber: input.issueNumber,
+          labels: ["sym:claimed"]
+        }),
+      {
         issueNumber: input.issueNumber,
-        labels: ["sym:claimed"]
-      })
+        label: "sym:claimed",
+        operation: "removeLabel"
+      }
     );
   }
 
@@ -857,38 +908,66 @@ export class RunController {
     const api = this.githubIssuesApi as LabelWritingGitHubIssuesApi;
     if (input.outcome.kind === "cancelled") {
       const reason = input.cancelReason;
-      await this.bestEffort(() =>
-        api.removeLabelsFromIssue({
-          ...input.repository,
+      await this.bestEffort(
+        () =>
+          api.removeLabelsFromIssue({
+            ...input.repository,
+            issueNumber: input.issueNumber,
+            labels: ["sym:running"]
+          }),
+        {
           issueNumber: input.issueNumber,
-          labels: ["sym:running"]
-        })
+          label: "sym:running",
+          operation: "removeLabel",
+          phase: "cancelled"
+        }
       );
       if (reason === CANCEL_REASONS.CLOSED_ISSUE) {
-        await this.bestEffort(() =>
-          api.removeLabelsFromIssue({
-            ...input.repository,
+        await this.bestEffort(
+          () =>
+            api.removeLabelsFromIssue({
+              ...input.repository,
+              issueNumber: input.issueNumber,
+              labels: ["sym:claimed"]
+            }),
+          {
             issueNumber: input.issueNumber,
-            labels: ["sym:claimed"]
-          })
+            label: "sym:claimed",
+            operation: "removeLabel",
+            phase: "closed-issue-cleanup"
+          }
         );
-        await this.bestEffort(() =>
-          api.removeLabelsFromIssue({
-            ...input.repository,
+        await this.bestEffort(
+          () =>
+            api.removeLabelsFromIssue({
+              ...input.repository,
+              issueNumber: input.issueNumber,
+              labels: ["sym:failed"]
+            }),
+          {
             issueNumber: input.issueNumber,
-            labels: ["sym:failed"]
-          })
+            label: "sym:failed",
+            operation: "removeLabel",
+            phase: "closed-issue-cleanup"
+          }
         );
       }
       return;
     }
 
-    await this.bestEffort(() =>
-      api.removeLabelsFromIssue({
-        ...input.repository,
+    await this.bestEffort(
+      () =>
+        api.removeLabelsFromIssue({
+          ...input.repository,
+          issueNumber: input.issueNumber,
+          labels: ["sym:running"]
+        }),
+      {
         issueNumber: input.issueNumber,
-        labels: ["sym:running"]
-      })
+        label: "sym:running",
+        operation: "removeLabel",
+        phase: "terminal"
+      }
     );
 
     if (
@@ -978,6 +1057,18 @@ export class RunController {
         repository: input.repository
       });
       const capId = this.createRunId();
+      this.logger?.info(
+        {
+          cap: this.lifecyclePolicy.continuation.cap,
+          capRunId: capId,
+          issueNumber: input.issue.number,
+          kind,
+          parentRunId: input.runId,
+          project: input.project.name,
+          succeededContinuations
+        },
+        "symphonika continuation cap reached; marking issue failed"
+      );
       this.runStore.createCapReachedFailureRun({
         id: capId,
         issue: refreshed,
@@ -991,6 +1082,17 @@ export class RunController {
       });
       return;
     }
+
+    this.logger?.info(
+      {
+        delayMs: this.lifecyclePolicy.continuation.delayMs,
+        issueNumber: refreshed.number,
+        parentRunId: input.runId,
+        project: input.project.name,
+        succeededContinuations
+      },
+      "symphonika scheduling continuation"
+    );
 
     this.schedule({
       delayMs: this.lifecyclePolicy.continuation.delayMs,
@@ -1036,11 +1138,17 @@ export class RunController {
     return normalizeRawIssue(raw, input.project);
   }
 
-  private async bestEffort(fn: () => Promise<void>): Promise<void> {
+  private async bestEffort(
+    fn: () => Promise<void>,
+    context?: Record<string, unknown>
+  ): Promise<void> {
     try {
       await fn();
-    } catch {
-      // best-effort: swallow.
+    } catch (err) {
+      this.logger?.warn(
+        { err, ...context },
+        "symphonika best-effort op failed; continuing"
+      );
     }
   }
 }

--- a/src/lifecycle/stale-claims.ts
+++ b/src/lifecycle/stale-claims.ts
@@ -79,6 +79,10 @@ export async function detectStaleClaims(
         continue;
       }
       issue.labels.push(STALE_LABEL);
+      input.logger.info(
+        { issueNumber: issue.number, project: filtered.project },
+        "symphonika marked issue sym:stale"
+      );
       marks.push({
         issueNumber: issue.number,
         project: filtered.project


### PR DESCRIPTION
## Summary

- `bestEffort` no longer silently swallows label-write errors — it logs a `warn` with the operation context.
- Lifecycle state transitions now emit structured `info` logs: claim/start, run terminated (with classification + terminalReason + willRetry), continuation scheduled, continuation cap reached, sym:failed marked, sym:stale marked.
- Daemon polling logs a `warn` on transition into an errored state (e.g. unset `$GITHUB_TOKEN`) and `info` when errors clear; per-tick debug summary; debug "dispatch skipped" reason when `dispatchOneFresh` returns no candidate.

## Why

Investigating why issue 45 stopped being dispatched showed the daemon emits essentially nothing while it works:

- A `bestEffort(removeLabelsFromIssue(["sym:claimed"]))` after `markIssueFailed` either failed silently or raced with the next reconcile sweep — the issue ended up with both `sym:failed` and `sym:stale`, with no record in stderr.
- The continuation cap-reached synthetic failure (`terminal_reason="continuation cap reached"`) wrote nothing.
- Polling errors (e.g. unresolved `$GITHUB_TOKEN`) were captured in `/api/status` but the daemon's stdout stayed silent, so the daemon looked healthy while doing nothing.

These logs are scoped to *state transitions* — they don't run per-tick at info level except when something changed.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (215 / 215 pass)
- [ ] Restart the daemon with `GITHUB_TOKEN` exported and confirm a single `info` "claimed issue and starting run" line appears for issue 45, followed by lifecycle transitions
- [ ] Restart the daemon without `GITHUB_TOKEN` and confirm the new `warn` "polling has errors" line appears once instead of every tick