### PR TITLE
Verify workspace changes before success

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -133,8 +133,9 @@ The exact slugging algorithm must be deterministic and path-safe.
 
 A Run is one orchestrator-managed execution lifecycle for one issue in one workspace.
 
-Run success means the provider process completed successfully. It does not mean the GitHub issue is
-closed, merged, or complete.
+Run success means the provider process completed successfully and the issue branch has at least one
+commit ahead of the configured base branch in the Workspace. It does not mean the GitHub issue is
+closed, merged, pushed, or represented by a pull request.
 
 ### 4.8 Continuation
 
@@ -599,13 +600,19 @@ Terminal run state does not necessarily match GitHub issue state.
 
 ### 12.1 Success
 
-On provider success:
+On provider exit code 0:
 
-1. Mark run `succeeded`.
-2. Remove `sym:running`.
-3. Re-check GitHub issue.
-4. If the issue remains eligible, schedule a short continuation.
-5. If the continuation cap is reached, mark `sym:failed` and surface the reason.
+1. Inspect the Workspace issue branch against
+   `refs/remotes/origin/<configured-base-branch>..HEAD`.
+2. If the branch has zero commits ahead of base, mark the run `failed` with deterministic terminal
+   reason `no_workspace_changes`.
+3. If Workspace inspection fails, mark the run `failed` with deterministic terminal reason
+   `workspace_inspection_failed`.
+4. If the branch is ahead of base, mark run `succeeded`.
+5. Remove `sym:running`.
+6. Re-check GitHub issue.
+7. If the issue remains eligible, schedule a short continuation.
+8. If the continuation cap is reached, mark `sym:failed` and surface the reason.
 
 Default continuation delay: about 1 second.
 
@@ -628,6 +635,8 @@ Do not automatically retry deterministic failures:
 - missing workflow
 - input required
 - continuation cap reached
+- no workspace commits ahead of base after provider exit code 0
+- workspace success inspection failure
 - workspace branch conflict
 - Project validation failure
 

--- a/src/lifecycle/classify-failure.ts
+++ b/src/lifecycle/classify-failure.ts
@@ -1,11 +1,20 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
 import type { NormalizedProviderEvent } from "../provider.js";
 import type { FailureClassification } from "../run-store.js";
 import { WorkspacePreparationError } from "../workspace.js";
