### PR TITLE
Add daemon poll-now trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ npm link && symphonika daemon    # link the bin once, then run from anywhere
 
 Set `PINO_LOG_LEVEL=debug` (or the alias `LOG_LEVEL=debug`) to raise daemon log verbosity for per-tick visibility, e.g. `PINO_LOG_LEVEL=debug npm run dev -- daemon`. Accepted values match pino's level set: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `silent`.
 
+While the daemon is running, force a debugging poll without waiting for the configured interval:
+
+```sh
+npm run dev -- poll-now --config symphonika.yml
+```
+
+The command discovers `.symphonika/daemon.json`, preflights that the daemon reports the same state root, then posts to the local `/api/poll-now` endpoint. The daemon uses the same reconcile, polling, and dispatch gates as interval ticks, so invalid Projects, operational labels, excluded labels, active runs, and the dispatch mutex still apply.
+
 The `symphony/` directory in the tree is a git submodule of an unrelated upstream project (`openai/symphony`) used as a reference — it is not a launcher for Symphonika.
 
 ## Self-Hosting

--- a/SPEC.md
+++ b/SPEC.md
@@ -397,8 +397,9 @@ On daemon startup:
 
 Default poll interval: `30000` ms.
 
-Manual poll-now triggers may exist in CLI or UI/API. Validation and status commands must not
-dispatch work.
+Manual poll-now triggers may exist in CLI or UI/API. They run the same daemon reconcile, polling,
+and dispatch gates as interval ticks, and may queue or coalesce when another manual poll is already
+pending. Validation and status commands must not dispatch work.
 
 ### 8.3 Multi-Project Dispatch
 
@@ -705,6 +706,7 @@ Bootstrap CLI commands:
 - `symphonika init-project <name> --config <path>`
 - `symphonika daemon --config <path> [--port <port>]`
 - `symphonika status --config <path>`
+- `symphonika poll-now --config <path>`
 - `symphonika runs --config <path>`
 - `symphonika show-run <run-id> --config <path>`
 - `symphonika cancel <run-id> --config <path>`
@@ -743,7 +745,8 @@ The UI is primarily read-only. It shows:
 - rendered prompt links
 - retry and continuation state
 
-The only v1 mutating web action is explicit active-run cancellation.
+The v1 mutating web actions are explicit active-run cancellation and a manual poll-now trigger that
+uses the normal daemon scheduler path.
 
 Label creation, stale-claim reset, and workspace cleanup remain CLI-only.
 

--- a/docs/adr/0027-mostly-read-only-local-web-ui.md
+++ b/docs/adr/0027-mostly-read-only-local-web-ui.md
@@ -1,3 +1,3 @@
 # Mostly read-only local web UI
 
-The Symphonika v1 local web UI will be primarily an observability console for Projects, issues, runs, attempts, normalized events, raw logs, and validation status. The only mutating v1 action exposed in the web UI is explicit active-run cancellation; label creation, stale-claim reset, and workspace cleanup remain CLI-only.
+The Symphonika v1 local web UI will be primarily an observability console for Projects, issues, runs, attempts, normalized events, raw logs, and validation status. The mutating v1 actions exposed through the local web/API surface are explicit active-run cancellation and the manual poll-now trigger from ADR-0036; poll-now reuses the daemon scheduler path rather than bypassing dispatch gates. Label creation, stale-claim reset, and workspace cleanup remain CLI-only.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,6 +60,19 @@ type DaemonStatusResponse = {
   stateRoot?: string;
 };
 
+type PollNowResponse = {
+  candidateIssues: number;
+  dispatching: boolean;
+  errors: number;
+  filteredIssues: number;
+  issuePolling: {
+    errors: string[];
+    projects: ProjectIssuePollReport[];
+  };
+  kind: "coalesced" | "queued";
+  state: "dispatching" | "idle";
+};
+
 export function buildCli(dependencies: CliDependencies = {}): Command {
   const doctor = dependencies.runDoctor ?? runDoctor;
   const initProject = dependencies.runInitProject ?? runInitProject;
@@ -360,6 +373,45 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     });
 
   program
+    .command("poll-now")
+    .description("ask the running daemon to reconcile and poll immediately")
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .option("--daemon-url <url>", "local daemon base URL")
+    .action(async (options: { config: string; daemonUrl?: string }) => {
+      const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
+      const daemonUrl = resolveDaemonUrl(stateRoot, options.daemonUrl);
+      if (daemonUrl === undefined) {
+        const descriptorPath = daemonEndpointPath(stateRoot);
+        writeErr(
+          program,
+          `poll-now failed: daemon endpoint not found at ${descriptorPath}\n`
+        );
+        program.error("poll-now failed: daemon endpoint not found", {
+          exitCode: 1
+        });
+        return;
+      }
+
+      const daemonStatus = await fetchDaemonStatus(fetcher, daemonUrl, stateRoot);
+      if (daemonStatus.kind === "unavailable") {
+        writeErr(program, `poll-now failed: ${daemonStatus.error}\n`);
+        program.error(`poll-now failed: ${daemonStatus.error}`, {
+          exitCode: 1
+        });
+        return;
+      }
+
+      const outcome = await postPollNow(fetcher, daemonUrl);
+      if (!outcome.ok) {
+        writeErr(program, `poll-now failed: ${outcome.error}\n`);
+        program.error(`poll-now failed: ${outcome.error}`, { exitCode: 1 });
+        return;
+      }
+
+      printPollNowResult(program, outcome.response);
+    });
+
+  program
     .command("runs")
     .description("list runs from the run store")
     .option("--config <path>", "service config path", "symphonika.yml")
@@ -631,6 +683,142 @@ async function postCancel(
   };
 }
 
+async function postPollNow(
+  fetcher: FetchFn,
+  daemonUrl: string
+): Promise<
+  | { ok: false; error: string }
+  | { ok: true; response: PollNowResponse }
+> {
+  let response: Response;
+  try {
+    response = await fetcher(`${daemonUrl}/api/poll-now`, { method: "POST" });
+  } catch (error) {
+    return { error: errorMessage(error), ok: false };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+
+  if (!response.ok) {
+    const error =
+      isObject(body) && typeof body.error === "string"
+        ? body.error
+        : `daemon returned HTTP ${response.status}`;
+    return { error, ok: false };
+  }
+
+  const parsed = readPollNowResponse(body);
+  if (parsed === undefined) {
+    return {
+      error: "daemon returned an unexpected poll-now response",
+      ok: false
+    };
+  }
+  return { ok: true, response: parsed };
+}
+
+function readPollNowResponse(value: unknown): PollNowResponse | undefined {
+  if (!isObject(value)) {
+    return undefined;
+  }
+  const kind = value.kind;
+  if (kind !== "queued" && kind !== "coalesced") {
+    return undefined;
+  }
+  const candidateIssues = readNonnegativeNumber(value.candidateIssues);
+  const filteredIssues = readNonnegativeNumber(value.filteredIssues);
+  const errors = readNonnegativeNumber(value.errors);
+  if (
+    candidateIssues === undefined ||
+    filteredIssues === undefined ||
+    errors === undefined
+  ) {
+    return undefined;
+  }
+  const dispatching =
+    typeof value.dispatching === "boolean" ? value.dispatching : false;
+  const state =
+    value.state === "dispatching" || dispatching ? "dispatching" : "idle";
+
+  return {
+    candidateIssues,
+    dispatching,
+    errors,
+    filteredIssues,
+    issuePolling: readPollNowIssuePolling(value.issuePolling),
+    kind,
+    state
+  };
+}
+
+function readPollNowIssuePolling(value: unknown): PollNowResponse["issuePolling"] {
+  if (!isObject(value)) {
+    return { errors: [], projects: [] };
+  }
+  return {
+    errors: Array.isArray(value.errors)
+      ? value.errors.filter((error): error is string => typeof error === "string")
+      : [],
+    projects: readPollNowProjects(value.projects)
+  };
+}
+
+function readPollNowProjects(value: unknown): ProjectIssuePollReport[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const projects: ProjectIssuePollReport[] = [];
+  for (const entry of value) {
+    if (
+      !isObject(entry) ||
+      typeof entry.name !== "string" ||
+      typeof entry.ok !== "boolean"
+    ) {
+      continue;
+    }
+    const fetchedIssues = readNonnegativeNumber(entry.fetchedIssues);
+    if (fetchedIssues === undefined) {
+      continue;
+    }
+    const project: ProjectIssuePollReport = {
+      fetchedIssues,
+      name: entry.name,
+      ok: entry.ok
+    };
+    const candidateIssues = readNonnegativeNumber(entry.candidateIssues);
+    if (candidateIssues !== undefined) {
+      project.candidateIssues = candidateIssues;
+    }
+    const filteredIssues = readNonnegativeNumber(entry.filteredIssues);
+    if (filteredIssues !== undefined) {
+      project.filteredIssues = filteredIssues;
+    }
+    const weight = readNonnegativeNumber(entry.weight);
+    if (weight !== undefined) {
+      project.weight = weight;
+    }
+    if (typeof entry.lastPolledAt === "string") {
+      project.lastPolledAt = entry.lastPolledAt;
+    }
+    if (typeof entry.error === "string") {
+      project.error = entry.error;
+    }
+    projects.push(project);
+  }
+  return projects;
+}
+
+function readNonnegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
 function readRunState(value: unknown): RunState | undefined {
   if (!isObject(value) || typeof value.state !== "string") {
     return undefined;
@@ -792,6 +980,38 @@ function formatLastPollOutcome(
         : `${project.name} failed (${project.error ?? "unknown error"})`
     )
     .join("; ");
+}
+
+function printPollNowResult(program: Command, result: PollNowResponse): void {
+  writeOut(program, `poll-now ${result.kind}\n`);
+  writeOut(program, `state:     ${result.state}\n`);
+  writeOut(program, `candidate: ${result.candidateIssues}\n`);
+  writeOut(program, `filtered:  ${result.filteredIssues}\n`);
+  writeOut(program, `errors:    ${result.errors}\n`);
+  if (result.issuePolling.projects.length > 0) {
+    writeOut(program, "projects:\n");
+    for (const project of result.issuePolling.projects) {
+      writeOut(program, `  ${formatPollNowProject(project)}\n`);
+    }
+  }
+  if (result.issuePolling.errors.length > 0) {
+    writeOut(program, "poll errors:\n");
+    for (const error of result.issuePolling.errors) {
+      writeOut(program, `  - ${error}\n`);
+    }
+  }
+}
+
+function formatPollNowProject(project: ProjectIssuePollReport): string {
+  if (!project.ok) {
+    return `${project.name} failed (${project.error ?? "unknown error"})`;
+  }
+  return [
+    `${project.name} ok`,
+    `(${project.fetchedIssues} fetched,`,
+    `${project.candidateIssues ?? 0} candidate,`,
+    `${project.filteredIssues ?? 0} filtered)`
+  ].join(" ");
 }
 
 function projectCursorFromStatus(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5,7 +5,7 @@ import type { Logger } from "pino";
 import pino from "pino";
 import { parse } from "yaml";
 
-import { createHttpApp } from "./http/app.js";
+import { createHttpApp, type PollNowResult } from "./http/app.js";
 import {
   removeDaemonEndpoint,
   writeDaemonEndpoint
@@ -115,6 +115,7 @@ export async function startDaemon(
   let scheduledWork = Promise.resolve();
   let lastPollErrorsKey = "";
   let lastPullRequestFollowupAt = Date.now();
+  let pendingPollNow: Promise<PollNowResult> | undefined;
   const inflightDispatches = new Set<Promise<void>>();
   const projectsLoader = async (): Promise<
     Map<string, RunControllerProjectConfig>
@@ -344,6 +345,44 @@ export async function startDaemon(
   const scheduleTick = (): void => {
     enqueueScheduledWork(tick);
   };
+  const pollNowSummary = (kind: PollNowResult["kind"]): PollNowResult => ({
+    candidateIssues: issuePollStatus.candidateIssues.length,
+    dispatching: dispatchMutex.held,
+    errors: issuePollStatus.errors.length,
+    filteredIssues: issuePollStatus.filteredIssues.length,
+    issuePolling: {
+      errors: issuePollStatus.errors.slice(),
+      projects: issuePollStatus.projects.map((project) => ({ ...project }))
+    },
+    kind,
+    state: dispatchMutex.held ? "dispatching" : "idle"
+  });
+  const triggerPollNow = (): Promise<PollNowResult> => {
+    if (pendingPollNow !== undefined) {
+      return pendingPollNow.then((result) => ({
+        ...result,
+        kind: "coalesced"
+      }));
+    }
+
+    const queued = new Promise<PollNowResult>((resolve, reject) => {
+      enqueueScheduledWork(async () => {
+        try {
+          await tick();
+          resolve(pollNowSummary("queued"));
+        } catch (error) {
+          const reason =
+            error instanceof Error ? error : new Error(errorMessage(error));
+          reject(reason);
+          throw reason;
+        }
+      });
+    });
+    pendingPollNow = queued.finally(() => {
+      pendingPollNow = undefined;
+    });
+    return pendingPollNow;
+  };
 
   let intervalMs: number | undefined;
   if (state.configExists) {
@@ -396,6 +435,7 @@ export async function startDaemon(
         stateRoot: state.stateRoot
       }),
     issuePollStatus,
+    pollNow: triggerPollNow,
     runStore,
     stateRoot: state.stateRoot,
     version: VERSION

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -5,7 +5,10 @@ import { Readable } from "node:stream";
 
 import { Hono, type Context } from "hono";
 
-import type { IssuePollStatus } from "../issue-polling.js";
+import type {
+  IssuePollStatus,
+  ProjectIssuePollReport
+} from "../issue-polling.js";
 import { emptyIssuePollStatus } from "../issue-polling.js";
 import { isPathInside } from "../path-safety.js";
 import type { StatusSnapshot } from "../status.js";
@@ -30,6 +33,21 @@ export type CancelRunFn = (
       | { kind: "already-terminal"; state: RunState }
     >;
 
+export type PollNowResult = {
+  candidateIssues: number;
+  dispatching: boolean;
+  errors: number;
+  filteredIssues: number;
+  issuePolling: {
+    errors: string[];
+    projects: ProjectIssuePollReport[];
+  };
+  kind: "coalesced" | "queued";
+  state: "dispatching" | "idle";
+};
+
+export type PollNowFn = () => PollNowResult | Promise<PollNowResult>;
+
 export type HttpAppOptions = {
   cancelRun?: CancelRunFn;
   dispatchRuntime?: {
@@ -51,6 +69,7 @@ export type HttpAppOptions = {
   getStatusSnapshot?: () => StatusSnapshot;
   issuePollStatus?: IssuePollStatus;
   now?: () => number;
+  pollNow?: PollNowFn;
   runStore?: RunStore;
   startedAtMs?: number;
   stateRoot: string;
@@ -184,6 +203,17 @@ export function createHttpApp(options: HttpAppOptions): Hono {
       uptimeMs: uptimeMs(startedAtMs, now)
     })
   );
+
+  app.post("/api/poll-now", async (context) => {
+    if (options.pollNow === undefined) {
+      return context.json(
+        { error: "poll-now trigger unavailable", kind: "unavailable" },
+        503
+      );
+    }
+
+    return context.json(await Promise.resolve(options.pollNow()));
+  });
 
   if (runStore !== undefined) {
     app.get("/api/runs", (context) => {

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -503,6 +503,129 @@ describe("CLI run commands", () => {
     verifyStore.close();
   });
 
+  it("poll-now discovers the local daemon, preflights state root, and prints the poll summary", async () => {
+    const stateRoot = await makeTempRoot();
+    const cfg = path.join(stateRoot, "symphonika.yml");
+    const resolvedStateRoot = path.join(stateRoot, ".symphonika");
+    await mkdir(resolvedStateRoot, { recursive: true });
+    await writeFile(
+      path.join(resolvedStateRoot, "daemon.json"),
+      JSON.stringify({ url: "http://127.0.0.1:3030" }),
+      "utf8"
+    );
+    const requests: Array<{ method: string; url: string }> = [];
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        requests.push({ method: init?.method ?? "GET", url });
+        if (url.endsWith("/api/status")) {
+          return Promise.resolve(
+            Response.json({ state: "idle", stateRoot: resolvedStateRoot })
+          );
+        }
+        return Promise.resolve(
+          Response.json({
+            candidateIssues: 2,
+            dispatching: false,
+            errors: 0,
+            filteredIssues: 1,
+            issuePolling: {
+              errors: [],
+              projects: [
+                {
+                  candidateIssues: 2,
+                  fetchedIssues: 3,
+                  filteredIssues: 1,
+                  name: "alpha",
+                  ok: true
+                }
+              ]
+            },
+            kind: "queued",
+            state: "idle"
+          })
+        );
+      }
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "poll-now",
+      "--config",
+      cfg
+    ]);
+
+    expect(output.stdout).toContain("poll-now queued");
+    expect(output.stdout).toContain("candidate: 2");
+    expect(output.stdout).toContain("filtered:  1");
+    expect(output.stdout).toContain("errors:    0");
+    expect(output.stdout).toContain("alpha ok (3 fetched, 2 candidate, 1 filtered)");
+    expect(requests).toEqual([
+      { method: "GET", url: "http://127.0.0.1:3030/api/status" },
+      { method: "POST", url: "http://127.0.0.1:3030/api/poll-now" }
+    ]);
+  });
+
+  it("poll-now refuses a daemon endpoint for another state root", async () => {
+    const stateRoot = await makeTempRoot();
+    const requests: string[] = [];
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: (input: string | URL | Request) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        requests.push(url);
+        if (url.endsWith("/api/status")) {
+          return Promise.resolve(
+            Response.json({ stateRoot: path.join(stateRoot, "..", "other") })
+          );
+        }
+        return Promise.resolve(Response.json({ kind: "queued" }));
+      }
+    });
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "symphonika",
+        "poll-now",
+        "--config",
+        path.join(stateRoot, "symphonika.yml"),
+        "--daemon-url",
+        "http://127.0.0.1:3030"
+      ])
+    ).rejects.toThrow();
+
+    expect(output.stderr).toContain("state root mismatch");
+    expect(requests).toEqual(["http://127.0.0.1:3030/api/status"]);
+  });
+
+  it("poll-now errors when no daemon endpoint descriptor is present", async () => {
+    const stateRoot = await makeTempRoot();
+    const { output, program } = captureProgram(stateRoot);
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "symphonika",
+        "poll-now",
+        "--config",
+        path.join(stateRoot, "symphonika.yml")
+      ])
+    ).rejects.toThrow();
+
+    expect(output.stderr).toContain("poll-now failed: daemon endpoint not found");
+  });
+
   it("cancel refuses a daemon endpoint for another state root", async () => {
     const stateRoot = await makeTempRoot();
     const requests: string[] = [];

--- a/tests/daemon-issue-polling.test.ts
+++ b/tests/daemon-issue-polling.test.ts
@@ -317,6 +317,82 @@ describe("daemon GitHub issue polling", () => {
     }
   });
 
+  it("coalesces concurrent poll-now requests into one manual polling cycle", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const manualPoll = deferred<ReturnType<typeof issueFixture>[]>();
+    const githubIssuesApi = {
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: [],
+            number: 79,
+            title: "Startup snapshot"
+          })
+        ])
+        .mockImplementationOnce(() => manualPoll.promise)
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      const first = fetch(`${daemon.url}/api/poll-now`, { method: "POST" });
+      await waitFor(() =>
+        Promise.resolve(githubIssuesApi.listOpenIssues.mock.calls.length >= 2)
+      );
+      const second = fetch(`${daemon.url}/api/poll-now`, { method: "POST" });
+      manualPoll.resolve([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 80,
+          title: "Manual poll snapshot"
+        })
+      ]);
+
+      const [firstResponse, secondResponse] = await Promise.all([
+        first,
+        second
+      ]);
+      const firstBody = (await firstResponse.json()) as {
+        candidateIssues: number;
+        kind: string;
+      };
+      const secondBody = (await secondResponse.json()) as {
+        candidateIssues: number;
+        kind: string;
+      };
+
+      expect(firstResponse.status).toBe(200);
+      expect(secondResponse.status).toBe(200);
+      expect(firstBody).toMatchObject({
+        candidateIssues: 1,
+        kind: "queued"
+      });
+      expect(secondBody).toMatchObject({
+        candidateIssues: 1,
+        kind: "coalesced"
+      });
+      expect(githubIssuesApi.listOpenIssues).toHaveBeenCalledTimes(2);
+
+      const statusResponse = await fetch(`${daemon.url}/api/status`);
+      const status = (await statusResponse.json()) as {
+        candidateIssues: Array<{ issue: { number: number } }>;
+      };
+      expect(status.candidateIssues.map((entry) => entry.issue.number)).toEqual([
+        80
+      ]);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("marks GitHub issues stale when sym:claimed is present and no live run exists", async () => {
     const root = await makeTempRoot();
     await writeValidProject(root);
@@ -578,4 +654,18 @@ async function waitFor(
   }
 
   throw new Error("condition was not met before timeout");
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T) => void;
+} {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
 }

