### PR TITLE
Complete operator CLI and web UI

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -314,6 +314,7 @@ Recommended layout:
 
 ```text
 .symphonika/
+  daemon.json
   symphonika.db
   logs/
     runs/
@@ -322,9 +323,14 @@ Recommended layout:
         provider.normalized.jsonl
         stderr.log
         prompt.md
+        prompt-metadata.json
+        issue-snapshot.json
 ```
 
 Agents may modify workspaces, so orchestrator evidence must stay outside the Git worktree.
+When the daemon is running, `daemon.json` records the local API endpoint for that state root.
+Operator CLI commands that use the descriptor must preflight the daemon status and reject endpoints
+whose reported state root differs from the configured state root.
 
 ### 7.4 Prompt Evidence
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 import { InvalidArgumentError, Command } from "commander";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { DaemonHandle, StartDaemonOptions } from "./daemon.js";
 import { startDaemon } from "./daemon.js";
+import { daemonEndpointPath, readDaemonEndpoint } from "./daemon-endpoint.js";
 import type {
   ClearStaleOptions,
   ClearStaleReport,
@@ -14,6 +16,7 @@ import type {
   InitProjectReport
 } from "./doctor.js";
 import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
+import type { ProjectIssuePollReport } from "./issue-polling.js";
 import type {
   ListRunsFilter,
   OpenRunStoreOptions,
@@ -31,6 +34,7 @@ import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
 
 export type CliDependencies = {
+  fetch?: FetchFn;
   openRunStore?: (options: OpenRunStoreOptions) => RunStore;
   registerSignalHandlers?: boolean;
   runClearStale?: (options: ClearStaleOptions) => Promise<ClearStaleReport>;
@@ -40,6 +44,20 @@ export type CliDependencies = {
   startDaemon?: (options: StartDaemonOptions) => Promise<DaemonHandle>;
 };
 
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+type DaemonStatusResponse = {
+  candidateIssues?: unknown[];
+  filteredIssues?: unknown[];
+  issuePolling?: {
+    errors?: string[];
+    projects?: ProjectIssuePollReport[];
+  };
+  staleIssues?: unknown[];
+  state?: string;
+  stateRoot?: string;
+};
+
 export function buildCli(dependencies: CliDependencies = {}): Command {
   const doctor = dependencies.runDoctor ?? runDoctor;
   const initProject = dependencies.runInitProject ?? runInitProject;
@@ -47,6 +65,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
   const smoke = dependencies.runSmoke ?? runSmoke;
   const start = dependencies.startDaemon ?? startDaemon;
   const openRunStore = dependencies.openRunStore ?? openRunStoreReal;
+  const fetcher = dependencies.fetch ?? fetch;
   const registerSignalHandlers = dependencies.registerSignalHandlers ?? true;
   const program = new Command();
 
@@ -233,13 +252,15 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         writeOut(program, `issue:        #${detail.issueNumber} ${detail.issueTitle}\n`);
         writeOut(program, `state:        ${detail.state}\n`);
         writeOut(program, `provider:     ${detail.provider}\n`);
+        writeOut(program, `started:      ${detail.createdAt}\n`);
+        writeOut(program, `updated:      ${detail.updatedAt}\n`);
         writeOut(program, `branch:       ${formatPath(detail.branchName)}\n`);
         writeOut(program, `workspace:    ${formatPath(detail.workspacePath)}\n`);
-        writeOut(program, `prompt:       ${formatPath(detail.promptPath)}\n`);
-        writeOut(program, `raw log:      ${formatPath(detail.rawLogPath)}\n`);
-        writeOut(program, `normalized:   ${formatPath(detail.normalizedLogPath)}\n`);
-        writeOut(program, `metadata:     ${formatPath(detail.metadataPath)}\n`);
-        writeOut(program, `issue snap:   ${formatPath(detail.issueSnapshotPath)}\n`);
+        writeOut(program, `prompt.md:                 ${formatEvidencePath(detail.promptPath)}\n`);
+        writeOut(program, `provider.raw.jsonl:        ${formatEvidencePath(detail.rawLogPath)}\n`);
+        writeOut(program, `provider.normalized.jsonl: ${formatEvidencePath(detail.normalizedLogPath)}\n`);
+        writeOut(program, `issue-snapshot.json:       ${formatEvidencePath(detail.issueSnapshotPath)}\n`);
+        writeOut(program, `prompt-metadata.json:      ${formatEvidencePath(detail.metadataPath)}\n`);
         if (detail.terminalReason !== null) {
           writeOut(program, `terminal:     ${detail.terminalReason}\n`);
         }
@@ -248,18 +269,68 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
 
   program
     .command("status")
-    .description("print run store summary grouped by lifecycle state")
+    .description("print project validation, issue polling, and run summaries")
     .option("--config <path>", "service config path", "symphonika.yml")
-    .action(async (options: { config: string }) => {
+    .option("--daemon-url <url>", "local daemon base URL")
+    .action(async (options: { config: string; daemonUrl?: string }) => {
       const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
       const store = openRunStore({ stateRoot });
       try {
+        const report = await doctor({ configPath: options.config });
+        const daemonUrl = resolveDaemonUrl(stateRoot, options.daemonUrl);
+        const daemonStatus =
+          daemonUrl === undefined
+            ? ({ error: "not configured", kind: "unavailable" } as const)
+            : await fetchDaemonStatus(fetcher, daemonUrl, stateRoot);
         const all = store.listRuns();
         const byState = new Map<string, number>();
         for (const run of all) {
           byState.set(run.state, (byState.get(run.state) ?? 0) + 1);
         }
         writeOut(program, `state root: ${stateRoot}\n`);
+        if (daemonUrl !== undefined) {
+          writeOut(
+            program,
+            `daemon: ${formatDaemonAvailability(daemonStatus, daemonUrl)}\n`
+          );
+        }
+        writeOut(program, "\nProjects:\n");
+        if (report.projects.length === 0) {
+          writeOut(program, "  (no projects validated)\n");
+        }
+        for (const project of report.projects) {
+          writeOut(
+            program,
+            `  ${project.name}: ${project.validForDispatch ? "valid" : "invalid"}\n`
+          );
+          writeOut(program, `    workflow: ${project.workflowPath}\n`);
+          writeOut(
+            program,
+            `    missing operational labels: ${formatList(project.missingOperationalLabels)}\n`
+          );
+        }
+        if (report.errors.length > 0) {
+          writeOut(program, "validation errors:\n");
+          for (const error of report.errors) {
+            writeOut(program, `  - ${error}\n`);
+          }
+        }
+        const issueCounts = issueCountsFromStatus(
+          daemonStatus,
+          report.projects,
+          byState
+        );
+        writeOut(program, "\nIssue counts:\n");
+        writeOut(program, `  candidate: ${issueCounts.candidate}\n`);
+        writeOut(program, `  filtered:  ${issueCounts.filtered}\n`);
+        writeOut(program, `  running:   ${issueCounts.running}\n`);
+        writeOut(program, `  failed:    ${issueCounts.failed}\n`);
+        writeOut(program, `  stale:     ${issueCounts.stale}\n`);
+        writeOut(
+          program,
+          `last poll outcome: ${formatLastPollOutcome(daemonStatus)}\n`
+        );
+        writeOut(program, "\nRun state counts:\n");
         writeOut(program, `total runs: ${all.length}\n`);
         for (const [state, count] of [...byState.entries()].sort()) {
           writeOut(program, `${state}: ${count}\n`);
@@ -274,7 +345,6 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
             );
           }
         }
-        const report = await doctor({ configPath: options.config });
         printStaleSection(program, report.projects);
       } finally {
         store.close();
@@ -313,10 +383,11 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
             writeOut(program, "(no runs)\n");
             return;
           }
+          writeOut(program, "id  project  issue  state  started  updated\n");
           for (const run of runs) {
             writeOut(
               program,
-              `${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}\n`
+              `${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.createdAt}  ${run.updatedAt}\n`
             );
           }
         } finally {
@@ -346,13 +417,15 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         writeOut(program, `issue:        #${detail.issueNumber} ${detail.issueTitle}\n`);
         writeOut(program, `state:        ${detail.state}\n`);
         writeOut(program, `provider:     ${detail.provider}\n`);
+        writeOut(program, `started:      ${detail.createdAt}\n`);
+        writeOut(program, `updated:      ${detail.updatedAt}\n`);
         writeOut(program, `branch:       ${formatPath(detail.branchName)}\n`);
         writeOut(program, `workspace:    ${formatPath(detail.workspacePath)}\n`);
-        writeOut(program, `prompt:       ${formatPath(detail.promptPath)}\n`);
-        writeOut(program, `raw log:      ${formatPath(detail.rawLogPath)}\n`);
-        writeOut(program, `normalized:   ${formatPath(detail.normalizedLogPath)}\n`);
-        writeOut(program, `metadata:     ${formatPath(detail.metadataPath)}\n`);
-        writeOut(program, `issue snap:   ${formatPath(detail.issueSnapshotPath)}\n`);
+        writeOut(program, `prompt.md:                 ${formatEvidencePath(detail.promptPath)}\n`);
+        writeOut(program, `provider.raw.jsonl:        ${formatEvidencePath(detail.rawLogPath)}\n`);
+        writeOut(program, `provider.normalized.jsonl: ${formatEvidencePath(detail.normalizedLogPath)}\n`);
+        writeOut(program, `issue-snapshot.json:       ${formatEvidencePath(detail.issueSnapshotPath)}\n`);
+        writeOut(program, `prompt-metadata.json:      ${formatEvidencePath(detail.metadataPath)}\n`);
         writeOut(program, `retries:      ${detail.retryCount}${detail.isContinuation ? " (continuation)" : ""}\n`);
         if (detail.terminalReason !== null) {
           writeOut(program, `terminal:     ${detail.terminalReason}\n`);
@@ -393,18 +466,16 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
           }
         }
         const events = store.listProviderEvents(id, { limit: options.events });
-        if (events.length > 0) {
-          writeOut(program, `\nrecent events (last ${events.length}):\n`);
-          for (const event of events) {
-            const message =
-              typeof event.normalized.message === "string"
-                ? event.normalized.message
-                : JSON.stringify(event.normalized);
-            writeOut(
-              program,
-              `  ${event.sequence}. ${event.type}  ${message}\n`
-            );
-          }
+        writeOut(program, `\nnormalized events (last ${events.length}):\n`);
+        if (events.length === 0) {
+          writeOut(program, "  (no events recorded)\n");
+        }
+        for (const event of events) {
+          const message =
+            typeof event.normalized.message === "string"
+              ? event.normalized.message
+              : JSON.stringify(event.normalized);
+          writeOut(program, `  ${event.sequence}. ${event.type}  ${message}\n`);
         }
       } finally {
         store.close();
@@ -416,35 +487,40 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .description("request cancellation of an active run via the run store")
     .argument("<id>", "run id")
     .option("--config <path>", "service config path", "symphonika.yml")
-    .action((id: string, options: { config: string }) => {
+    .option("--daemon-url <url>", "local daemon base URL")
+    .action(async (id: string, options: { config: string; daemonUrl?: string }) => {
       const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
-      const store = openRunStore({ stateRoot });
-      try {
-        const detail = store.getRun(id);
-        if (detail === undefined) {
-          writeErr(program, `run ${id} not found\n`);
-          program.error(`run ${id} not found`, { exitCode: 1 });
-          return;
-        }
-        if (
-          detail.state === "cancelled" ||
-          detail.state === "failed" ||
-          detail.state === "stale" ||
-          detail.state === "succeeded"
-        ) {
-          writeErr(program, `run ${id} already ${detail.state}\n`);
-          program.error(`run ${id} already ${detail.state}`, { exitCode: 1 });
-          return;
-        }
-        store.markCancelRequested(id, "operator");
-        writeOut(program, `cancel requested for ${id}\n`);
-        writeOut(
-          program,
-          "the running daemon will pick up the request on its next iteration; if no daemon is running, the request will be honored on next startup.\n"
-        );
-      } finally {
-        store.close();
+      const daemonUrl = resolveDaemonUrl(stateRoot, options.daemonUrl);
+      if (daemonUrl === undefined) {
+        const descriptorPath = daemonEndpointPath(stateRoot);
+        writeErr(program, `cancel failed: daemon endpoint not found at ${descriptorPath}\n`);
+        program.error("cancel failed: daemon endpoint not found", { exitCode: 1 });
+        return;
       }
+
+      const daemonStatus = await fetchDaemonStatus(fetcher, daemonUrl, stateRoot);
+      if (daemonStatus.kind === "unavailable") {
+        writeErr(program, `cancel failed: ${daemonStatus.error}\n`);
+        program.error(`cancel failed: ${daemonStatus.error}`, { exitCode: 1 });
+        return;
+      }
+      const outcome = await postCancel(fetcher, daemonUrl, id);
+      if (outcome.kind === "cancelled") {
+        writeOut(program, `cancelled ${id}\n`);
+        return;
+      }
+      if (outcome.kind === "not-found") {
+        writeErr(program, `run ${id} not found\n`);
+        program.error(`run ${id} not found`, { exitCode: 1 });
+        return;
+      }
+      if (outcome.kind === "already-terminal") {
+        writeErr(program, `run ${id} already ${outcome.state}\n`);
+        program.error(`run ${id} already ${outcome.state}`, { exitCode: 1 });
+        return;
+      }
+      writeErr(program, `cancel failed: ${outcome.error}\n`);
+      program.error(`cancel failed: ${outcome.error}`, { exitCode: 1 });
     });
 
   return program;
@@ -452,6 +528,274 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
 
 export async function runCli(argv = process.argv): Promise<void> {
   await buildCli().parseAsync(argv);
+}
+
+async function fetchDaemonStatus(
+  fetcher: FetchFn,
+  daemonUrl: string,
+  expectedStateRoot: string
+): Promise<
+  | { kind: "available"; status: DaemonStatusResponse }
+  | { kind: "unavailable"; error: string }
+> {
+  try {
+    const response = await fetcher(`${daemonUrl}/api/status`);
+    if (!response.ok) {
+      return { error: `HTTP ${response.status}`, kind: "unavailable" };
+    }
+    const status = (await response.json()) as DaemonStatusResponse;
+    if (typeof status.stateRoot !== "string") {
+      return {
+        error: "daemon status did not report a state root",
+        kind: "unavailable"
+      };
+    }
+    if (path.resolve(status.stateRoot) !== path.resolve(expectedStateRoot)) {
+      return {
+        error: `state root mismatch (${status.stateRoot})`,
+        kind: "unavailable"
+      };
+    }
+    return { kind: "available", status };
+  } catch (error) {
+    return { error: errorMessage(error), kind: "unavailable" };
+  }
+}
+
+function resolveDaemonUrl(
+  stateRoot: string,
+  explicitDaemonUrl: string | undefined
+): string | undefined {
+  if (explicitDaemonUrl !== undefined) {
+    return trimTrailingSlash(explicitDaemonUrl);
+  }
+
+  const endpoint = readDaemonEndpoint(stateRoot);
+  return endpoint === undefined ? undefined : trimTrailingSlash(endpoint.url);
+}
+
+async function postCancel(
+  fetcher: FetchFn,
+  daemonUrl: string,
+  runId: string
+): Promise<
+  | { kind: "cancelled" }
+  | { kind: "not-found" }
+  | { kind: "already-terminal"; state: RunState }
+  | { kind: "error"; error: string }
+> {
+  let response: Response;
+  try {
+    response = await fetcher(
+      `${daemonUrl}/api/runs/${encodeURIComponent(runId)}/cancel`,
+      { method: "POST" }
+    );
+  } catch (error) {
+    return { error: errorMessage(error), kind: "error" };
+  }
+
+  if (response.status === 404) {
+    return { kind: "not-found" };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+
+  if (response.status === 409) {
+    const state = readRunState(body);
+    return state === undefined
+      ? { error: "daemon returned terminal conflict without a run state", kind: "error" }
+      : { kind: "already-terminal", state };
+  }
+  if (!response.ok) {
+    return { error: `daemon returned HTTP ${response.status}`, kind: "error" };
+  }
+  if (isObject(body) && body.kind === "cancelled") {
+    return { kind: "cancelled" };
+  }
+  return {
+    error: "daemon returned an unexpected cancellation response",
+    kind: "error"
+  };
+}
+
+function readRunState(value: unknown): RunState | undefined {
+  if (!isObject(value) || typeof value.state !== "string") {
+    return undefined;
+  }
+  return isRunState(value.state) ? value.state : undefined;
+}
+
+function isRunState(value: string): value is RunState {
+  return (
+    value === "queued" ||
+    value === "preparing_workspace" ||
+    value === "running" ||
+    value === "input_required" ||
+    value === "failed" ||
+    value === "succeeded" ||
+    value === "cancelled" ||
+    value === "stale"
+  );
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function issueCountsFromStatus(
+  daemonStatus:
+    | { kind: "available"; status: DaemonStatusResponse }
+    | { kind: "unavailable"; error: string },
+  projects: DoctorProjectReport[],
+  byState: Map<string, number>
+): {
+  candidate: number;
+  failed: number;
+  filtered: number;
+  running: number;
+  stale: number;
+} {
+  if (daemonStatus.kind === "available") {
+    const filteredIssues = daemonStatus.status.filteredIssues;
+    return {
+      candidate: arrayLength(daemonStatus.status.candidateIssues),
+      failed: Math.max(
+        countIssuesWithLabel(filteredIssues, "sym:failed"),
+        (byState.get("failed") ?? 0) + (byState.get("input_required") ?? 0)
+      ),
+      filtered: arrayLength(filteredIssues),
+      running: Math.max(
+        countIssuesWithLabel(filteredIssues, "sym:running"),
+        byState.get("running") ?? 0
+      ),
+      stale: Math.max(
+        projects.reduce((count, project) => count + project.staleIssues.length, 0),
+        countIssuesWithLabel(filteredIssues, "sym:stale"),
+        arrayLength(daemonStatus.status.staleIssues),
+        byState.get("stale") ?? 0
+      )
+    };
+  }
+
+  return {
+    candidate: 0,
+    failed: (byState.get("failed") ?? 0) + (byState.get("input_required") ?? 0),
+    filtered: 0,
+    running: byState.get("running") ?? 0,
+    stale: Math.max(
+      projects.reduce((count, project) => count + project.staleIssues.length, 0),
+      byState.get("stale") ?? 0
+    )
+  };
+}
+
+function countIssuesWithLabel(
+  entries: unknown[] | undefined,
+  label: string
+): number {
+  if (!Array.isArray(entries)) {
+    return 0;
+  }
+  const seen = new Set<string>();
+  let anonymous = 0;
+  for (const entry of entries) {
+    const labels = labelsFromPollEntry(entry);
+    if (!labels.has(label)) {
+      continue;
+    }
+    const key = pollEntryKey(entry);
+    if (key === undefined) {
+      anonymous += 1;
+      continue;
+    }
+    seen.add(key);
+  }
+  return seen.size + anonymous;
+}
+
+function labelsFromPollEntry(entry: unknown): Set<string> {
+  if (!isObject(entry) || !isObject(entry.issue)) {
+    return new Set();
+  }
+  const labels = entry.issue.labels;
+  if (!Array.isArray(labels)) {
+    return new Set();
+  }
+  return new Set(labels.filter((label): label is string => typeof label === "string"));
+}
+
+function pollEntryKey(entry: unknown): string | undefined {
+  if (!isObject(entry) || !isObject(entry.issue)) {
+    return undefined;
+  }
+  const project = typeof entry.project === "string" ? entry.project : "unknown";
+  const number = entry.issue.number;
+  if (typeof number === "number" || typeof number === "string") {
+    return `${project}:number:${number}`;
+  }
+  return undefined;
+}
+
+function arrayLength(value: unknown[] | undefined): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function formatDaemonAvailability(
+  daemonStatus:
+    | { kind: "available"; status: DaemonStatusResponse }
+    | { kind: "unavailable"; error: string },
+  daemonUrl: string
+): string {
+  if (daemonStatus.kind === "available") {
+    return `${daemonStatus.status.state ?? "unknown"} at ${daemonUrl}`;
+  }
+  return `unavailable at ${daemonUrl} (${daemonStatus.error})`;
+}
+
+function formatLastPollOutcome(
+  daemonStatus:
+    | { kind: "available"; status: DaemonStatusResponse }
+    | { kind: "unavailable"; error: string }
+): string {
+  if (daemonStatus.kind === "unavailable") {
+    return `unknown (${daemonStatus.error})`;
+  }
+  const issuePolling = daemonStatus.status.issuePolling;
+  if (issuePolling === undefined) {
+    return "unknown";
+  }
+  const errors = issuePolling.errors ?? [];
+  if (errors.length > 0) {
+    return `failed: ${errors.join("; ")}`;
+  }
+  const projects = issuePolling.projects ?? [];
+  if (projects.length === 0) {
+    return "not yet polled";
+  }
+  return projects
+    .map((project) =>
+      project.ok
+        ? `${project.name} ok (${project.fetchedIssues} fetched)`
+        : `${project.name} failed (${project.error ?? "unknown error"})`
+    )
+    .join("; ");
+}
+
+function formatList(values: string[]): string {
+  return values.length === 0 ? "(none)" : values.join(", ");
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function parsePositiveInt(value: string): number {
@@ -464,6 +808,10 @@ function parsePositiveInt(value: string): number {
 
 function formatPath(value: string): string {
   return value.length === 0 ? "<not yet recorded>" : value;
+}
+
+function formatEvidencePath(value: string): string {
+  return formatPath(value);
 }
 
 function formatRecentRunSuffix(

--- a/src/daemon-endpoint.ts
+++ b/src/daemon-endpoint.ts
@@ -1,0 +1,58 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type DaemonEndpoint = {
+  pid?: number;
+  startedAt?: string;
+  stateRoot?: string;
+  url: string;
+};
+
+export function daemonEndpointPath(stateRoot: string): string {
+  return path.join(stateRoot, "daemon.json");
+}
+
+export function readDaemonEndpoint(stateRoot: string): DaemonEndpoint | undefined {
+  const descriptorPath = daemonEndpointPath(stateRoot);
+  if (!existsSync(descriptorPath)) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(readFileSync(descriptorPath, "utf8")) as unknown;
+  if (!isRecord(parsed) || typeof parsed.url !== "string" || parsed.url.length === 0) {
+    throw new Error(`Invalid daemon endpoint descriptor: ${descriptorPath}`);
+  }
+
+  const endpoint: DaemonEndpoint = { url: parsed.url };
+  if (typeof parsed.pid === "number") {
+    endpoint.pid = parsed.pid;
+  }
+  if (typeof parsed.startedAt === "string") {
+    endpoint.startedAt = parsed.startedAt;
+  }
+  if (typeof parsed.stateRoot === "string") {
+    endpoint.stateRoot = parsed.stateRoot;
+  }
+  return endpoint;
+}
+
+export async function writeDaemonEndpoint(
+  stateRoot: string,
+  endpoint: DaemonEndpoint
+): Promise<void> {
+  await mkdir(stateRoot, { recursive: true });
+  await writeFile(
+    daemonEndpointPath(stateRoot),
+    `${JSON.stringify(endpoint, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+export async function removeDaemonEndpoint(stateRoot: string): Promise<void> {
+  await rm(daemonEndpointPath(stateRoot), { force: true });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/daemon-endpoint.ts
+++ b/src/daemon-endpoint.ts
@@ -19,9 +19,14 @@ export function readDaemonEndpoint(stateRoot: string): DaemonEndpoint | undefine
     return undefined;
   }
 
-  const parsed = JSON.parse(readFileSync(descriptorPath, "utf8")) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(descriptorPath, "utf8")) as unknown;
+  } catch {
+    return undefined;
+  }
   if (!isRecord(parsed) || typeof parsed.url !== "string" || parsed.url.length === 0) {
-    throw new Error(`Invalid daemon endpoint descriptor: ${descriptorPath}`);
+    return undefined;
   }
 
   const endpoint: DaemonEndpoint = { url: parsed.url };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -376,12 +376,17 @@ export async function startDaemon(
   await waitForListening(server);
   const port = resolveListeningPort(server, requestedPort);
   const url = `http://${host}:${port}`;
-  await writeDaemonEndpoint(state.stateRoot, {
-    pid: process.pid,
-    startedAt: new Date().toISOString(),
-    stateRoot: state.stateRoot,
-    url
-  });
+  try {
+    await writeDaemonEndpoint(state.stateRoot, {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      stateRoot: state.stateRoot,
+      url
+    });
+  } catch (error) {
+    await rollbackDaemonStartup(server, runStore, logger);
+    throw error;
+  }
   if (state.configExists) {
     await reconcile();
     if (issuePollStatus.candidateIssues.length > 0) {
@@ -471,6 +476,30 @@ function stopServer(server: ServerType, logger: Logger): Promise<void> {
       resolve();
     });
   });
+}
+
+async function rollbackDaemonStartup(
+  server: ServerType,
+  runStore: ReturnType<typeof openRunStore>,
+  logger: Logger
+): Promise<void> {
+  try {
+    await stopServer(server, logger);
+  } catch (error) {
+    logger.warn(
+      { error: errorMessage(error) },
+      "symphonika daemon startup rollback failed to stop server"
+    );
+  }
+
+  try {
+    runStore.close();
+  } catch (error) {
+    logger.warn(
+      { error: errorMessage(error) },
+      "symphonika daemon startup rollback failed to close run store"
+    );
+  }
 }
 
 function errorMessage(error: unknown): string {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -6,6 +6,10 @@ import pino from "pino";
 import { parse } from "yaml";
 
 import { createHttpApp } from "./http/app.js";
+import {
+  removeDaemonEndpoint,
+  writeDaemonEndpoint
+} from "./daemon-endpoint.js";
 import type {
   GitHubIssuesApi,
   PollConfiguredGitHubIssuesOptions,
@@ -316,6 +320,7 @@ export async function startDaemon(
   const TERMINAL_STATES = new Set<RunState>([
     "cancelled",
     "failed",
+    "input_required",
     "stale",
     "succeeded"
   ]);
@@ -350,14 +355,18 @@ export async function startDaemon(
       })),
     getRuns: () => runStore.listRuns(),
     getScheduled: () => activeRuns.peekDelayed(),
+    getStatusSnapshot: () =>
+      buildStatusSnapshot({
+        configPath: state.configPath,
+        issuePollStatus,
+        runStore,
+        stateRoot: state.stateRoot
+      }),
     issuePollStatus,
     runStore,
     stateRoot: state.stateRoot,
     version: VERSION
   });
-  // Reference buildStatusSnapshot so eslint/tsc don't strip the import; it's
-  // exported for CLI use and may be wired into HTTP pages later.
-  void buildStatusSnapshot;
 
   const server = serve({
     fetch: app.fetch,
@@ -367,6 +376,12 @@ export async function startDaemon(
   await waitForListening(server);
   const port = resolveListeningPort(server, requestedPort);
   const url = `http://${host}:${port}`;
+  await writeDaemonEndpoint(state.stateRoot, {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    stateRoot: state.stateRoot,
+    url
+  });
   if (state.configExists) {
     await reconcile();
     if (issuePollStatus.candidateIssues.length > 0) {
@@ -401,6 +416,7 @@ export async function startDaemon(
       await scheduledWork;
       await Promise.allSettled(Array.from(inflightDispatches));
       await stopServer(server, logger);
+      await removeDaemonEndpoint(state.stateRoot);
       runStore.close();
     }
   };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -420,9 +420,12 @@ export async function startDaemon(
       activeRuns.cancelAll();
       await scheduledWork;
       await Promise.allSettled(Array.from(inflightDispatches));
-      await stopServer(server, logger);
-      await removeDaemonEndpoint(state.stateRoot);
-      runStore.close();
+      try {
+        await stopServer(server, logger);
+        await removeDaemonEndpoint(state.stateRoot);
+      } finally {
+        runStore.close();
+      }
     }
   };
 }

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -3,11 +3,12 @@ import { access } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
 
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 
 import type { IssuePollStatus } from "../issue-polling.js";
 import { emptyIssuePollStatus } from "../issue-polling.js";
 import { isPathInside } from "../path-safety.js";
+import type { StatusSnapshot } from "../status.js";
 import type {
   ListRunsFilter,
   RunState,
@@ -47,6 +48,7 @@ export type HttpAppOptions = {
     kind: "retry" | "continuation";
     runId: string;
   }>;
+  getStatusSnapshot?: () => StatusSnapshot;
   issuePollStatus?: IssuePollStatus;
   now?: () => number;
   runStore?: RunStore;
@@ -66,6 +68,14 @@ const KNOWN_RUN_STATES: ReadonlySet<RunState> = new Set([
   "stale"
 ]);
 
+const TERMINAL_RUN_STATES: ReadonlySet<RunState> = new Set([
+  "cancelled",
+  "failed",
+  "input_required",
+  "stale",
+  "succeeded"
+]);
+
 type FileColumn =
   | "issueSnapshotPath"
   | "metadataPath"
@@ -73,9 +83,11 @@ type FileColumn =
   | "promptPath"
   | "rawLogPath";
 
+type RunFileDescriptor = { column: FileColumn; contentType: string };
+
 const FILE_DESCRIPTORS: Record<
   string,
-  { column: FileColumn; contentType: string }
+  RunFileDescriptor
 > = {
   "issue-snapshot": {
     column: "issueSnapshotPath",
@@ -99,6 +111,29 @@ const FILE_DESCRIPTORS: Record<
   }
 };
 
+const LOG_FILE_DESCRIPTORS: Record<string, RunFileDescriptor> = {
+  "issue-snapshot.json": {
+    column: "issueSnapshotPath",
+    contentType: "application/json; charset=utf-8"
+  },
+  "prompt-metadata.json": {
+    column: "metadataPath",
+    contentType: "application/json; charset=utf-8"
+  },
+  "prompt.md": {
+    column: "promptPath",
+    contentType: "text/markdown; charset=utf-8"
+  },
+  "provider.normalized.jsonl": {
+    column: "normalizedLogPath",
+    contentType: "application/x-ndjson"
+  },
+  "provider.raw.jsonl": {
+    column: "rawLogPath",
+    contentType: "application/x-ndjson"
+  }
+};
+
 export function createHttpApp(options: HttpAppOptions): Hono {
   const app = new Hono();
   const startedAtMs = options.startedAtMs ?? Date.now();
@@ -111,7 +146,11 @@ export function createHttpApp(options: HttpAppOptions): Hono {
   const getActiveRuns = options.getActiveRuns ?? (() => []);
   const getScheduled = options.getScheduled ?? (() => []);
   const runStore = options.runStore;
-  const cancelRun = options.cancelRun;
+  const cancelRun =
+    options.cancelRun ??
+    (runStore === undefined
+      ? undefined
+      : (runId: string) => cancelRunInStore(runStore, runId));
 
   app.get("/health", (context) =>
     context.json({
@@ -197,38 +236,22 @@ export function createHttpApp(options: HttpAppOptions): Hono {
 
     app.get("/api/runs/:id/files/:fileKind", async (context) => {
       const id = context.req.param("id");
-      const detail = runStore.getRun(id);
-      if (detail === undefined) {
-        return context.json({ error: "run not found" }, 404);
-      }
       const fileKind = context.req.param("fileKind");
       const descriptor = FILE_DESCRIPTORS[fileKind];
       if (descriptor === undefined) {
         return context.json({ error: "unknown file kind" }, 404);
       }
-      const filePath = detail[descriptor.column];
-      if (typeof filePath !== "string" || filePath.length === 0) {
-        return context.json({ error: "file not yet recorded" }, 404);
+      return streamRunFile(context, runStore, options.stateRoot, id, descriptor);
+    });
+
+    app.get("/logs/runs/:id/:fileName", async (context) => {
+      const id = context.req.param("id");
+      const fileName = context.req.param("fileName");
+      const descriptor = LOG_FILE_DESCRIPTORS[fileName];
+      if (descriptor === undefined) {
+        return context.json({ error: "unknown file" }, 404);
       }
-      const evidenceRoot = path.join(
-        path.resolve(options.stateRoot),
-        "logs",
-        "runs",
-        id
-      );
-      if (!isPathInside(filePath, evidenceRoot)) {
-        return context.json({ error: "file not available" }, 404);
-      }
-      try {
-        await access(filePath);
-      } catch {
-        return context.json({ error: "file not found" }, 404);
-      }
-      const stream: ReadStream = createReadStream(filePath);
-      return new Response(Readable.toWeb(stream) as ReadableStream, {
-        headers: { "content-type": descriptor.contentType },
-        status: 200
-      });
+      return streamRunFile(context, runStore, options.stateRoot, id, descriptor);
     });
 
     app.post("/api/runs/:id/cancel", async (context) => {
@@ -265,13 +288,64 @@ export function createHttpApp(options: HttpAppOptions): Hono {
 
     registerPages({
       app,
+      ...(options.getStatusSnapshot === undefined
+        ? {}
+        : { getStatusSnapshot: options.getStatusSnapshot }),
       issuePollStatus,
-      ...(options.runStore !== undefined ? { runStore: options.runStore } : {}),
+      runStore,
       version: options.version
-    } as Parameters<typeof registerPages>[0]);
+    });
   }
 
   return app;
+}
+
+async function streamRunFile(
+  context: Context,
+  runStore: RunStore,
+  stateRoot: string,
+  id: string,
+  descriptor: RunFileDescriptor
+): Promise<Response> {
+  const detail = runStore.getRun(id);
+  if (detail === undefined) {
+    return context.json({ error: "run not found" }, 404);
+  }
+  const filePath = detail[descriptor.column];
+  if (typeof filePath !== "string" || filePath.length === 0) {
+    return context.json({ error: "file not yet recorded" }, 404);
+  }
+  const evidenceRoot = path.join(path.resolve(stateRoot), "logs", "runs", id);
+  if (!isPathInside(filePath, evidenceRoot)) {
+    return context.json({ error: "file not available" }, 404);
+  }
+  try {
+    await access(filePath);
+  } catch {
+    return context.json({ error: "file not found" }, 404);
+  }
+  const stream: ReadStream = createReadStream(filePath);
+  return new Response(Readable.toWeb(stream) as ReadableStream, {
+    headers: { "content-type": descriptor.contentType },
+    status: 200
+  });
+}
+
+function cancelRunInStore(
+  runStore: RunStore,
+  runId: string
+): ReturnType<CancelRunFn> {
+  const detail = runStore.getRun(runId);
+  if (detail === undefined) {
+    return { kind: "not-found" };
+  }
+  if (TERMINAL_RUN_STATES.has(detail.state)) {
+    return { kind: "already-terminal", state: detail.state };
+  }
+  runStore.markCancelRequested(runId, "operator");
+  runStore.recordTerminalReason(runId, "operator");
+  runStore.updateRunState(runId, "cancelled");
+  return { kind: "cancelled" };
 }
 
 function parsePositiveInt(value: string | undefined): number | undefined {

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -27,6 +27,7 @@ export type RegisterPagesOptions = {
 const TERMINAL_STATES: ReadonlySet<RunState> = new Set([
   "cancelled",
   "failed",
+  "input_required",
   "stale",
   "succeeded"
 ]);
@@ -50,7 +51,7 @@ export function registerPages(options: RegisterPagesOptions): void {
       "Symphonika",
       [
         renderHeader(options.version, snapshot),
-        renderProjectsCard(snapshot),
+        renderProjectsCard(snapshot, options.issuePollStatus),
         renderStaleIssuesCard(options.issuePollStatus?.filteredIssues ?? []),
         renderRunsTable("Recent runs", recentRuns)
       ].join("")
@@ -154,23 +155,42 @@ function renderHeader(version: string, snapshot: StatusSnapshot | undefined): st
 </section>`;
 }
 
-function renderProjectsCard(snapshot: StatusSnapshot | undefined): string {
-  if (snapshot === undefined || snapshot.projects.length === 0) {
+function renderProjectsCard(
+  snapshot: StatusSnapshot | undefined,
+  issuePollStatus: IssuePollStatus | undefined
+): string {
+  if (snapshot !== undefined && snapshot.projects.length > 0) {
+    const rows = snapshot.projects
+      .map((project) => {
+        const missing =
+          project.missingOperationalLabels.length === 0
+            ? "&mdash;"
+            : escapeHtml(project.missingOperationalLabels.join(", "));
+        const valid = project.validForDispatch ? "valid" : "invalid";
+        return `<tr><td>${escapeHtml(project.name)}</td><td>${escapeHtml(valid)}</td><td><code>${escapeHtml(project.workflowPath)}</code></td><td>${missing}</td></tr>`;
+      })
+      .join("");
+    return `<section><h2>Projects</h2>
+<table><thead><tr><th>Name</th><th>Validation</th><th>Workflow</th><th>Missing operational labels</th></tr></thead>
+<tbody>${rows}</tbody></table></section>`;
+  }
+
+  const pollProjects = issuePollStatus?.projects ?? [];
+  if (pollProjects.length === 0) {
     return "";
   }
 
-  const rows = snapshot.projects
+  const rows = pollProjects
     .map((project) => {
-      const missing =
-        project.missingOperationalLabels.length === 0
-          ? "&mdash;"
-          : escapeHtml(project.missingOperationalLabels.join(", "));
-      const valid = project.validForDispatch ? "valid" : "invalid";
-      return `<tr><td>${escapeHtml(project.name)}</td><td>${escapeHtml(valid)}</td><td><code>${escapeHtml(project.workflowPath)}</code></td><td>${missing}</td></tr>`;
+      const status = project.ok ? "poll ok" : "poll failed";
+      const detail = project.ok
+        ? `${project.fetchedIssues} fetched`
+        : project.error ?? "unknown error";
+      return `<tr><td>${escapeHtml(project.name)}</td><td>${escapeHtml(status)}</td><td>${escapeHtml(detail)}</td></tr>`;
     })
     .join("");
   return `<section><h2>Projects</h2>
-<table><thead><tr><th>Name</th><th>Validation</th><th>Workflow</th><th>Missing operational labels</th></tr></thead>
+<table><thead><tr><th>Name</th><th>Issue polling</th><th>Last poll</th></tr></thead>
 <tbody>${rows}</tbody></table></section>`;
 }
 
@@ -203,11 +223,11 @@ function renderRunsTable(title: string, runs: RunStatus[]): string {
   const rows = runs
     .map(
       (run) =>
-        `<tr><td><a href="/runs/${encodeURIComponent(run.id)}"><code>${escapeHtml(run.id)}</code></a></td><td>${escapeHtml(run.project)}</td><td>#${run.issueNumber} ${escapeHtml(run.issueTitle)}</td><td><span class="state-${escapeHtml(run.state)}">${escapeHtml(run.state)}</span></td><td>${escapeHtml(run.provider)}</td><td><code>${escapeHtml(run.branchName)}</code></td></tr>`
+        `<tr><td><a href="/runs/${encodeURIComponent(run.id)}"><code>${escapeHtml(run.id)}</code></a></td><td>${escapeHtml(run.project)}</td><td>#${run.issueNumber} ${escapeHtml(run.issueTitle)}</td><td><span class="state-${escapeHtml(run.state)}">${escapeHtml(run.state)}</span></td><td>${escapeHtml(run.provider)}</td><td>${escapeHtml(run.createdAt)}</td><td>${escapeHtml(run.updatedAt)}</td><td><code>${escapeHtml(run.branchName)}</code></td></tr>`
     )
     .join("");
   return `<section><h2>${escapeHtml(title)}</h2>
-<table><thead><tr><th>Run id</th><th>Project</th><th>Issue</th><th>State</th><th>Provider</th><th>Branch</th></tr></thead>
+<table><thead><tr><th>Run id</th><th>Project</th><th>Issue</th><th>State</th><th>Provider</th><th>Started</th><th>Updated</th><th>Branch</th></tr></thead>
 <tbody>${rows}</tbody></table></section>`;
 }
 
@@ -226,6 +246,8 @@ function renderRunSummary(detail: RunStatus, capContext: CapContext | null): str
   <p><strong>Issue:</strong> #${detail.issueNumber} ${escapeHtml(detail.issueTitle)}</p>
   <p><strong>State:</strong> <span class="state-${escapeHtml(detail.state)}">${escapeHtml(detail.state)}</span></p>
   <p><strong>Provider:</strong> ${escapeHtml(detail.provider)}</p>
+  <p><strong>Started:</strong> ${escapeHtml(detail.createdAt)}</p>
+  <p><strong>Updated:</strong> ${escapeHtml(detail.updatedAt)}</p>
   <p><strong>Branch:</strong> <code>${escapeHtml(detail.branchName)}</code></p>
   <p><strong>Workspace:</strong> <code>${escapeHtml(detail.workspacePath)}</code></p>
   <p><strong>Retries:</strong> ${detail.retryCount}${detail.isContinuation ? " (continuation)" : ""}</p>
@@ -248,6 +270,8 @@ function renderAttemptsTable(
     attemptNumber: number;
     state: RunState;
     providerName: string;
+    createdAt: string;
+    updatedAt: string;
     branchName: string;
     promptPath: string;
   }[]
@@ -258,10 +282,10 @@ function renderAttemptsTable(
   const rows = attempts
     .map(
       (attempt) =>
-        `<tr><td>${attempt.attemptNumber}</td><td><code>${escapeHtml(attempt.id)}</code></td><td><span class="state-${escapeHtml(attempt.state)}">${escapeHtml(attempt.state)}</span></td><td>${escapeHtml(attempt.providerName)}</td><td><code>${escapeHtml(attempt.branchName)}</code></td><td><code>${escapeHtml(attempt.promptPath)}</code></td></tr>`
+        `<tr><td>${attempt.attemptNumber}</td><td><code>${escapeHtml(attempt.id)}</code></td><td><span class="state-${escapeHtml(attempt.state)}">${escapeHtml(attempt.state)}</span></td><td>${escapeHtml(attempt.providerName)}</td><td>${escapeHtml(attempt.createdAt)}</td><td>${escapeHtml(attempt.updatedAt)}</td><td><code>${escapeHtml(attempt.branchName)}</code></td><td><code>${escapeHtml(attempt.promptPath)}</code></td></tr>`
     )
     .join("");
-  return `<section><h2>Attempts</h2><table><thead><tr><th>#</th><th>Attempt id</th><th>State</th><th>Provider</th><th>Branch</th><th>Prompt</th></tr></thead><tbody>${rows}</tbody></table></section>`;
+  return `<section><h2>Attempts</h2><table><thead><tr><th>#</th><th>Attempt id</th><th>State</th><th>Provider</th><th>Attempt started</th><th>Attempt updated</th><th>Branch</th><th>Prompt</th></tr></thead><tbody>${rows}</tbody></table></section>`;
 }
 
 function renderTransitionsTable(
@@ -304,19 +328,23 @@ function renderEventsTable(
 
 function renderRunFileLinks(detail: RunStatus): string {
   const items: string[] = [];
-  const linkIfPresent = (label: string, kind: string, value: string): void => {
+  const linkIfPresent = (label: string, fileName: string, value: string): void => {
     if (value.length === 0) {
       return;
     }
     items.push(
-      `<li><a href="/api/runs/${encodeURIComponent(detail.id)}/files/${kind}">${escapeHtml(label)}</a></li>`
+      `<li><a href="/logs/runs/${encodeURIComponent(detail.id)}/${encodeURIComponent(fileName)}">${escapeHtml(label)}</a></li>`
     );
   };
-  linkIfPresent("Rendered prompt", "prompt", detail.promptPath);
-  linkIfPresent("Provider raw log", "raw-log", detail.rawLogPath);
-  linkIfPresent("Normalized log", "normalized-log", detail.normalizedLogPath);
-  linkIfPresent("Issue snapshot", "issue-snapshot", detail.issueSnapshotPath);
-  linkIfPresent("Prompt metadata", "metadata", detail.metadataPath);
+  linkIfPresent("prompt.md", "prompt.md", detail.promptPath);
+  linkIfPresent("provider.raw.jsonl", "provider.raw.jsonl", detail.rawLogPath);
+  linkIfPresent(
+    "provider.normalized.jsonl",
+    "provider.normalized.jsonl",
+    detail.normalizedLogPath
+  );
+  linkIfPresent("issue-snapshot.json", "issue-snapshot.json", detail.issueSnapshotPath);
+  linkIfPresent("prompt-metadata.json", "prompt-metadata.json", detail.metadataPath);
   if (items.length === 0) {
     return "";
   }

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -25,6 +25,7 @@ export type RunStatus = {
   cancelReason: CancelReason | null;
   cancelRequested: boolean;
   continuationParentRunId: string | null;
+  createdAt: string;
   failureClassification: FailureClassification | null;
   id: string;
   isContinuation: boolean;
@@ -40,12 +41,14 @@ export type RunStatus = {
   retryCount: number;
   state: RunState;
   terminalReason: string | null;
+  updatedAt: string;
   workspacePath: string;
 };
 
 export type AttemptStatus = {
   attemptNumber: number;
   branchName: string;
+  createdAt: string;
   id: string;
   issueSnapshotPath: string;
   normalizedLogPath: string;
@@ -55,6 +58,7 @@ export type AttemptStatus = {
   rawLogPath: string;
   runId: string;
   state: RunState;
+  updatedAt: string;
   workspacePath: string;
 };
 
@@ -136,6 +140,7 @@ type RunRow = {
   cancel_reason: string | null;
   cancel_requested: number;
   continuation_parent_run_id: string | null;
+  created_at: string;
   failure_classification: string | null;
   id: string;
   is_continuation: number;
@@ -151,12 +156,14 @@ type RunRow = {
   retry_count: number;
   state: RunState;
   terminal_reason: string | null;
+  updated_at: string;
   workspace_path: string | null;
 };
 
 type AttemptRow = {
   attempt_number: number;
   branch_name: string;
+  created_at: string;
   id: string;
   issue_snapshot_path: string;
   normalized_log_path: string;
@@ -166,6 +173,7 @@ type AttemptRow = {
   raw_log_path: string;
   run_id: string;
   state: RunState;
+  updated_at: string;
   workspace_path: string;
 };
 
@@ -472,7 +480,8 @@ export class RunStore {
           "workspace_path, branch_name, prompt_path, metadata_path,",
           "issue_snapshot_path, raw_log_path, normalized_log_path,",
           "is_continuation, continuation_parent_run_id, retry_count,",
-          "failure_classification, terminal_reason, cancel_requested, cancel_reason",
+          "failure_classification, terminal_reason, cancel_requested, cancel_reason,",
+          "created_at, updated_at",
           "from runs",
           where,
           "order by created_at desc, id desc",
@@ -494,7 +503,8 @@ export class RunStore {
           "workspace_path, branch_name, prompt_path, metadata_path,",
           "issue_snapshot_path, raw_log_path, normalized_log_path,",
           "is_continuation, continuation_parent_run_id, retry_count,",
-          "failure_classification, terminal_reason, cancel_requested, cancel_reason",
+          "failure_classification, terminal_reason, cancel_requested, cancel_reason,",
+          "created_at, updated_at",
           "from runs where id = ?"
         ].join(" ")
       )
@@ -517,7 +527,7 @@ export class RunStore {
         [
           "select id, run_id, attempt_number, state, provider_name, provider_command,",
           "workspace_path, branch_name, prompt_path, issue_snapshot_path,",
-          "raw_log_path, normalized_log_path",
+          "raw_log_path, normalized_log_path, created_at, updated_at",
           "from attempts where run_id = ? order by attempt_number asc, id asc"
         ].join(" ")
       )
@@ -526,6 +536,7 @@ export class RunStore {
     return rows.map((row) => ({
       attemptNumber: row.attempt_number,
       branchName: row.branch_name,
+      createdAt: row.created_at,
       id: row.id,
       issueSnapshotPath: row.issue_snapshot_path,
       normalizedLogPath: row.normalized_log_path,
@@ -535,6 +546,7 @@ export class RunStore {
       rawLogPath: row.raw_log_path,
       runId: row.run_id,
       state: row.state,
+      updatedAt: row.updated_at,
       workspacePath: row.workspace_path
     }));
   }
@@ -757,6 +769,7 @@ function mapRunRow(row: RunRow): RunStatus {
     cancelReason: (row.cancel_reason as CancelReason | null) ?? null,
     cancelRequested: row.cancel_requested === 1,
     continuationParentRunId: row.continuation_parent_run_id ?? null,
+    createdAt: row.created_at,
     failureClassification:
       (row.failure_classification as FailureClassification | null) ?? null,
     id: row.id,
@@ -773,6 +786,7 @@ function mapRunRow(row: RunRow): RunStatus {
     retryCount: row.retry_count ?? 0,
     state: row.state,
     terminalReason: row.terminal_reason ?? null,
+    updatedAt: row.updated_at,
     workspacePath: row.workspace_path ?? ""
   };
 }

--- a/src/smoke.ts
+++ b/src/smoke.ts
@@ -38,6 +38,7 @@ export type SmokeOptions = {
 export type SmokeRunDetail = Pick<
   RunDetail,
   | "branchName"
+  | "createdAt"
   | "id"
   | "issueNumber"
   | "issueSnapshotPath"
@@ -50,6 +51,7 @@ export type SmokeRunDetail = Pick<
   | "rawLogPath"
   | "state"
   | "terminalReason"
+  | "updatedAt"
   | "workspacePath"
 >;
 
@@ -173,6 +175,7 @@ export async function runSmoke(options: SmokeOptions = {}): Promise<SmokeReport>
 function pickRunDetail(detail: RunDetail): SmokeRunDetail {
   return {
     branchName: detail.branchName,
+    createdAt: detail.createdAt,
     id: detail.id,
     issueNumber: detail.issueNumber,
     issueSnapshotPath: detail.issueSnapshotPath,
@@ -185,6 +188,7 @@ function pickRunDetail(detail: RunDetail): SmokeRunDetail {
     rawLogPath: detail.rawLogPath,
     state: detail.state,
     terminalReason: detail.terminalReason,
+    updatedAt: detail.updatedAt,
     workspacePath: detail.workspacePath
   };
 }

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -227,6 +227,46 @@ describe("CLI run commands", () => {
     expect(requests).toEqual(["http://127.0.0.1:3030/api/status"]);
   });
 
+  it("status and cancel treat a malformed daemon endpoint descriptor as unavailable", async () => {
+    const stateRoot = await makeTempRoot();
+    const resolvedStateRoot = path.join(stateRoot, ".symphonika");
+    await mkdir(resolvedStateRoot, { recursive: true });
+    await writeFile(path.join(resolvedStateRoot, "daemon.json"), "{", "utf8");
+
+    const status = captureProgram(stateRoot, {
+      runDoctor: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          ok: true,
+          projects: []
+        } satisfies DoctorReport)
+    });
+    await status.program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml")
+    ]);
+    expect(status.output.stdout).toContain(
+      "last poll outcome: unknown (not configured)"
+    );
+
+    const cancel = captureProgram(stateRoot);
+    await expect(
+      cancel.program.parseAsync([
+        "node",
+        "symphonika",
+        "cancel",
+        "run-1",
+        "--config",
+        path.join(stateRoot, "symphonika.yml")
+      ])
+    ).rejects.toThrow();
+    expect(cancel.output.stderr).toContain("daemon endpoint not found");
+  });
+
   it("status prints stale GitHub issues by project and issue number", async () => {
     const stateRoot = await makeTempRoot();
     const { output, program } = captureProgram(stateRoot, {

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -103,6 +103,130 @@ describe("CLI run commands", () => {
     expect(output.stdout).toContain("r-failed");
   });
 
+  it("status prints project validation, issue counts, and last poll outcome", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "r-running",
+      issue: sampleIssue({ number: 1, title: "Sample" }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("r-running", "running");
+    store.close();
+
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: () =>
+        Promise.resolve(
+          Response.json({
+            candidateIssues: [{ issue: { number: 1 }, project: "alpha" }],
+            filteredIssues: [
+              { issue: { labels: ["sym:running"], number: 2 }, project: "alpha" },
+              { issue: { labels: ["sym:failed"], number: 3 }, project: "alpha" },
+              { issue: { labels: ["sym:stale"], number: 4 }, project: "alpha" }
+            ],
+            issuePolling: {
+              errors: [],
+              projects: [{ fetchedIssues: 4, name: "alpha", ok: true }]
+            },
+            staleIssues: [
+              { issue: { labels: ["sym:stale"], number: 4 }, project: "alpha" }
+            ],
+            state: "idle",
+            stateRoot: path.join(stateRoot, ".symphonika")
+          })
+        ),
+      runDoctor: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          ok: true,
+          projects: [
+            {
+              missingOperationalLabels: [],
+              name: "alpha",
+              staleIssues: [],
+              validForDispatch: true,
+              workflowPath: "/tmp/WORKFLOW.md"
+            }
+          ]
+        } satisfies DoctorReport)
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml"),
+      "--daemon-url",
+      "http://127.0.0.1:3030"
+    ]);
+
+    expect(output.stdout).toContain("daemon: idle at http://127.0.0.1:3030");
+    expect(output.stdout).toContain("Projects:");
+    expect(output.stdout).toContain("alpha: valid");
+    expect(output.stdout).toContain("candidate: 1");
+    expect(output.stdout).toContain("filtered:  3");
+    expect(output.stdout).toContain("running:   1");
+    expect(output.stdout).toContain("failed:    1");
+    expect(output.stdout).toContain("stale:     1");
+    expect(output.stdout).toContain("last poll outcome: alpha ok (4 fetched)");
+  });
+
+  it("status discovers the local daemon endpoint descriptor", async () => {
+    const stateRoot = await makeTempRoot();
+    const resolvedStateRoot = path.join(stateRoot, ".symphonika");
+    await mkdir(resolvedStateRoot, { recursive: true });
+    await writeFile(
+      path.join(resolvedStateRoot, "daemon.json"),
+      JSON.stringify({ url: "http://127.0.0.1:3030" }),
+      "utf8"
+    );
+    const requests: string[] = [];
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: (input: string | URL | Request) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        requests.push(url);
+        return Promise.resolve(
+          Response.json({
+            issuePolling: {
+              errors: [],
+              projects: [{ fetchedIssues: 2, name: "alpha", ok: true }]
+            },
+            state: "idle",
+            stateRoot: resolvedStateRoot
+          })
+        );
+      },
+      runDoctor: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          ok: true,
+          projects: []
+        } satisfies DoctorReport)
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml")
+    ]);
+
+    expect(output.stdout).toContain("daemon: idle at http://127.0.0.1:3030");
+    expect(output.stdout).toContain("last poll outcome: alpha ok (2 fetched)");
+    expect(requests).toEqual(["http://127.0.0.1:3030/api/status"]);
+  });
+
   it("status prints stale GitHub issues by project and issue number", async () => {
     const stateRoot = await makeTempRoot();
     const { output, program } = captureProgram(stateRoot, {
@@ -180,6 +304,8 @@ describe("CLI run commands", () => {
       "failed"
     ]);
     expect(failed.output.stdout).toContain("r-only-failed");
+    expect(failed.output.stdout).toContain("started");
+    expect(failed.output.stdout).toContain("updated");
   });
 
   it("show-run errors when the run is missing and prints detail when present", async () => {
@@ -191,6 +317,29 @@ describe("CLI run commands", () => {
       projectName: "alpha",
       providerCommand: "x",
       providerName: "codex"
+    });
+    store.createAttempt({
+      attemptNumber: 1,
+      branchName: "sym/alpha/7-detail",
+      branchRef: "refs/heads/sym/alpha/7-detail",
+      id: "show-1-attempt-1",
+      issueSnapshotPath: "",
+      metadataPath: "",
+      normalizedLogPath: "",
+      promptPath: "",
+      providerCommand: "x",
+      providerName: "codex",
+      rawLogPath: "",
+      runId: "show-1",
+      state: "running",
+      workspacePath: stateRoot
+    });
+    store.recordProviderEvent({
+      attemptId: "show-1-attempt-1",
+      normalized: { message: "hello from provider", type: "message" },
+      raw: { message: "hello from provider" },
+      runId: "show-1",
+      sequence: 1
     });
     store.close();
 
@@ -219,10 +368,16 @@ describe("CLI run commands", () => {
     ]);
     expect(present.output.stdout).toContain("show-1");
     expect(present.output.stdout).toContain("Detail");
+    expect(present.output.stdout).toContain("started:");
+    expect(present.output.stdout).toContain("updated:");
+    expect(present.output.stdout).toContain("prompt.md");
+    expect(present.output.stdout).toContain("show-1-attempt-1");
+    expect(present.output.stdout).toContain("normalized events");
+    expect(present.output.stdout).toContain("hello from provider");
     expect(present.output.stdout).toContain("<not yet recorded>");
   });
 
-  it("cancel writes markCancelRequested for non-terminal runs and errors otherwise", async () => {
+  it("cancel discovers the local daemon and posts to its cancel endpoint", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });
     store.createRun({
@@ -233,18 +388,34 @@ describe("CLI run commands", () => {
       providerName: "codex"
     });
     store.updateRunState("cancel-live", "running");
-    store.createRun({
-      id: "cancel-done",
-      issue: sampleIssue({ number: 12 }),
-      projectName: "alpha",
-      providerCommand: "x",
-      providerName: "codex"
-    });
-    store.updateRunState("cancel-done", "succeeded");
     store.close();
 
     const cfg = path.join(stateRoot, "symphonika.yml");
-    const live = captureProgram(stateRoot);
+    const resolvedStateRoot = path.join(stateRoot, ".symphonika");
+    await mkdir(resolvedStateRoot, { recursive: true });
+    await writeFile(
+      path.join(resolvedStateRoot, "daemon.json"),
+      JSON.stringify({ url: "http://127.0.0.1:3030" }),
+      "utf8"
+    );
+    const requests: Array<{ method: string; url: string }> = [];
+    const live = captureProgram(stateRoot, {
+      fetch: (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        requests.push({ method: init?.method ?? "GET", url });
+        if (url.endsWith("/api/status")) {
+          return Promise.resolve(
+            Response.json({ stateRoot: resolvedStateRoot })
+          );
+        }
+        return Promise.resolve(Response.json({ kind: "cancelled" }));
+      }
+    });
     await live.program.parseAsync([
       "node",
       "symphonika",
@@ -253,38 +424,56 @@ describe("CLI run commands", () => {
       "--config",
       cfg
     ]);
-    expect(live.output.stdout).toContain("cancel requested for cancel-live");
+    expect(live.output.stdout).toContain("cancelled cancel-live");
+    expect(requests).toEqual([
+      { method: "GET", url: "http://127.0.0.1:3030/api/status" },
+      {
+        method: "POST",
+        url: "http://127.0.0.1:3030/api/runs/cancel-live/cancel"
+      }
+    ]);
 
     const verifyStore = openRunStore({ stateRoot });
-    expect(verifyStore.getRun("cancel-live")?.cancelRequested).toBe(true);
-    expect(verifyStore.getRun("cancel-live")?.cancelReason).toBe("operator");
+    expect(verifyStore.getRun("cancel-live")?.cancelRequested).toBe(false);
     verifyStore.close();
+  });
 
-    const done = captureProgram(stateRoot);
+  it("cancel refuses a daemon endpoint for another state root", async () => {
+    const stateRoot = await makeTempRoot();
+    const requests: string[] = [];
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: (input: string | URL | Request) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        requests.push(url);
+        if (url.endsWith("/api/status")) {
+          return Promise.resolve(
+            Response.json({ stateRoot: path.join(stateRoot, "..", "other") })
+          );
+        }
+        return Promise.resolve(Response.json({ kind: "cancelled" }));
+      }
+    });
+
     await expect(
-      done.program.parseAsync([
+      program.parseAsync([
         "node",
         "symphonika",
         "cancel",
-        "cancel-done",
+        "cancel-live",
         "--config",
-        cfg
+        path.join(stateRoot, "symphonika.yml"),
+        "--daemon-url",
+        "http://127.0.0.1:3030"
       ])
     ).rejects.toThrow();
-    expect(done.output.stderr).toContain("already succeeded");
 
-    const missing = captureProgram(stateRoot);
-    await expect(
-      missing.program.parseAsync([
-        "node",
-        "symphonika",
-        "cancel",
-        "missing",
-        "--config",
-        cfg
-      ])
-    ).rejects.toThrow();
-    expect(missing.output.stderr).toContain("not found");
+    expect(output.stderr).toContain("state root mismatch");
+    expect(requests).toEqual(["http://127.0.0.1:3030/api/status"]);
   });
 
   it("show-run renders cap context for a cap_reached:no_commits run", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -157,6 +157,7 @@ describe("CLI", () => {
           ok: true,
           runDetail: {
             branchName: "sym/symphonika/42-x",
+            createdAt: "2026-05-04T17:00:00.000Z",
             id: "run-x",
             issueNumber: 42,
             issueSnapshotPath: "/tmp/state/logs/runs/run-x/issue-snapshot.json",
@@ -170,6 +171,7 @@ describe("CLI", () => {
             rawLogPath: "/tmp/state/logs/runs/run-x/provider.raw.jsonl",
             state: "succeeded",
             terminalReason: null,
+            updatedAt: "2026-05-04T17:00:01.000Z",
             workspacePath: "/tmp/state/workspaces/symphonika/issues/42-x"
           },
           runId: "run-x",

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
@@ -56,6 +57,23 @@ describe("startDaemon", () => {
     }
     await expect(readFile(endpointPath, "utf8")).rejects.toThrow();
   });
+
+  it("cleans up the HTTP listener when endpoint descriptor writing fails", async () => {
+    const cwd = await makeTempRoot();
+    const port = await getFreePort();
+    await mkdir(path.join(cwd, ".symphonika", "daemon.json"), {
+      recursive: true
+    });
+
+    await expect(
+      startDaemon({
+        cwd,
+        logger: pino({ enabled: false }),
+        port
+      })
+    ).rejects.toThrow();
+    await expect(fetch(`http://127.0.0.1:${port}/health`)).rejects.toThrow();
+  });
 });
 
 describe("resolveLogLevel", () => {
@@ -80,4 +98,25 @@ describe("resolveLogLevel", () => {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (typeof address !== "object" || address === null) {
+        server.close(() => reject(new Error("free port lookup failed")));
+        return;
+      }
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
 }

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
@@ -30,10 +30,12 @@ describe("startDaemon", () => {
       logger: pino({ enabled: false }),
       port: 0
     });
+    const endpointPath = path.join(cwd, ".symphonika", "daemon.json");
 
     try {
       const response = await fetch(`${daemon.url}/health`);
       const body: unknown = await response.json();
+      const endpoint = JSON.parse(await readFile(endpointPath, "utf8")) as unknown;
 
       expect(response.status).toBe(200);
       expect(body).toMatchObject({
@@ -45,9 +47,14 @@ describe("startDaemon", () => {
       if (isRecord(body)) {
         expect(typeof body.uptimeMs).toBe("number");
       }
+      expect(endpoint).toMatchObject({
+        stateRoot: path.join(cwd, ".symphonika"),
+        url: daemon.url
+      });
     } finally {
       await daemon.stop();
     }
+    await expect(readFile(endpointPath, "utf8")).rejects.toThrow();
   });
 });
 

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -3,9 +3,10 @@ import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resolveLogLevel, startDaemon } from "../src/daemon.js";
+import { RunStore } from "../src/run-store.js";
 
 const tempRoots: string[] = [];
 
@@ -73,6 +74,27 @@ describe("startDaemon", () => {
       })
     ).rejects.toThrow();
     await expect(fetch(`http://127.0.0.1:${port}/health`)).rejects.toThrow();
+  });
+
+  it("closes the run store when endpoint descriptor removal fails during stop", async () => {
+    const cwd = await makeTempRoot();
+    const daemon = await startDaemon({
+      cwd,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+    const closeRunStore = vi.spyOn(RunStore.prototype, "close");
+    const endpointPath = path.join(cwd, ".symphonika", "daemon.json");
+
+    try {
+      await rm(endpointPath, { force: true });
+      await mkdir(endpointPath);
+
+      await expect(daemon.stop()).rejects.toThrow();
+      expect(closeRunStore).toHaveBeenCalledTimes(1);
+    } finally {
+      closeRunStore.mockRestore();
+    }
   });
 });
 

--- a/tests/http-app-runs.test.ts
+++ b/tests/http-app-runs.test.ts
@@ -246,6 +246,11 @@ describe("HTTP app — runs API and pages", () => {
       expect(ok.headers.get("content-type")).toContain("application/x-ndjson");
       expect(await ok.text()).toContain('{"x":1}');
 
+      const log = await app.request("/logs/runs/run-files/provider.raw.jsonl");
+      expect(log.status).toBe(200);
+      expect(log.headers.get("content-type")).toContain("application/x-ndjson");
+      expect(await log.text()).toContain('{"x":1}');
+
       expect(
         (await app.request("/api/runs/run-empty/files/raw-log")).status
       ).toBe(404);
@@ -257,7 +262,7 @@ describe("HTTP app — runs API and pages", () => {
     }
   });
 
-  it("POST /api/runs/:id/cancel returns 200/404/409 and 303 for form submissions", async () => {
+  it("POST /api/runs/:id/cancel cancels run-store backed active runs", async () => {
     const test = await setup();
     try {
       test.runStore.createRun({
@@ -268,12 +273,24 @@ describe("HTTP app — runs API and pages", () => {
         providerName: "codex"
       });
       test.runStore.updateRunState("live", "running");
+      test.runStore.createRun({
+        id: "done",
+        issue: sampleIssue({ number: 12 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("done", "succeeded");
+      test.runStore.createRun({
+        id: "needs-input",
+        issue: sampleIssue({ number: 13 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("needs-input", "input_required");
 
       const app = createHttpApp({
-        cancelRun: (runId) => {
-          test.runStore.markCancelRequested(runId, "operator");
-          return { kind: "cancelled" };
-        },
         runStore: test.runStore,
         stateRoot: test.stateRoot,
         version: "0.1.0"
@@ -283,6 +300,32 @@ describe("HTTP app — runs API and pages", () => {
       expect(ok.status).toBe(200);
       const okBody = (await ok.json()) as { kind: string };
       expect(okBody.kind).toBe("cancelled");
+      const detail = test.runStore.getRun("live");
+      expect(detail?.state).toBe("cancelled");
+      expect(detail?.cancelRequested).toBe(true);
+      expect(detail?.cancelReason).toBe("operator");
+      expect(detail?.terminalReason).toBe("operator");
+
+      const missing = await app.request("/api/runs/missing/cancel", {
+        method: "POST"
+      });
+      expect(missing.status).toBe(404);
+
+      const done = await app.request("/api/runs/done/cancel", { method: "POST" });
+      expect(done.status).toBe(409);
+      expect(await done.json()).toMatchObject({
+        kind: "already-terminal",
+        state: "succeeded"
+      });
+
+      const inputRequired = await app.request("/api/runs/needs-input/cancel", {
+        method: "POST"
+      });
+      expect(inputRequired.status).toBe(409);
+      expect(await inputRequired.json()).toMatchObject({
+        kind: "already-terminal",
+        state: "input_required"
+      });
 
       const form = await app.request("/api/runs/live/cancel", {
         body: "",
@@ -331,6 +374,85 @@ describe("HTTP app — runs API and pages", () => {
 
       const missing = await app.request("/runs/missing");
       expect(missing.status).toBe(404);
+    } finally {
+      test.cleanup();
+    }
+  });
+
+  it("renders polling projects, timestamps, and stable log links on pages", async () => {
+    const test = await setup();
+    try {
+      const evidenceDir = path.join(test.stateRoot, "logs", "runs", "run-page");
+      await mkdir(evidenceDir, { recursive: true });
+      const rawLogPath = path.join(evidenceDir, "provider.raw.jsonl");
+      await writeFile(rawLogPath, '{"type":"message"}\n', "utf8");
+
+      test.runStore.createRun({
+        id: "run-page",
+        issue: sampleIssue({ number: 77, title: "Visible run" }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("run-page", "running");
+      test.runStore.updateRunEvidence("run-page", {
+        branchName: "sym/run-page",
+        branchRef: "refs/heads/sym/run-page",
+        issueSnapshotPath: "",
+        metadataPath: "",
+        normalizedLogPath: "",
+        promptPath: "",
+        rawLogPath,
+        workspacePath: test.stateRoot
+      });
+      test.runStore.createAttempt({
+        attemptNumber: 1,
+        branchName: "sym/run-page",
+        branchRef: "refs/heads/sym/run-page",
+        id: "run-page-attempt-1",
+        issueSnapshotPath: "",
+        metadataPath: "",
+        normalizedLogPath: "",
+        promptPath: "",
+        providerCommand: "x",
+        providerName: "codex",
+        rawLogPath,
+        runId: "run-page",
+        state: "running",
+        workspacePath: test.stateRoot
+      });
+      const detail = test.runStore.getRun("run-page");
+
+      const app = createHttpApp({
+        issuePollStatus: {
+          candidateIssues: [],
+          errors: [],
+          filteredIssues: [],
+          projects: [{ fetchedIssues: 4, name: "alpha", ok: true }]
+        },
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+
+      const dashboard = await app.request("/");
+      expect(dashboard.status).toBe(200);
+      const dashboardBody = await dashboard.text();
+      expect(dashboardBody).toContain("Projects");
+      expect(dashboardBody).toContain("poll ok");
+      expect(dashboardBody).toContain("4 fetched");
+      expect(dashboardBody).toContain(detail?.createdAt);
+      expect(dashboardBody).toContain(detail?.updatedAt);
+
+      const runPage = await app.request("/runs/run-page");
+      expect(runPage.status).toBe(200);
+      const runPageBody = await runPage.text();
+      expect(runPageBody).toContain("Started");
+      expect(runPageBody).toContain("Updated");
+      expect(runPageBody).toContain("Attempt started");
+      expect(runPageBody).toContain("run-page-attempt-1");
+      expect(runPageBody).toContain(detail?.attempts[0]?.createdAt);
+      expect(runPageBody).toContain("/logs/runs/run-page/provider.raw.jsonl");
     } finally {
       test.cleanup();
     }

--- a/tests/run-store-detail.test.ts
+++ b/tests/run-store-detail.test.ts
@@ -75,6 +75,12 @@ describe("RunStore detail queries", () => {
       expect(detail?.issueTitle).toBe("Sample issue");
       expect(detail?.attempts).toHaveLength(1);
       expect(detail?.attempts[0]?.id).toBe("run-A-attempt-1");
+      expect(detail?.attempts[0]?.createdAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T/
+      );
+      expect(detail?.attempts[0]?.updatedAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T/
+      );
       expect(detail?.transitions.map((t) => t.state)).toEqual([
         "queued",
         "preparing_workspace",


### PR DESCRIPTION
Closes #45.

Reimplements PR #72 on top of current main, preserving the operator CLI/web behavior while fixing the reviewed daemon-targeting bug.

Summary:
- Adds daemon endpoint discovery via .symphonika/daemon.json with state-root preflight before status/cancel.
- Expands status, runs, show-run, smoke, run detail, and pages with timestamps, polling state, events, attempts, and evidence links.
- Adds run-store-backed web/API cancellation plus stable /logs/runs/:id/:fileName evidence routes.

Verification:
- npm run lint
- npm run typecheck
- npm test
- npm run build