+
+const execFileAsync = promisify(execFile);
 
 export type ClassifyFailureInput = {
   cancelRequested: boolean;
   error?: unknown;
   events: NormalizedProviderEvent[];
+  successWorkspace?: {
+    baseBranch: string;
+    workspacePath: string;
+  };
 };
 
 export type ClassifiedTerminal = {
@@ -14,7 +23,9 @@ export type ClassifiedTerminal = {
   reason: string;
 };
 
-export function classifyFailure(input: ClassifyFailureInput): ClassifiedTerminal {
+export async function classifyFailure(
+  input: ClassifyFailureInput
+): Promise<ClassifiedTerminal> {
   if (input.cancelRequested) {
     return {
       kind: "cancelled",
@@ -71,10 +82,7 @@ export function classifyFailure(input: ClassifyFailureInput): ClassifiedTerminal
 
   const exitCode = numberField(exit, "exitCode");
   if (exitCode === 0) {
-    return {
-      kind: "success",
-      reason: ""
-    };
+    return verifyWorkspaceSuccess(input.successWorkspace);
   }
 
   return {
@@ -84,6 +92,51 @@ export function classifyFailure(input: ClassifyFailureInput): ClassifiedTerminal
       exitCode === undefined
         ? `process_exit_signal_${stringField(exit, "signal") ?? "unknown"}`
         : `process_exit_${exitCode}`
+  };
+}
+
+async function verifyWorkspaceSuccess(
+  workspace: ClassifyFailureInput["successWorkspace"]
+): Promise<ClassifiedTerminal> {
+  if (workspace === undefined) {
+    return workspaceInspectionFailed();
+  }
+
+  try {
+    const baseRef = `refs/remotes/origin/${workspace.baseBranch}`;
+    const { stdout } = await execFileAsync("git", [
+      "-C",
+      workspace.workspacePath,
+      "rev-list",
+      "--count",
+      `${baseRef}..HEAD`
+    ]);
+    const trimmed = stdout.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      return workspaceInspectionFailed();
+    }
+    const aheadCount = Number(trimmed);
+    if (aheadCount === 0) {
+      return {
+        classification: "deterministic",
+        kind: "failed",
+        reason: "no_workspace_changes"
+      };
+    }
+    return {
+      kind: "success",
+      reason: ""
+    };
+  } catch {
+    return workspaceInspectionFailed();
+  }
+}
+
+function workspaceInspectionFailed(): ClassifiedTerminal {
+  return {
+    classification: "deterministic",
+    kind: "failed",
+    reason: "workspace_inspection_failed"
   };
 }
 

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -626,10 +626,18 @@ export class RunController {
           cancelReason = removed.cancelReason;
         }
       }
-      const terminal = classifyFailure({
+      const terminal = await classifyFailure({
         cancelRequested,
         ...(caughtError === undefined ? {} : { error: caughtError }),
-        events: runtime.events
+        events: runtime.events,
+        ...(started === undefined
+          ? {}
+          : {
+              successWorkspace: {
+                baseBranch: input.project.workspace.git.base_branch,
+                workspacePath: started.evidence.workspacePath
+              }
+            })
       });
       const outcomeState = mapOutcomeToRunState(terminal);
       if (attemptCreated) {

--- a/tests/classify-failure.test.ts
+++ b/tests/classify-failure.test.ts
@@ -1,23 +1,84 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { classifyFailure } from "../src/lifecycle/classify-failure.js";
 import { WorkspacePreparationError } from "../src/workspace.js";
+import {
+  createGitWorkspaceAhead,
+  createGitWorkspaceAtBase
+} from "./helpers/git-workspace.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-classify-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
 
 describe("classifyFailure", () => {
-  it("classifies a clean process_exit code 0 as success", () => {
-    const result = classifyFailure({
+  it("classifies a clean process_exit code 0 as success when the workspace is ahead of base", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await createGitWorkspaceAhead({
+      branchName: "sym/symphonika/8-test",
+      workspacePath
+    });
+
+    const result = await classifyFailure({
       cancelRequested: false,
       events: [
         { type: "session_started" },
         { type: "process_exit", exitCode: 0 }
-      ]
+      ],
+      successWorkspace: { baseBranch: "main", workspacePath }
     });
 
     expect(result.kind).toBe("success");
   });
 
-  it("treats cancelRequested override as cancelled regardless of event flags", () => {
-    const result = classifyFailure({
+  it("classifies exit code 0 with no commits ahead of base as deterministic failure", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await createGitWorkspaceAtBase({
+      branchName: "sym/symphonika/8-test",
+      workspacePath
+    });
+
+    const result = await classifyFailure({
+      cancelRequested: false,
+      events: [{ type: "process_exit", exitCode: 0 }],
+      successWorkspace: { baseBranch: "main", workspacePath }
+    });
+
+    expect(result.kind).toBe("failed");
+    expect(result.classification).toBe("deterministic");
+    expect(result.reason).toBe("no_workspace_changes");
+  });
+
+  it("classifies workspace inspection errors on exit code 0 as deterministic failure", async () => {
+    const root = await makeTempRoot();
+    const result = await classifyFailure({
+      cancelRequested: false,
+      events: [{ type: "process_exit", exitCode: 0 }],
+      successWorkspace: { baseBranch: "main", workspacePath: root }
+    });
+
+    expect(result.kind).toBe("failed");
+    expect(result.classification).toBe("deterministic");
+    expect(result.reason).toBe("workspace_inspection_failed");
+  });
+
+  it("treats cancelRequested override as cancelled regardless of event flags", async () => {
+    const result = await classifyFailure({
       cancelRequested: true,
       events: [{ type: "process_exit", exitCode: 0 }]
     });
@@ -25,8 +86,8 @@ describe("classifyFailure", () => {
     expect(result.kind).toBe("cancelled");
   });
 
-  it("classifies input_required terminally", () => {
-    const result = classifyFailure({
+  it("classifies input_required terminally", async () => {
+    const result = await classifyFailure({
       cancelRequested: false,
       events: [{ type: "input_required" }]
     });
@@ -35,8 +96,8 @@ describe("classifyFailure", () => {
     expect(result.classification).toBe("input_required");
   });
 
-  it("classifies malformed_event as deterministic failure", () => {
-    const result = classifyFailure({
+  it("classifies malformed_event as deterministic failure", async () => {
+    const result = await classifyFailure({
       cancelRequested: false,
       events: [
         { type: "malformed_event", line: "{" },
@@ -48,8 +109,8 @@ describe("classifyFailure", () => {
     expect(result.classification).toBe("deterministic");
   });
 
-  it("classifies turn_failed as transient failure", () => {
-    const result = classifyFailure({
+  it("classifies turn_failed as transient failure", async () => {
+    const result = await classifyFailure({
       cancelRequested: false,
       events: [
         { type: "turn_failed", message: "boom" },
@@ -61,8 +122,8 @@ describe("classifyFailure", () => {
     expect(result.classification).toBe("transient");
   });
 
-  it("classifies non-zero process_exit as transient failure", () => {
-    const result = classifyFailure({
+  it("classifies non-zero process_exit as transient failure", async () => {
+    const result = await classifyFailure({
       cancelRequested: false,
       events: [{ type: "process_exit", exitCode: 1 }]
     });
@@ -71,8 +132,8 @@ describe("classifyFailure", () => {
     expect(result.classification).toBe("transient");
   });
 
-  it("classifies WorkspacePreparationError as deterministic", () => {
-    const result = classifyFailure({
+  it("classifies WorkspacePreparationError as deterministic", async () => {
+    const result = await classifyFailure({
       cancelRequested: false,
       error: new WorkspacePreparationError("branch_conflict", "boom"),
       events: []
@@ -83,8 +144,8 @@ describe("classifyFailure", () => {
     expect(result.reason).toContain("workspace_branch_conflict");
   });
 
-  it("classifies workflow render errors as deterministic", () => {
-    const result = classifyFailure({
+  it("classifies workflow render errors as deterministic", async () => {
+    const result = await classifyFailure({
       cancelRequested: false,
       error: new Error("workflow template references unknown variable {{x}}"),
       events: []
@@ -94,10 +155,10 @@ describe("classifyFailure", () => {
     expect(result.classification).toBe("deterministic");
   });
 
-  it("classifies ENOENT validate errors as deterministic", () => {
+  it("classifies ENOENT validate errors as deterministic", async () => {
     const error = new Error("ENOENT: no such file") as Error & { code?: string };
     error.code = "ENOENT";
-    const result = classifyFailure({
+    const result = await classifyFailure({
       cancelRequested: false,
       error,
       events: []
@@ -107,8 +168,8 @@ describe("classifyFailure", () => {
     expect(result.classification).toBe("deterministic");
   });
 
-  it("classifies generic Error as transient", () => {
-    const result = classifyFailure({
+  it("classifies generic Error as transient", async () => {
+    const result = await classifyFailure({
       cancelRequested: false,
       error: new Error("connection reset"),
       events: []

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -15,6 +15,7 @@ import type {
   PreparedIssueWorkspace,
   PrepareIssueWorkspaceInput
 } from "../src/workspace.js";
+import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
 
 const tempRoots: string[] = [];
 const DEFAULT_CODEX_COMMAND = `codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server`;
@@ -44,7 +45,6 @@ describe("daemon dispatch", () => {
       "issues",
       "8-dispatch-an-end-to-end-run-through-a-test-provider"
     );
-    await mkdir(workspacePath, { recursive: true });
     await writeValidProject(root);
 
     const githubIssuesApi = {
@@ -117,6 +117,7 @@ describe("daemon dispatch", () => {
       reused: false,
       workspacePath
     };
+    await createGitWorkspaceAhead(preparedWorkspace);
     const prepareIssueWorkspace = vi.fn(
       (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
         void input;
@@ -325,8 +326,9 @@ describe("daemon dispatch", () => {
       "issues",
       "8-dispatch-an-end-to-end-run-through-a-test-provider"
     );
-    await mkdir(workspacePath, { recursive: true });
     await writeValidProject(root, { pollingIntervalMs: 10 });
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
 
     const githubIssuesApi = {
       addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
@@ -347,7 +349,7 @@ describe("daemon dispatch", () => {
     const prepareIssueWorkspace = vi.fn(
       (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
         void input;
-        return Promise.resolve(preparedWorkspaceFixture(root));
+        return Promise.resolve(preparedWorkspace);
       }
     );
 

--- a/tests/dispatch-continuation.test.ts
+++ b/tests/dispatch-continuation.test.ts
@@ -1,5 +1,5 @@
 import Database from "better-sqlite3";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
@@ -11,6 +11,7 @@ import type { AgentProvider, ProviderEvent } from "../src/provider.js";
 import type {
   PreparedIssueWorkspace
 } from "../src/workspace.js";
+import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
 
 const tempRoots: string[] = [];
 
@@ -144,7 +145,8 @@ async function waitForCondition(
 describe("dispatch continuation cap", () => {
   it("schedules continuations up to the cap, then writes a cap-reached failure row", async () => {
     const root = await makeTempRoot();
-    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    const prepared = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(prepared);
     await writeProject(root);
 
     const provider: AgentProvider = {
@@ -176,7 +178,7 @@ describe("dispatch continuation cap", () => {
     const prepareIssueWorkspace = vi.fn(
       (): Promise<PreparedIssueWorkspace> => {
         createCount += 1;
-        return Promise.resolve(preparedWorkspaceFixture(root, createCount > 1));
+        return Promise.resolve({ ...prepared, reused: createCount > 1 });
       }
     );
     let runCounter = 0;
@@ -259,7 +261,8 @@ describe("dispatch continuation cap", () => {
 
   it("does not schedule continuation when refreshed issue is closed", async () => {
     const root = await makeTempRoot();
-    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    const prepared = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(prepared);
     await writeProject(root);
 
     const provider: AgentProvider = {
@@ -286,7 +289,7 @@ describe("dispatch continuation cap", () => {
     };
     const prepareIssueWorkspace = vi.fn(
       (): Promise<PreparedIssueWorkspace> =>
-        Promise.resolve(preparedWorkspaceFixture(root))
+        Promise.resolve(prepared)
     );
 
     const daemon = await startDaemon({
@@ -327,7 +330,8 @@ describe("dispatch continuation cap", () => {
 
   it("does not start scheduled continuation when issue loses eligibility during delay", async () => {
     const root = await makeTempRoot();
-    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    const prepared = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(prepared);
     await writeProject(root);
 
     let runAttemptCount = 0;
@@ -364,7 +368,7 @@ describe("dispatch continuation cap", () => {
     };
     const prepareIssueWorkspace = vi.fn(
       (): Promise<PreparedIssueWorkspace> =>
-        Promise.resolve(preparedWorkspaceFixture(root))
+        Promise.resolve(prepared)
     );
 
     let runCounter = 0;

--- a/tests/dispatch-mutex.test.ts
+++ b/tests/dispatch-mutex.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
@@ -8,6 +8,7 @@ import { startDaemon } from "../src/daemon.js";
 import type { LifecyclePolicy } from "../src/lifecycle/active-runs.js";
 import type { AgentProvider, ProviderEvent } from "../src/provider.js";
 import type { PreparedIssueWorkspace } from "../src/workspace.js";
+import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
 
 const tempRoots: string[] = [];
 
@@ -133,7 +134,8 @@ async function waitForCondition(
 describe("dispatch mutex", () => {
   it("scheduled continuation never runs concurrently with another active dispatch", async () => {
     const root = await makeTempRoot();
-    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    const prepared = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(prepared);
     await writeProject(root, "Work {{issue.number}}\n");
 
     let active = 0;
@@ -174,7 +176,7 @@ describe("dispatch mutex", () => {
     };
     const prepareIssueWorkspace = vi.fn(
       (): Promise<PreparedIssueWorkspace> =>
-        Promise.resolve(preparedWorkspaceFixture(root))
+        Promise.resolve(prepared)
     );
 
     let runCounter = 0;
@@ -208,7 +210,8 @@ describe("dispatch mutex", () => {
 
   it("renders run.continuation as true on continuation runs and false on the fresh run", async () => {
     const root = await makeTempRoot();
-    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    const prepared = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(prepared);
     await writeProject(
       root,
       "Continuation? {{run.continuation}} attempt={{run.attempt}}\n"
@@ -240,7 +243,7 @@ describe("dispatch mutex", () => {
     };
     const prepareIssueWorkspace = vi.fn(
       (): Promise<PreparedIssueWorkspace> =>
-        Promise.resolve(preparedWorkspaceFixture(root))
+        Promise.resolve(prepared)
     );
 
     let runCounter = 0;

--- a/tests/dispatch-project-disable.test.ts
+++ b/tests/dispatch-project-disable.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
@@ -10,6 +10,7 @@ import type { AgentProvider, ProviderEvent } from "../src/provider.js";
 import type {
   PreparedIssueWorkspace
 } from "../src/workspace.js";
+import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
 
 const tempRoots: string[] = [];
 
@@ -145,7 +146,8 @@ async function waitForCondition(
 describe("dispatch project disable", () => {
   it("disabling a project mid-flight does not interrupt the active run; no continuation is scheduled afterwards", async () => {
     const root = await makeTempRoot();
-    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    const prepared = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(prepared);
     await writeProject(root);
 
     let runAttemptCount = 0;
@@ -176,7 +178,7 @@ describe("dispatch project disable", () => {
     };
     const prepareIssueWorkspace = vi.fn(
       (): Promise<PreparedIssueWorkspace> =>
-        Promise.resolve(preparedWorkspaceFixture(root))
+        Promise.resolve(prepared)
     );
 
     const daemon = await startDaemon({
@@ -230,7 +232,6 @@ describe("dispatch project disable", () => {
 
   it("does not dispatch new work when the only project is disabled at startup", async () => {
     const root = await makeTempRoot();
-    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
     await writeProject(root, { disabled: true });
 
     const provider: AgentProvider = {
@@ -284,7 +285,8 @@ describe("dispatch project disable", () => {
 
   it("removing a project mid-flight does not interrupt the active run; no continuation is scheduled afterwards", async () => {
     const root = await makeTempRoot();
-    await mkdir(preparedWorkspaceFixture(root).workspacePath, { recursive: true });
+    const prepared = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(prepared);
     await writeProject(root);
 
     let runAttemptCount = 0;
@@ -313,7 +315,7 @@ describe("dispatch project disable", () => {
     };
     const prepareIssueWorkspace = vi.fn(
       (): Promise<PreparedIssueWorkspace> =>
-        Promise.resolve(preparedWorkspaceFixture(root))
+        Promise.resolve(prepared)
     );
 
     const daemon = await startDaemon({

--- a/tests/dispatch-retry.test.ts
+++ b/tests/dispatch-retry.test.ts
@@ -11,6 +11,7 @@ import type { AgentProvider, ProviderEvent } from "../src/provider.js";
 import type {
   PreparedIssueWorkspace
 } from "../src/workspace.js";
+import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
 
 const tempRoots: string[] = [];
 
@@ -146,7 +147,7 @@ describe("dispatch retry policy", () => {
   it("retries transient failures up to the cap and records retry_count", async () => {
     const root = await makeTempRoot();
     const prepared = preparedWorkspaceFixture(root);
-    await mkdir(prepared.workspacePath, { recursive: true });
+    await createGitWorkspaceAhead(prepared);
     await writeProject(root);
 
     let attempts = 0;

--- a/tests/helpers/git-workspace.ts
+++ b/tests/helpers/git-workspace.ts
@@ -1,0 +1,59 @@
+import { execFile } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type GitWorkspaceFixture = {
+  baseBranch?: string;
+  branchName: string;
+  workspacePath: string;
+};
+
+export async function createGitWorkspaceAhead(
+  fixture: GitWorkspaceFixture
+): Promise<void> {
+  await createGitWorkspace(fixture, { commitWork: true });
+}
+
+export async function createGitWorkspaceAtBase(
+  fixture: GitWorkspaceFixture
+): Promise<void> {
+  await createGitWorkspace(fixture, { commitWork: false });
+}
+
+async function createGitWorkspace(
+  fixture: GitWorkspaceFixture,
+  options: { commitWork: boolean }
+): Promise<void> {
+  const baseBranch = fixture.baseBranch ?? "main";
+  await mkdir(path.dirname(fixture.workspacePath), { recursive: true });
+  await git(["init", "--initial-branch", fixture.branchName, fixture.workspacePath]);
+  await git(["-C", fixture.workspacePath, "config", "user.email", "test@example.com"]);
+  await git(["-C", fixture.workspacePath, "config", "user.name", "Symphonika Test"]);
+  await writeFile(path.join(fixture.workspacePath, "README.md"), "# Fixture\n");
+  await git(["-C", fixture.workspacePath, "add", "README.md"]);
+  await git(["-C", fixture.workspacePath, "commit", "-m", "Base"]);
+  const baseSha = await git(["-C", fixture.workspacePath, "rev-parse", "HEAD"]);
+  await git([
+    "-C",
+    fixture.workspacePath,
+    "update-ref",
+    `refs/remotes/origin/${baseBranch}`,
+    baseSha
+  ]);
+
+  if (!options.commitWork) {
+    return;
+  }
+
+  await writeFile(path.join(fixture.workspacePath, "agent-work.txt"), "done\n");
+  await git(["-C", fixture.workspacePath, "add", "agent-work.txt"]);
+  await git(["-C", fixture.workspacePath, "commit", "-m", "Agent work"]);
+}
+
+async function git(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args);
+  return stdout.trim();
+}

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -18,6 +18,10 @@ import type {
   PreparedIssueWorkspace,
   PrepareIssueWorkspaceInput
 } from "../src/workspace.js";
+import {
+  createGitWorkspaceAhead,
+  createGitWorkspaceAtBase
+} from "./helpers/git-workspace.js";
 
 const tempRoots: string[] = [];
 
@@ -155,7 +159,6 @@ describe("runSmoke", () => {
       "issues",
       issueDirectory
     );
-    await mkdir(workspacePath, { recursive: true });
 
     const githubApi = successfulGitHubApi();
     const githubIssuesApi: GitHubIssuesApi = {
@@ -194,7 +197,7 @@ describe("runSmoke", () => {
     const prepareIssueWorkspace = vi.fn(
       (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
         void input;
-        return Promise.resolve({
+        const prepared = {
           branchName: `sym/symphonika/${issueDirectory}`,
           branchRef: `refs/heads/sym/symphonika/${issueDirectory}`,
           cachePath: path.join(
@@ -208,9 +211,14 @@ describe("runSmoke", () => {
           issueDirectoryName: issueDirectory,
           reused: false,
           workspacePath
-        });
+        };
+        return Promise.resolve(prepared);
       }
     );
+    await createGitWorkspaceAhead({
+      branchName: `sym/symphonika/${issueDirectory}`,
+      workspacePath
+    });
 
     const report = await runSmoke({
       agentProviders: { codex },
@@ -244,6 +252,102 @@ describe("runSmoke", () => {
     await expect(readFile(detail.promptPath, "utf8")).resolves.toContain(
       issueTitle
     );
+  });
+
+  it("surfaces no_workspace_changes when an exit-0 provider leaves the issue branch at base", async () => {
+    const root = await makeTempRoot();
+    await writeBootstrapProject(root);
+
+    const issueNumber = 52;
+    const issueTitle = "Verify provider work before success";
+    const issueDirectory = `${issueNumber}-verify-provider-work-before-success`;
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      issueDirectory
+    );
+    const branchName = `sym/symphonika/${issueDirectory}`;
+    await createGitWorkspaceAtBase({ branchName, workspacePath });
+
+    const githubApi = successfulGitHubApi();
+    const githubIssuesApi: GitHubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        {
+          body: "Exit 0, but no workspace commits.",
+          created_at: "2026-04-20T10:00:00Z",
+          html_url: `https://github.com/pmatos/symphonika/issues/${issueNumber}`,
+          id: 6000 + issueNumber,
+          labels: [{ name: "agent-ready" }],
+          number: issueNumber,
+          state: "open",
+          title: issueTitle,
+          updated_at: "2026-04-21T11:00:00Z"
+        }
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codex: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> =>
+        Promise.resolve({
+          branchName,
+          branchRef: `refs/heads/${branchName}`,
+          cachePath: path.join(
+            root,
+            ".symphonika",
+            "workspaces",
+            "symphonika",
+            ".cache",
+            "repo.git"
+          ),
+          issueDirectoryName: issueDirectory,
+          reused: false,
+          workspacePath
+        })
+    );
+
+    const report = await runSmoke({
+      agentProviders: { codex },
+      configPath: path.join(root, "symphonika.yml"),
+      cwd: root,
+      env: { GITHUB_TOKEN: "test-token" },
+      githubApi,
+      githubIssuesApi,
+      prepareIssueWorkspace
+    });
+
+    expect(report.dispatched).toBe(true);
+    expect(report.ok).toBe(false);
+    expect(report.runDetail).toMatchObject({
+      issueNumber,
+      state: "failed",
+      terminalReason: "no_workspace_changes",
+      workspacePath
+    });
+    expect(report.errors).toHaveLength(1);
+    expect(report.errors[0]).toContain("terminalReason=no_workspace_changes");
+    expect(githubIssuesApi.addLabelsToIssue).toHaveBeenCalledWith({
+      issueNumber,
+      labels: ["sym:failed"],
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "test-token"
+    });
   });
 
   it("surfaces a failed terminal run state when the provider reports turn_failed", async () => {


### PR DESCRIPTION
Summary
- require exit-0 provider runs to prove the workspace branch is ahead of origin/base before marking success
- classify zero-ahead branches as deterministic no_workspace_changes and git inspection errors as workspace_inspection_failed
- update tests and SPEC.md for the new success contract

Validation
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #52