### PR TITLE
Fix Claude Code Review permissions and add local smoke runner

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,15 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "tsx src/cli.ts",
     "lint": "eslint .",
     "smoke": "tsx src/cli.ts smoke",
+    "smoke:local": "scripts/smoke.sh",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -44,9 +44,43 @@ require_bin git
 require_bin node
 require_bin npm
 
-# `codex` is the provider declared in symphonika.yml. If you switch to claude,
-# require `claude` here instead.
-require_bin codex
+if [[ ! -d node_modules ]]; then
+  echo "smoke: installing dependencies"
+  npm ci
+fi
+
+# Resolve the provider binaries to require from the chosen config so a Claude
+# config doesn't fail the preflight just because Codex is missing (and vice
+# versa). Symphonika v1 supports both Codex and Claude providers.
+mapfile -t PROVIDER_BINS < <(node -e '
+  const fs = require("fs");
+  const yaml = require("yaml");
+  const cfg = yaml.parse(fs.readFileSync(process.argv[1], "utf8"));
+  const projects = Array.isArray(cfg.projects) ? cfg.projects : [];
+  const providers = (cfg.providers && typeof cfg.providers === "object") ? cfg.providers : {};
+  const seen = new Set();
+  for (const project of projects) {
+    if (project && project.disabled === true) continue;
+    const name = project && project.agent && project.agent.provider;
+    const command = name && providers[name] && providers[name].command;
+    if (typeof command !== "string" || command.trim() === "") continue;
+    const binary = command.trim().split(/\s+/)[0];
+    if (binary && !seen.has(binary)) {
+      seen.add(binary);
+      process.stdout.write(binary + "\n");
+    }
+  }
+' "${CONFIG_PATH}")
+
+if [[ ${#PROVIDER_BINS[@]} -eq 0 ]]; then
+  echo "smoke: could not resolve any provider binary from ${CONFIG_PATH}" >&2
+  echo "       check that projects[].agent.provider matches a providers[] entry with a command" >&2
+  exit 1
+fi
+
+for bin in "${PROVIDER_BINS[@]}"; do
+  require_bin "$bin"
+done
 
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
   if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
@@ -58,11 +92,6 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     echo "       export GITHUB_TOKEN=... or run 'gh auth login'" >&2
     exit 1
   fi
-fi
-
-if [[ ! -d node_modules ]]; then
-  echo "smoke: installing dependencies"
-  npm ci
 fi
 
 exec npm run --silent smoke -- --config "${CONFIG_PATH}" "${FORWARDED_ARGS[@]}"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Run `symphonika smoke` against the local checkout, after preflighting the
+# tools and credentials that the configured provider and tracker need.
+#
+# Usage: scripts/smoke.sh [--config <path>] [extra args forwarded to npm run smoke]
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+CONFIG_PATH="symphonika.yml"
+FORWARDED_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)
+      CONFIG_PATH="$2"
+      shift 2
+      ;;
+    --config=*)
+      CONFIG_PATH="${1#*=}"
+      shift
+      ;;
+    *)
+      FORWARDED_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ! -f "${CONFIG_PATH}" ]]; then
+  echo "smoke: config not found at ${CONFIG_PATH}" >&2
+  exit 1
+fi
+
+require_bin() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "smoke: missing required binary: $1" >&2
+    echo "       install it and try again" >&2
+    exit 1
+  fi
+}
+
+require_bin git
+require_bin node
+require_bin npm
+
+# `codex` is the provider declared in symphonika.yml. If you switch to claude,
+# require `claude` here instead.
+require_bin codex
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
+    GITHUB_TOKEN="$(gh auth token)"
+    export GITHUB_TOKEN
+    echo "smoke: GITHUB_TOKEN sourced from gh CLI"
+  else
+    echo "smoke: GITHUB_TOKEN is not set and gh CLI is not authenticated" >&2
+    echo "       export GITHUB_TOKEN=... or run 'gh auth login'" >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -d node_modules ]]; then
+  echo "smoke: installing dependencies"
+  npm ci
+fi
+
+exec npm run --silent smoke -- --config "${CONFIG_PATH}" "${FORWARDED_ARGS[@]}"


### PR DESCRIPTION
## Summary
- Grant `pull-requests: write` and `issues: write` to the Claude Code Review job so it can actually post review comments. Previously the job ran for ~9 min and exited successfully but with `permission_denials_count: 4` and `No buffered inline comments`, so PRs got zero feedback.
- Bump `actions/checkout` to `v6` (matches `ci.yml`) and add `persist-credentials: false`, clearing the Node.js 20 deprecation warning.
- Add `scripts/smoke.sh` and a `npm run smoke:local` alias so the smoke flow can be exercised against the configured `codex` provider without flipping the opt-in CI smoke job (which in its current shape would fail anyway because the runner image has no `codex` binary). The script preflights `git`/`node`/`codex` and falls back to `gh auth token` when `GITHUB_TOKEN` is not exported.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (249 passing on Node 25 locally)
- [x] `bash -n scripts/smoke.sh` (syntax check)
- [ ] Verify Claude Code Review posts comments on this PR