--- a/tests/http-app.test.ts
+++ b/tests/http-app.test.ts
@@ -158,4 +158,61 @@ describe("HTTP app", () => {
       runStore.close();
     }
   });
+
+  it("POST /api/poll-now invokes the daemon trigger and returns a poll summary", async () => {
+    let calls = 0;
+    const app = createHttpApp({
+      pollNow: () => {
+        calls += 1;
+        return Promise.resolve({
+          candidateIssues: 2,
+          dispatching: false,
+          errors: 0,
+          filteredIssues: 1,
+          issuePolling: {
+            errors: [],
+            projects: [
+              {
+                candidateIssues: 2,
+                fetchedIssues: 3,
+                filteredIssues: 1,
+                name: "alpha",
+                ok: true
+              }
+            ]
+          },
+          kind: "queued",
+          state: "idle"
+        });
+      },
+      stateRoot: "/tmp/symphonika-state",
+      version: "0.1.0"
+    });
+
+    const response = await app.request("/api/poll-now", { method: "POST" });
+    const body: unknown = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(calls).toBe(1);
+    expect(body).toEqual({
+      candidateIssues: 2,
+      dispatching: false,
+      errors: 0,
+      filteredIssues: 1,
+      issuePolling: {
+        errors: [],
+        projects: [
+          {
+            candidateIssues: 2,
+            fetchedIssues: 3,
+            filteredIssues: 1,
+            name: "alpha",
+            ok: true
+          }
+        ]
+      },
+      kind: "queued",
+      state: "idle"
+    });
+  });
 });


### PR DESCRIPTION
Summary:
- add POST /api/poll-now with queued/coalesced manual daemon ticks
- add symphonika poll-now CLI discovery, state-root preflight, and summary output
- document the operator debugging poll path and ADR/API scope

Tests:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #80