### PR TITLE
Add runtime config hot reload

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -175,6 +175,12 @@ The default service config file is `symphonika.yml`.
 It is reloadable and owned by the orchestrator. It lists Projects and service-level runtime
 settings.
 
+v1 implements reload by defensively re-reading `symphonika.yml` on each daemon tick and manual
+poll-now trigger. A valid reload replaces the effective snapshot used for future polling,
+dispatch, retry, continuation, provider-command selection, and PR follow-up policy. An invalid
+reload is surfaced in structured logs and operator status while the daemon keeps using the last
+known good effective snapshot.
+
 Example:
 
 ```yaml
@@ -238,6 +244,12 @@ Each Project must reference a valid `WORKFLOW.md`.
 
 `WORKFLOW.md` is reloadable and repository-owned. It contains the prompt body and may contain
 optional YAML front matter for prompt-adjacent execution policy.
+
+Workflow contracts are re-read as part of the daemon's defensive service-config reload. A valid
+workflow edit applies to future attempts. In-flight attempts keep the rendered prompt and workflow
+content hash captured when the attempt was created. If a reload sees an invalid workflow for an
+existing Project, the daemon reports the reload error and keeps the last known good effective
+workflow snapshot for future work until a valid reload is available.
 
 Service discovery, tracker settings, workspace roots, provider selection, and GitHub labels belong
 in `symphonika.yml`, not in `WORKFLOW.md`.

--- a/docs/adr/0008-hot-reload-service-config-and-workflow-contracts.md
+++ b/docs/adr/0008-hot-reload-service-config-and-workflow-contracts.md
@@ -1,3 +1,5 @@
 # Hot-reload service config and workflow contracts
 
 Symphonika will hot-reload both the orchestrator-owned service config and each repository-owned workflow contract. Project additions, removals, and configuration edits should not require restarting the daemon, while in-flight runs continue using the configuration snapshot they started with so run behavior remains explainable.
+
+The bootstrap implementation uses defensive re-read semantics rather than filesystem watchers: every daemon tick and manual poll-now trigger attempts to reload `symphonika.yml` plus the referenced `WORKFLOW.md` files before polling and dispatch. Successful reloads replace the effective snapshot for future work. Invalid reloads are operator-visible in structured logs, CLI/API status, and the local status API, but do not discard the last known good effective snapshot.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import type {
 } from "./doctor.js";
 import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
 import type { ProjectIssuePollReport } from "./issue-polling.js";
+import type { RuntimeReloadStatus } from "./reload.js";
 import type {
   ListRunsFilter,
   OpenRunStoreOptions,
@@ -55,6 +56,7 @@ type DaemonStatusResponse = {
     projects?: ProjectIssuePollReport[];
   };
   projectStates?: ProjectState[];
+  reload?: RuntimeReloadStatus;
   staleIssues?: unknown[];
   state?: string;
   stateRoot?: string;
@@ -308,6 +310,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
             program,
             `daemon: ${formatDaemonAvailability(daemonStatus, daemonUrl)}\n`
           );
+          writeOut(program, `config reload: ${formatReloadOutcome(daemonStatus)}\n`);
         }
         writeOut(program, "\nProjects:\n");
         if (report.projects.length === 0) {
@@ -980,6 +983,25 @@ function formatLastPollOutcome(
         : `${project.name} failed (${project.error ?? "unknown error"})`
     )
     .join("; ");
+}
+
+function formatReloadOutcome(
+  daemonStatus:
+    | { kind: "available"; status: DaemonStatusResponse }
+    | { kind: "unavailable"; error: string }
+): string {
+  if (daemonStatus.kind === "unavailable") {
+    return `unknown (${daemonStatus.error})`;
+  }
+  const reload = daemonStatus.status.reload;
+  if (reload === undefined) {
+    return "unknown";
+  }
+  if (reload.ok) {
+    return reload.lastLoadedAt === null ? "not yet loaded" : `ok at ${reload.lastLoadedAt}`;
+  }
+  const suffix = reload.usingLastKnownGood ? " (using last known good)" : "";
+  return `failed${suffix}: ${reload.errors.join("; ")}`;
 }
 
 function printPollNowResult(program: Command, result: PollNowResponse): void {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -13,8 +13,10 @@ import {
 import type { GitHubIssuesApi } from "./issue-polling.js";
 import {
   DEFAULT_GITHUB_ISSUES_API,
+  DEFAULT_POLLING_INTERVAL_MS,
   emptyIssuePollStatus,
   pollConfiguredGitHubIssuesFromConfig,
+  readConfiguredPollingIntervalMs,
   replaceIssuePollStatus
 } from "./issue-polling.js";
 import { ActiveRunRegistry } from "./lifecycle/active-runs.js";
@@ -347,10 +349,10 @@ export async function startDaemon(
     if (!state.configExists) {
       return;
     }
-    const nextIntervalMs = runtimeConfig.getSnapshot()?.pollingIntervalMs;
-    if (nextIntervalMs === undefined) {
-      return;
-    }
+    const nextIntervalMs =
+      runtimeConfig.getSnapshot()?.pollingIntervalMs ??
+      intervalMs ??
+      DEFAULT_POLLING_INTERVAL_MS;
     if (nextIntervalMs === intervalMs) {
       return;
     }
@@ -410,7 +412,9 @@ export async function startDaemon(
   let intervalMs: number | undefined;
   if (state.configExists) {
     await refreshIssuePollStatus();
-    intervalMs = runtimeConfig.getSnapshot()?.pollingIntervalMs;
+    intervalMs =
+      runtimeConfig.getSnapshot()?.pollingIntervalMs ??
+      (await readConfiguredPollingIntervalMs(state.configPath));
   }
   const TERMINAL_STATES = new Set<RunState>([
     "cancelled",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -10,17 +10,11 @@ import {
   removeDaemonEndpoint,
   writeDaemonEndpoint
 } from "./daemon-endpoint.js";
-import type {
-  GitHubIssuesApi,
-  PollConfiguredGitHubIssuesOptions,
-  PollingProjectConfig
-} from "./issue-polling.js";
+import type { GitHubIssuesApi } from "./issue-polling.js";
 import {
   DEFAULT_GITHUB_ISSUES_API,
   emptyIssuePollStatus,
-  loadPollingProjectsByName,
-  pollConfiguredGitHubIssues,
-  readConfiguredPollingIntervalMs,
+  pollConfiguredGitHubIssuesFromConfig,
   replaceIssuePollStatus
 } from "./issue-polling.js";
 import { ActiveRunRegistry } from "./lifecycle/active-runs.js";
@@ -38,6 +32,7 @@ import { detectStaleClaims } from "./lifecycle/stale-claims.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
 import { runPullRequestFollowup } from "./pull-request-followup.js";
+import { RuntimeConfigReloader } from "./reload.js";
 import {
   openRunStore,
   type RunState,
@@ -103,6 +98,10 @@ export async function startDaemon(
   }
   const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;
   const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
+  const runtimeConfig = new RuntimeConfigReloader({
+    configPath: state.configPath,
+    logger
+  });
   const activeRuns = new ActiveRunRegistry();
   const dispatchMutex = createAsyncMutex();
   const dispatchRuntime = {
@@ -117,30 +116,13 @@ export async function startDaemon(
   let lastPullRequestFollowupAt = Date.now();
   let pendingPollNow: Promise<PollNowResult> | undefined;
   const inflightDispatches = new Set<Promise<void>>();
-  const projectsLoader = async (): Promise<
+  const projectsLoader = (): Promise<
     Map<string, RunControllerProjectConfig>
   > => {
-    if (!state.configExists) {
-      return new Map();
-    }
-    const map = await loadPollingProjectsByName(state.configPath);
-    const enriched = new Map<string, RunControllerProjectConfig>();
-    const richDetails = await loadRichProjects(state.configPath);
-    for (const [name, project] of map) {
-      const detail = richDetails.get(name);
-      if (detail === undefined) {
-        continue;
-      }
-      enriched.set(name, {
-        ...project,
-        workflow: detail.workflow,
-        workspace: detail.workspace
-      });
-    }
-    return enriched;
+    return Promise.resolve(runtimeConfig.projectsByName());
   };
-  const providersLoader = async (): Promise<RunControllerProvidersConfig> => {
-    return loadProvidersConfig(state.configPath);
+  const providersLoader = (): Promise<RunControllerProvidersConfig> => {
+    return Promise.resolve(runtimeConfig.providersConfig());
   };
   const enqueueScheduledWork = (work: () => Promise<void>): void => {
     scheduledWork = scheduledWork.then(work, work);
@@ -204,9 +186,25 @@ export async function startDaemon(
 
     polling = true;
     try {
-      const nextStatus = await pollConfiguredGitHubIssues(
-        issuePollOptions(state.configPath, options)
-      );
+      const snapshot = await runtimeConfig.reload();
+      const reloadStatus = runtimeConfig.getStatus();
+      if (snapshot === undefined) {
+        replaceIssuePollStatus(issuePollStatus, {
+          candidateIssues: [],
+          errors: reloadStatus.errors,
+          filteredIssues: [],
+          projects: []
+        });
+        return;
+      }
+      const nextStatus = await pollConfiguredGitHubIssuesFromConfig({
+        config: snapshot.polling,
+        ...(options.env === undefined ? {} : { env: options.env }),
+        ...(options.githubIssuesApi === undefined
+          ? {}
+          : { githubIssuesApi: options.githubIssuesApi }),
+        initialErrors: reloadStatus.errors
+      });
       replaceIssuePollStatus(issuePollStatus, nextStatus);
       await persistProjectPollState(runStore, state.configPath, nextStatus);
     } catch (error) {
@@ -234,10 +232,8 @@ export async function startDaemon(
     if (!state.configExists) {
       return;
     }
-    let projects: Map<string, PollingProjectConfig>;
-    try {
-      projects = await loadPollingProjectsByName(state.configPath);
-    } catch {
+    const projects = runtimeConfig.projectsByName();
+    if (projects.size === 0) {
       return;
     }
     try {
@@ -289,11 +285,15 @@ export async function startDaemon(
           now - lastPullRequestFollowupAt >= PR_FOLLOWUP_MIN_INTERVAL_MS
         ) {
           lastPullRequestFollowupAt = now;
+          const snapshot = runtimeConfig.getSnapshot();
           prResult = await runPullRequestFollowup({
             configPath: state.configPath,
             env,
             githubIssuesApi,
             logger,
+            ...(snapshot === undefined
+              ? {}
+              : { policy: snapshot.pullRequestPolicy }),
             projectsLoader,
             runController,
             runStore
@@ -329,6 +329,7 @@ export async function startDaemon(
   };
   const tick = async (): Promise<void> => {
     await refreshIssuePollStatus();
+    refreshPollingInterval();
     await reconcile();
     launchWork();
     logger.debug(
@@ -340,6 +341,28 @@ export async function startDaemon(
         projects: issuePollStatus.projects.length
       },
       "symphonika tick"
+    );
+  };
+  const refreshPollingInterval = (): void => {
+    if (!state.configExists) {
+      return;
+    }
+    const nextIntervalMs = runtimeConfig.getSnapshot()?.pollingIntervalMs;
+    if (nextIntervalMs === undefined) {
+      return;
+    }
+    if (nextIntervalMs === intervalMs) {
+      return;
+    }
+    intervalMs = nextIntervalMs;
+    if (pollTimer !== undefined) {
+      clearInterval(pollTimer);
+    }
+    pollTimer = setInterval(scheduleTick, intervalMs);
+    pollTimer.unref?.();
+    logger.info(
+      { pollingIntervalMs: intervalMs },
+      "symphonika polling interval reloaded"
     );
   };
   const scheduleTick = (): void => {
@@ -387,7 +410,7 @@ export async function startDaemon(
   let intervalMs: number | undefined;
   if (state.configExists) {
     await refreshIssuePollStatus();
-    intervalMs = await readConfiguredPollingIntervalMs(state.configPath);
+    intervalMs = runtimeConfig.getSnapshot()?.pollingIntervalMs;
   }
   const TERMINAL_STATES = new Set<RunState>([
     "cancelled",
@@ -431,10 +454,12 @@ export async function startDaemon(
       buildStatusSnapshot({
         configPath: state.configPath,
         issuePollStatus,
+        reloadStatus: runtimeConfig.getStatus(),
         runStore,
         stateRoot: state.stateRoot
       }),
     issuePollStatus,
+    getReloadStatus: () => runtimeConfig.getStatus(),
     pollNow: triggerPollNow,
     runStore,
     stateRoot: state.stateRoot,
@@ -579,22 +604,6 @@ function rawProjectWeight(weight: unknown): number | undefined {
     : undefined;
 }
 
-function issuePollOptions(
-  configPath: string,
-  options: StartDaemonOptions
-): PollConfiguredGitHubIssuesOptions {
-  const pollOptions: PollConfiguredGitHubIssuesOptions = {
-    configPath
-  };
-  if (options.env !== undefined) {
-    pollOptions.env = options.env;
-  }
-  if (options.githubIssuesApi !== undefined) {
-    pollOptions.githubIssuesApi = options.githubIssuesApi;
-  }
-  return pollOptions;
-}
-
 function waitForListening(server: ServerType): Promise<void> {
   if (server.listening) {
     return Promise.resolve();
@@ -662,113 +671,6 @@ function hasRegisteredProviders(
   providers: AgentProviderRegistry | undefined
 ): providers is AgentProviderRegistry {
   return providers !== undefined && Object.values(providers).some(Boolean);
-}
-
-type RichProjectDetail = {
-  workflow: string;
-  workspace: {
-    git: {
-      base_branch: string;
-      remote: string;
-    };
-    root: string;
-  };
-};
-
-async function loadRichProjects(
-  configPath: string
-): Promise<Map<string, RichProjectDetail>> {
-  const map = new Map<string, RichProjectDetail>();
-  let raw: unknown;
-  try {
-    raw = parse(await readFile(configPath, "utf8")) ?? {};
-  } catch {
-    return map;
-  }
-  if (!isRecord(raw)) {
-    return map;
-  }
-  const projects = raw["projects"];
-  if (!Array.isArray(projects)) {
-    return map;
-  }
-  for (const project of projects) {
-    if (!isRecord(project)) {
-      continue;
-    }
-    const name = project["name"];
-    if (typeof name !== "string") {
-      continue;
-    }
-    const workflow = project["workflow"];
-    const workspace = project["workspace"];
-    if (typeof workflow !== "string" || !isRecord(workspace)) {
-      continue;
-    }
-    const root = workspace["root"];
-    const git = workspace["git"];
-    if (typeof root !== "string" || !isRecord(git)) {
-      continue;
-    }
-    const remote = git["remote"];
-    const baseBranch = git["base_branch"];
-    if (typeof remote !== "string" || typeof baseBranch !== "string") {
-      continue;
-    }
-    map.set(name, {
-      workflow,
-      workspace: {
-        git: {
-          base_branch: baseBranch,
-          remote
-        },
-        root
-      }
-    });
-  }
-  return map;
-}
-
-async function loadProvidersConfig(
-  configPath: string
-): Promise<RunControllerProvidersConfig> {
-  let raw: unknown;
-  try {
-    raw = parse(await readFile(configPath, "utf8")) ?? {};
-  } catch {
-    return defaultProvidersConfig();
-  }
-  if (!isRecord(raw)) {
-    return defaultProvidersConfig();
-  }
-  const providers = raw["providers"];
-  if (!isRecord(providers)) {
-    return defaultProvidersConfig();
-  }
-  return {
-    claude: { command: providerCommand(providers["claude"], defaultProvidersConfig().claude.command) },
-    codex: { command: providerCommand(providers["codex"], defaultProvidersConfig().codex.command) }
-  };
-}
-
-function providerCommand(input: unknown, fallback: string): string {
-  if (isRecord(input) && typeof input["command"] === "string") {
-    return input["command"];
-  }
-  return fallback;
-}
-
-function defaultProvidersConfig(): RunControllerProvidersConfig {
-  return {
-    claude: {
-      command:
-        "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"
-    },
-    codex: {
-      command:
-        `codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server`
-    }
-  };
 }
 
 export function resolveLogLevel(env: NodeJS.ProcessEnv): string {

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -11,6 +11,7 @@ import type {
 } from "../issue-polling.js";
 import { emptyIssuePollStatus } from "../issue-polling.js";
 import { isPathInside } from "../path-safety.js";
+import type { RuntimeReloadStatus } from "../reload.js";
 import type { StatusSnapshot } from "../status.js";
 import type {
   ListRunsFilter,
@@ -61,6 +62,7 @@ export type HttpAppOptions = {
     runId: string;
   }>;
   getRuns?: () => RunStatus[];
+  getReloadStatus?: () => RuntimeReloadStatus;
   getScheduled?: () => Array<{
     dueAt: number;
     kind: "retry" | "continuation";
@@ -191,6 +193,7 @@ export function createHttpApp(options: HttpAppOptions): Hono {
         projects: issuePollStatus.projects
       },
       projectStates: runStore?.listProjectStates() ?? [],
+      reload: options.getReloadStatus?.() ?? emptyReloadStatus(),
       runs: getRuns(),
       scheduled: getScheduled(),
       service: "symphonika",
@@ -329,6 +332,16 @@ export function createHttpApp(options: HttpAppOptions): Hono {
   }
 
   return app;
+}
+
+function emptyReloadStatus(): RuntimeReloadStatus {
+  return {
+    errors: [],
+    lastAttemptedAt: null,
+    lastLoadedAt: null,
+    ok: true,
+    usingLastKnownGood: false
+  };
 }
 
 async function streamRunFile(

--- a/src/issue-polling.ts
+++ b/src/issue-polling.ts
@@ -160,7 +160,7 @@ export type PollConfiguredGitHubIssuesOptions = {
 };
 
 export type PollingProjectConfig = z.infer<typeof pollingProjectSchema>;
-type PollingServiceConfig = {
+export type PollingServiceConfig = {
   polling?: {
     interval_ms?: number | undefined;
   };
@@ -661,8 +661,6 @@ export async function readConfiguredPollingIntervalMs(
 export async function pollConfiguredGitHubIssues(
   options: PollConfiguredGitHubIssuesOptions
 ): Promise<IssuePollStatus> {
-  const env = options.env ?? process.env;
-  const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
   const status = emptyIssuePollStatus();
   const config = await readPollingConfig(options.configPath, status.errors);
 
@@ -670,7 +668,28 @@ export async function pollConfiguredGitHubIssues(
     return status;
   }
 
-  for (const project of config.projects) {
+  return pollConfiguredGitHubIssuesFromConfig({
+    config,
+    ...(options.env === undefined ? {} : { env: options.env }),
+    ...(options.githubIssuesApi === undefined
+      ? {}
+      : { githubIssuesApi: options.githubIssuesApi }),
+    initialErrors: status.errors
+  });
+}
+
+export async function pollConfiguredGitHubIssuesFromConfig(options: {
+  config: PollingServiceConfig;
+  env?: NodeJS.ProcessEnv;
+  githubIssuesApi?: GitHubIssuesApi;
+  initialErrors?: string[];
+}): Promise<IssuePollStatus> {
+  const env = options.env ?? process.env;
+  const githubIssuesApi = options.githubIssuesApi ?? DEFAULT_GITHUB_ISSUES_API;
+  const status = emptyIssuePollStatus();
+  status.errors.push(...(options.initialErrors ?? []));
+
+  for (const project of options.config.projects) {
     if (project.disabled === true) {
       continue;
     }

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -32,6 +32,7 @@ import {
   persistRunEvidence,
   renderAutonomousPrompt
 } from "../workflow.js";
+import type { WorkflowContract } from "../workflow.js";
 
 import {
   ActiveRunRegistry,
@@ -44,8 +45,14 @@ import { classifyCapReachedOutcome } from "./cap-reached-context.js";
 import { classifyFailure, type ClassifiedTerminal } from "./classify-failure.js";
 import { buildCapReachedReason } from "./terminal-reason.js";
 
+export type WorkflowSnapshot = {
+  body: string;
+  contentHash: string;
+  path: string;
+};
+
 export type RunControllerProjectConfig = PollingProjectConfig & {
-  workflow: string;
+  workflow: string | WorkflowSnapshot;
   workspace: {
     git: {
       base_branch: string;
@@ -929,8 +936,8 @@ export class RunController {
       project: input.project
     });
 
-    const workflowPath = path.resolve(this.configDir, input.project.workflow);
-    const workflow = await loadWorkflowContract(workflowPath);
+    const workflow = await this.loadWorkflow(input.project.workflow);
+    const workflowPath = workflow.path;
     if (workflow.errors.length > 0) {
       throw new Error(workflow.errors.join("\n"));
     }
@@ -1000,6 +1007,21 @@ export class RunController {
       prepared,
       prompt: renderedPrompt.prompt,
       promptPath: evidence.promptPath
+    };
+  }
+
+  private async loadWorkflow(
+    workflow: string | WorkflowSnapshot
+  ): Promise<WorkflowContract> {
+    if (typeof workflow === "string") {
+      return loadWorkflowContract(path.resolve(this.configDir, workflow));
+    }
+
+    return {
+      body: workflow.body,
+      contentHash: workflow.contentHash,
+      errors: [],
+      path: workflow.path
     };
   }
 

--- a/src/pull-request-followup.ts
+++ b/src/pull-request-followup.ts
@@ -53,7 +53,7 @@ export type RunPullRequestFollowupOptions = {
   runStore: RunStore;
 };
 
-const DEFAULT_POLICY: PullRequestFollowupPolicy = {
+export const DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY: PullRequestFollowupPolicy = {
   enabled: true,
   maxReviewDispatchesPerPr: 3,
   merge: {
@@ -134,27 +134,40 @@ export async function readPullRequestFollowupPolicy(
   try {
     raw = parse(await readFile(configPath, "utf8")) ?? {};
   } catch {
-    return DEFAULT_POLICY;
+    return DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY;
   }
   const parsed = pullRequestPolicySchema.safeParse(raw);
   if (!parsed.success) {
-    return DEFAULT_POLICY;
+    return DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY;
+  }
+  return pullRequestFollowupPolicyFromRaw(parsed.data) ?? DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY;
+}
+
+export function pullRequestFollowupPolicyFromRaw(
+  raw: unknown
+): PullRequestFollowupPolicy | undefined {
+  const parsed = pullRequestPolicySchema.safeParse(raw);
+  if (!parsed.success) {
+    return undefined;
   }
   const input = parsed.data.pull_requests;
   return {
-    enabled: input?.enabled ?? DEFAULT_POLICY.enabled,
+    enabled: input?.enabled ?? DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY.enabled,
     maxReviewDispatchesPerPr:
       input?.review_followup?.max_dispatches_per_pr ??
-      DEFAULT_POLICY.maxReviewDispatchesPerPr,
+      DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY.maxReviewDispatchesPerPr,
     merge: {
-      enabled: input?.merge?.enabled ?? DEFAULT_POLICY.merge.enabled,
-      method: input?.merge?.method ?? DEFAULT_POLICY.merge.method,
+      enabled:
+        input?.merge?.enabled ??
+        DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY.merge.enabled,
+      method:
+        input?.merge?.method ?? DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY.merge.method,
       requireReviewDecision:
         input?.merge?.require_review_decision ??
-        DEFAULT_POLICY.merge.requireReviewDecision,
+        DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY.merge.requireReviewDecision,
       requireStatusSuccess:
         input?.merge?.require_status_success ??
-        DEFAULT_POLICY.merge.requireStatusSuccess
+        DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY.merge.requireStatusSuccess
     }
   };
 }
@@ -170,7 +183,7 @@ export function pullRequestNeedsReviewFollowup(
 
 export function pullRequestReadyToMerge(
   state: RawGitHubPullRequestFollowupState,
-  policy: PullRequestFollowupPolicy = DEFAULT_POLICY
+  policy: PullRequestFollowupPolicy = DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY
 ): boolean {
   if (!policy.merge.enabled || state.draft || state.merged || state.state !== "OPEN") {
     return false;

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -9,6 +9,7 @@ import type {
   PollingProjectConfig,
   PollingServiceConfig
 } from "./issue-polling.js";
+import { DEFAULT_POLLING_INTERVAL_MS } from "./issue-polling.js";
 import type {
   RunControllerProjectConfig,
   RunControllerProvidersConfig,
@@ -405,5 +406,3 @@ function formatZodIssueWithPrefix(
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
-
-const DEFAULT_POLLING_INTERVAL_MS = 30_000;

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -1,0 +1,409 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { Logger } from "pino";
+import { parse } from "yaml";
+import { z } from "zod";
+
+import type {
+  PollingProjectConfig,
+  PollingServiceConfig
+} from "./issue-polling.js";
+import type {
+  RunControllerProjectConfig,
+  RunControllerProvidersConfig,
+  WorkflowSnapshot
+} from "./lifecycle/run-controller.js";
+import type { PullRequestFollowupPolicy } from "./pull-request-followup.js";
+import {
+  DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY,
+  pullRequestFollowupPolicyFromRaw
+} from "./pull-request-followup.js";
+import {
+  loadWorkflowContract,
+  validateWorkflowTemplate
+} from "./workflow.js";
+
+export type RuntimeConfigSnapshot = {
+  configPath: string;
+  loadedAt: string;
+  polling: PollingServiceConfig;
+  pollingIntervalMs: number;
+  projects: RunControllerProjectConfig[];
+  providers: RunControllerProvidersConfig;
+  pullRequestPolicy: PullRequestFollowupPolicy;
+};
+
+export type RuntimeReloadStatus = {
+  errors: string[];
+  lastAttemptedAt: string | null;
+  lastLoadedAt: string | null;
+  ok: boolean;
+  usingLastKnownGood: boolean;
+};
+
+export type RuntimeConfigReloaderOptions = {
+  configPath: string;
+  logger?: Logger;
+};
+
+const providerNameSchema = z.enum(["codex", "claude"]);
+const providerCommandSchema = z
+  .object({
+    command: z.string().trim().min(1)
+  })
+  .passthrough();
+
+const pollingProjectSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    disabled: z.boolean().optional(),
+    weight: z.number().int().positive().optional(),
+    tracker: z
+      .object({
+        kind: z.literal("github"),
+        owner: z.string().trim().min(1),
+        repo: z.string().trim().min(1),
+        token: z.string().trim().min(1)
+      })
+      .passthrough(),
+    issue_filters: z
+      .object({
+        states: z.array(z.literal("open")).min(1),
+        labels_all: z.array(z.string().trim().min(1)),
+        labels_none: z.array(z.string().trim().min(1))
+      })
+      .passthrough(),
+    priority: z
+      .object({
+        labels: z.record(z.string(), z.number().int().nonnegative()),
+        default: z.number().int().nonnegative()
+      })
+      .passthrough(),
+    agent: z
+      .object({
+        provider: providerNameSchema
+      })
+      .passthrough()
+  })
+  .passthrough();
+
+const runtimeProjectDetailSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    workspace: z
+      .object({
+        root: z.string().trim().min(1),
+        git: z
+          .object({
+            remote: z.string().trim().min(1),
+            base_branch: z.string().trim().min(1)
+          })
+          .passthrough()
+      })
+      .passthrough(),
+    workflow: z.string().trim().min(1)
+  })
+  .passthrough();
+
+const serviceConfigSchema = z
+  .object({
+    polling: z
+      .object({
+        interval_ms: z.number().int().positive().optional()
+      })
+      .passthrough()
+      .optional(),
+    providers: z
+      .object({
+        codex: providerCommandSchema,
+        claude: providerCommandSchema
+      })
+      .passthrough(),
+    projects: z.array(z.unknown()).min(1)
+  })
+  .passthrough();
+
+export class RuntimeConfigReloader {
+  private readonly configDir: string;
+  private readonly configPath: string;
+  private readonly logger?: Logger;
+  private snapshot: RuntimeConfigSnapshot | undefined;
+  private status: RuntimeReloadStatus = {
+    errors: [],
+    lastAttemptedAt: null,
+    lastLoadedAt: null,
+    ok: false,
+    usingLastKnownGood: false
+  };
+
+  constructor(options: RuntimeConfigReloaderOptions) {
+    this.configPath = options.configPath;
+    this.configDir = path.dirname(options.configPath);
+    if (options.logger !== undefined) {
+      this.logger = options.logger;
+    }
+  }
+
+  getSnapshot(): RuntimeConfigSnapshot | undefined {
+    return this.snapshot;
+  }
+
+  getStatus(): RuntimeReloadStatus {
+    return {
+      ...this.status,
+      errors: this.status.errors.slice()
+    };
+  }
+
+  projectsByName(): Map<string, RunControllerProjectConfig> {
+    const map = new Map<string, RunControllerProjectConfig>();
+    for (const project of this.snapshot?.projects ?? []) {
+      map.set(project.name, project);
+    }
+    return map;
+  }
+
+  providersConfig(): RunControllerProvidersConfig {
+    return this.snapshot?.providers ?? defaultProvidersConfig();
+  }
+
+  async reload(): Promise<RuntimeConfigSnapshot | undefined> {
+    const attemptedAt = new Date().toISOString();
+    const reloadInput = {
+      attemptedAt,
+      configDir: this.configDir,
+      configPath: this.configPath
+    };
+    const result = await loadRuntimeConfigSnapshot({
+      ...reloadInput,
+      ...(this.snapshot === undefined ? {} : { previous: this.snapshot })
+    });
+
+    this.status.lastAttemptedAt = attemptedAt;
+    if (result.snapshot !== undefined) {
+      this.snapshot = result.snapshot;
+      this.status.lastLoadedAt = result.snapshot.loadedAt;
+    }
+    this.status.errors = result.errors;
+    this.status.ok = result.errors.length === 0;
+    this.status.usingLastKnownGood = result.usingLastKnownGood;
+
+    if (result.errors.length > 0) {
+      this.logger?.warn(
+        {
+          errors: result.errors,
+          usingLastKnownGood: result.usingLastKnownGood
+        },
+        "symphonika config reload failed"
+      );
+    } else {
+      this.logger?.debug(
+        {
+          pollingIntervalMs: this.snapshot?.pollingIntervalMs,
+          projects: this.snapshot?.polling.projects.length ?? 0
+        },
+        "symphonika config reload succeeded"
+      );
+    }
+
+    return this.snapshot;
+  }
+}
+
+async function loadRuntimeConfigSnapshot(input: {
+  attemptedAt: string;
+  configDir: string;
+  configPath: string;
+  previous?: RuntimeConfigSnapshot;
+}): Promise<{
+  errors: string[];
+  snapshot?: RuntimeConfigSnapshot;
+  usingLastKnownGood: boolean;
+}> {
+  const errors: string[] = [];
+  const raw = await readRawServiceConfig(input.configPath, errors);
+  if (raw === undefined) {
+    return lastKnownGoodOrNothing(input.previous, errors);
+  }
+
+  const parsed = serviceConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    errors.push(...parsed.error.issues.map(formatZodIssue));
+    return lastKnownGoodOrNothing(input.previous, errors);
+  }
+
+  const pollingProjects: PollingProjectConfig[] = [];
+  const dispatchProjects: RunControllerProjectConfig[] = [];
+
+  for (const [index, rawProject] of parsed.data.projects.entries()) {
+    const pollingProject = pollingProjectSchema.safeParse(rawProject);
+    if (!pollingProject.success) {
+      errors.push(
+        ...pollingProject.error.issues.map((issue) =>
+          formatZodIssueWithPrefix(issue, ["projects", String(index)])
+        )
+      );
+      continue;
+    }
+    pollingProjects.push(pollingProject.data);
+
+    const detail = runtimeProjectDetailSchema.safeParse(rawProject);
+    if (!detail.success) {
+      errors.push(
+        ...detail.error.issues.map((issue) =>
+          formatZodIssueWithPrefix(issue, ["projects", String(index)])
+        )
+      );
+      continue;
+    }
+
+    if (pollingProject.data.disabled === true) {
+      dispatchProjects.push({
+        ...pollingProject.data,
+        workflow: detail.data.workflow,
+        workspace: detail.data.workspace
+      });
+      continue;
+    }
+
+    const workflow = await readWorkflowSnapshot(
+      path.resolve(input.configDir, detail.data.workflow),
+      errors
+    );
+    if (workflow === undefined) {
+      return lastKnownGoodOrNothing(input.previous, errors);
+    }
+    dispatchProjects.push({
+      ...pollingProject.data,
+      workflow,
+      workspace: detail.data.workspace
+    });
+  }
+
+  if (pollingProjects.length === 0 && input.previous !== undefined) {
+    return lastKnownGoodOrNothing(input.previous, errors);
+  }
+
+  const polling: PollingServiceConfig = {
+    projects: pollingProjects
+  };
+  if (parsed.data.polling !== undefined) {
+    polling.polling = parsed.data.polling;
+  }
+
+  return {
+    errors,
+    snapshot: {
+      configPath: input.configPath,
+      loadedAt: input.attemptedAt,
+      polling,
+      pollingIntervalMs:
+        parsed.data.polling?.interval_ms ?? DEFAULT_POLLING_INTERVAL_MS,
+      projects: dispatchProjects,
+      providers: {
+        claude: { command: parsed.data.providers.claude.command },
+        codex: { command: parsed.data.providers.codex.command }
+      },
+      pullRequestPolicy:
+        pullRequestFollowupPolicyFromRaw(raw) ?? DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY
+    },
+    usingLastKnownGood: false
+  };
+}
+
+async function readRawServiceConfig(
+  configPath: string,
+  errors: string[]
+): Promise<unknown> {
+  let contents: string;
+  try {
+    contents = await readFile(configPath, "utf8");
+  } catch (error) {
+    errors.push(`service config not found at ${configPath}: ${errorMessage(error)}`);
+    return undefined;
+  }
+
+  try {
+    return parse(contents) ?? {};
+  } catch (error) {
+    errors.push(`service config could not be parsed: ${errorMessage(error)}`);
+    return undefined;
+  }
+}
+
+async function readWorkflowSnapshot(
+  workflowPath: string,
+  errors: string[]
+): Promise<WorkflowSnapshot | undefined> {
+  let workflow;
+  try {
+    workflow = await loadWorkflowContract(workflowPath);
+  } catch (error) {
+    errors.push(`workflow contract not found at ${workflowPath}: ${errorMessage(error)}`);
+    return undefined;
+  }
+
+  const workflowErrors = [...workflow.errors];
+  if (workflow.body.trim().length === 0) {
+    workflowErrors.push(`workflow contract at ${workflowPath} must not be empty`);
+  }
+  workflowErrors.push(...validateWorkflowTemplate(workflow.body, workflowPath));
+  if (workflowErrors.length > 0) {
+    errors.push(...workflowErrors);
+    return undefined;
+  }
+
+  return {
+    body: workflow.body,
+    contentHash: workflow.contentHash,
+    path: workflow.path
+  };
+}
+
+function lastKnownGoodOrNothing(
+  previous: RuntimeConfigSnapshot | undefined,
+  errors: string[]
+): {
+  errors: string[];
+  snapshot?: RuntimeConfigSnapshot;
+  usingLastKnownGood: boolean;
+} {
+  return {
+    errors,
+    ...(previous === undefined ? {} : { snapshot: previous }),
+    usingLastKnownGood: previous !== undefined
+  };
+}
+
+function defaultProvidersConfig(): RunControllerProvidersConfig {
+  return {
+    claude: {
+      command:
+        "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"
+    },
+    codex: {
+      command:
+        "codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server"
+    }
+  };
+}
+
+function formatZodIssue(issue: z.ZodIssue): string {
+  const location = issue.path.length === 0 ? "service config" : issue.path.join(".");
+  return `${location}: ${issue.message}`;
+}
+
+function formatZodIssueWithPrefix(
+  issue: z.ZodIssue,
+  prefix: string[]
+): string {
+  const location = [...prefix, ...issue.path].join(".");
+  return `${location}: ${issue.message}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const DEFAULT_POLLING_INTERVAL_MS = 30_000;

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,5 +1,6 @@
 import type { DoctorProjectReport, DoctorReport } from "./doctor.js";
 import type { IssuePollStatus } from "./issue-polling.js";
+import type { RuntimeReloadStatus } from "./reload.js";
 import type { ProjectState, RunStatus, RunStore } from "./run-store.js";
 
 export type StatusSnapshot = {
@@ -8,6 +9,7 @@ export type StatusSnapshot = {
   issuePolling: IssuePollStatus;
   projectStates: ProjectState[];
   projects: DoctorProjectReport[];
+  reload: RuntimeReloadStatus;
   runs: {
     active: RunStatus[];
     failed: RunStatus[];
@@ -21,6 +23,7 @@ export type BuildStatusSnapshotInput = {
   configPath: string;
   doctorReport?: DoctorReport;
   issuePollStatus: IssuePollStatus;
+  reloadStatus?: RuntimeReloadStatus;
   runStore: RunStore;
   stateRoot: string;
 };
@@ -51,6 +54,7 @@ export function buildStatusSnapshot(
     issuePolling: input.issuePollStatus,
     projectStates: input.runStore.listProjectStates(),
     projects: input.doctorReport?.projects ?? [],
+    reload: input.reloadStatus ?? emptyReloadStatus(),
     runs: {
       active,
       failed,
@@ -58,5 +62,15 @@ export function buildStatusSnapshot(
       stale
     },
     stateRoot: input.stateRoot
+  };
+}
+
+function emptyReloadStatus(): RuntimeReloadStatus {
+  return {
+    errors: [],
+    lastAttemptedAt: null,
+    lastLoadedAt: null,
+    ok: true,
+    usingLastKnownGood: false
   };
 }

--- a/tests/daemon-hot-reload.test.ts
+++ b/tests/daemon-hot-reload.test.ts
@@ -1,0 +1,506 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+import type { LifecyclePolicy } from "../src/lifecycle/active-runs.js";
+import type {
+  AgentProvider,
+  ProviderEvent,
+  ProviderRunInput
+} from "../src/provider.js";
+import type {
+  PreparedIssueWorkspace,
+  PrepareIssueWorkspaceInput
+} from "../src/workspace.js";
+import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
+
+const tempRoots: string[] = [];
+const noFollowupPolicy: LifecyclePolicy = {
+  continuation: { cap: 0, delayMs: 0 },
+  retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+};
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-reload-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("daemon hot reload", () => {
+  it("reschedules automatic polling when polling.interval_ms changes", async () => {
+    const root = await makeTempRoot();
+    await writeProject(root, { pollingIntervalMs: 1_000 });
+    const githubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([])
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      expect(githubIssuesApi.listOpenIssues).toHaveBeenCalledTimes(1);
+
+      await writeProject(root, { pollingIntervalMs: 10 });
+      const response = await fetch(`${daemon.url}/api/poll-now`, {
+        method: "POST"
+      });
+      expect(response.status).toBe(200);
+      await waitFor(() =>
+        Promise.resolve(githubIssuesApi.listOpenIssues.mock.calls.length >= 4)
+      );
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("keeps last-known-good behavior and reports reload errors when service config reload is invalid", async () => {
+    const root = await makeTempRoot();
+    await writeProject(root, { pollingIntervalMs: 1_000 });
+    const githubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 81,
+          title: "Reloadable issue"
+        })
+      ])
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      await expectCandidateNumbers(daemon.url, [81]);
+
+      await writeFile(path.join(root, "symphonika.yml"), "projects:\n  - [\n");
+      const response = await fetch(`${daemon.url}/api/poll-now`, {
+        method: "POST"
+      });
+      expect(response.status).toBe(200);
+
+      const status = await statusJson(daemon.url);
+      expect(candidateNumbers(status)).toEqual([81]);
+      expect(status.reload).toMatchObject({
+        ok: false,
+        errors: [expect.stringContaining("service config could not be parsed")]
+      });
+      expect(githubIssuesApi.listOpenIssues).toHaveBeenCalledTimes(2);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("applies changed project filters, provider commands, and workflow prompts to future work", async () => {
+    const root = await makeTempRoot();
+    await writeProject(root, {
+      labelsAll: ["agent-ready"],
+      pollingIntervalMs: 1_000,
+      providerCommand: "codex old-command app-server",
+      workflowBody: "First workflow for {{issue.title}}.\n"
+    });
+    const firstWorkspace = preparedWorkspaceFixture(root, 81, "first-reload-run");
+    const secondWorkspace = preparedWorkspaceFixture(root, 82, "second-reload-run");
+    await createGitWorkspaceAhead(firstWorkspace);
+    await createGitWorkspaceAhead(secondWorkspace);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(null),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 81,
+            title: "First reload run"
+          })
+        ])
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: ["next-ready"],
+            number: 82,
+            title: "Second reload run"
+          }),
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 83,
+            title: "Old filter should not dispatch"
+          })
+        ])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const providerInputs: ProviderRunInput[] = [];
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (
+        input: ProviderRunInput
+      ): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        providerInputs.push(input);
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
+        return Promise.resolve(
+          input.issue.number === 82 ? secondWorkspace : firstWorkspace
+        );
+      }
+    );
+    let runSequence = 0;
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => `run-reload-${++runSequence}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: noFollowupPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitFor(() => Promise.resolve(providerInputs.length === 1));
+      await waitForRunCount(daemon.url, 1);
+
+      await writeProject(root, {
+        labelsAll: ["next-ready"],
+        pollingIntervalMs: 1_000,
+        providerCommand: "codex new-command app-server",
+        workflowBody: "Second workflow for {{issue.title}}.\n"
+      });
+      const response = await fetch(`${daemon.url}/api/poll-now`, {
+        method: "POST"
+      });
+      expect(response.status).toBe(200);
+      await waitFor(() => Promise.resolve(providerInputs.length === 2));
+      await waitForRunCount(daemon.url, 2);
+
+      expect(providerInputs[0]?.issue.number).toBe(81);
+      expect(providerInputs[0]?.provider.command).toBe(
+        "codex old-command app-server"
+      );
+      expect(providerInputs[0]?.prompt).toContain(
+        "First workflow for First reload run."
+      );
+      expect(providerInputs[1]?.issue.number).toBe(82);
+      expect(providerInputs[1]?.provider.command).toBe(
+        "codex new-command app-server"
+      );
+      expect(providerInputs[1]?.prompt).toContain(
+        "Second workflow for Second reload run."
+      );
+      expect(providerInputs[1]?.prompt).not.toContain("First workflow");
+      expect(prepareIssueWorkspace).toHaveBeenCalledTimes(2);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("keeps the last good workflow snapshot when a workflow reload is invalid", async () => {
+    const root = await makeTempRoot();
+    await writeProject(root, {
+      pollingIntervalMs: 1_000,
+      workflowBody: "Stable workflow for {{issue.title}}.\n"
+    });
+    const firstWorkspace = preparedWorkspaceFixture(root, 91, "first-workflow-run");
+    const secondWorkspace = preparedWorkspaceFixture(root, 92, "second-workflow-run");
+    await createGitWorkspaceAhead(firstWorkspace);
+    await createGitWorkspaceAhead(secondWorkspace);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(null),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 91,
+            title: "First workflow run"
+          })
+        ])
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 92,
+            title: "Second workflow run"
+          })
+        ])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const providerInputs: ProviderRunInput[] = [];
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (
+        input: ProviderRunInput
+      ): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        providerInputs.push(input);
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
+        return Promise.resolve(
+          input.issue.number === 92 ? secondWorkspace : firstWorkspace
+        );
+      }
+    );
+    let runSequence = 0;
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => `run-workflow-reload-${++runSequence}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: noFollowupPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitFor(() => Promise.resolve(providerInputs.length === 1));
+
+      await writeFile(
+        path.join(root, "WORKFLOW.md"),
+        "Broken workflow for {{not_a_real_object.title}}.\n"
+      );
+      const response = await fetch(`${daemon.url}/api/poll-now`, {
+        method: "POST"
+      });
+      expect(response.status).toBe(200);
+      await waitFor(() => Promise.resolve(providerInputs.length === 2));
+
+      expect(providerInputs[1]?.issue.number).toBe(92);
+      expect(providerInputs[1]?.prompt).toContain(
+        "Stable workflow for Second workflow run."
+      );
+      expect(providerInputs[1]?.prompt).not.toContain("Broken workflow");
+      const status = await statusJson(daemon.url);
+      expect(status.reload).toMatchObject({
+        ok: false,
+        usingLastKnownGood: true,
+        errors: [expect.stringContaining("references unknown variable")]
+      });
+    } finally {
+      await daemon.stop();
+    }
+  });
+});
+
+function issueFixture(overrides: {
+  labels: unknown[];
+  number: number;
+  title: string;
+}): {
+  body: string;
+  created_at: string;
+  html_url: string;
+  id: number;
+  labels: unknown[];
+  number: number;
+  state: string;
+  title: string;
+  updated_at: string;
+} {
+  return {
+    body: `${overrides.title} body.`,
+    created_at: "2026-04-20T10:00:00Z",
+    html_url: `https://github.com/pmatos/symphonika/issues/${overrides.number}`,
+    id: 5000 + overrides.number,
+    labels: overrides.labels,
+    number: overrides.number,
+    state: "open",
+    title: overrides.title,
+    updated_at: "2026-04-21T11:00:00Z"
+  };
+}
+
+async function expectCandidateNumbers(
+  url: string,
+  expected: number[]
+): Promise<void> {
+  await waitFor(async () => candidateNumbers(await statusJson(url)).join(",") === expected.join(","));
+}
+
+async function statusJson(url: string): Promise<Record<string, unknown>> {
+  const response = await fetch(`${url}/api/status`);
+  expect(response.status).toBe(200);
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function candidateNumbers(status: Record<string, unknown>): number[] {
+  const candidates = status["candidateIssues"];
+  if (!Array.isArray(candidates)) {
+    return [];
+  }
+  const numbers: number[] = [];
+  for (const entry of candidates) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const issue = entry["issue"];
+    if (!isRecord(issue)) {
+      continue;
+    }
+    const number = issue["number"];
+    if (typeof number === "number") {
+      numbers.push(number);
+    }
+  }
+  return numbers;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function writeProject(
+  root: string,
+  options: {
+    labelsAll?: string[];
+    pollingIntervalMs: number;
+    providerCommand?: string;
+    workflowBody?: string;
+  }
+): Promise<void> {
+  await mkdir(root, { recursive: true });
+  const labelsAll = options.labelsAll ?? ["agent-ready"];
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      `  interval_ms: ${options.pollingIntervalMs}`,
+      "providers:",
+      "  codex:",
+      `    command: "${options.providerCommand ?? "codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server"}"`,
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      `      labels_all: [${labelsAll.map((label) => `"${label}"`).join(", ")}]`,
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "WORKFLOW.md"),
+    options.workflowBody ?? "Work on {{issue.title}}.\n"
+  );
+}
+
+function preparedWorkspaceFixture(
+  root: string,
+  issueNumber: number,
+  slug: string
+): PreparedIssueWorkspace {
+  const issueDirectoryName = `${issueNumber}-${slug}`;
+  const workspacePath = path.join(
+    root,
+    ".symphonika",
+    "workspaces",
+    "symphonika",
+    "issues",
+    issueDirectoryName
+  );
+  return {
+    branchName: `sym/symphonika/${issueDirectoryName}`,
+    branchRef: `refs/heads/sym/symphonika/${issueDirectoryName}`,
+    cachePath: path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      ".cache",
+      "repo.git"
+    ),
+    issueDirectoryName,
+    reused: false,
+    workspacePath
+  };
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 1_000;
+  const intervalMs = options.intervalMs ?? 10;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error("condition was not met before timeout");
+}
+
+async function waitForRunCount(url: string, count: number): Promise<void> {
+  await waitFor(async () => {
+    const status = await statusJson(url);
+    const runs = status["runs"];
+    return Array.isArray(runs) && runs.length === count;
+  });
+}

--- a/tests/daemon-hot-reload.test.ts
+++ b/tests/daemon-hot-reload.test.ts
@@ -110,6 +110,39 @@ describe("daemon hot reload", () => {
     }
   });
 
+  it("keeps periodic reload attempts after an invalid startup config", async () => {
+    const root = await makeTempRoot();
+    await writeProjectWithoutProviders(root, { pollingIntervalMs: 10 });
+    const githubIssuesApi = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 82,
+          title: "Recovered startup config"
+        })
+      ])
+    };
+
+    const daemon = await startDaemon({
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      expect(githubIssuesApi.listOpenIssues).not.toHaveBeenCalled();
+
+      await writeProject(root, { pollingIntervalMs: 10 });
+      await waitFor(() =>
+        Promise.resolve(githubIssuesApi.listOpenIssues.mock.calls.length >= 1)
+      );
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("applies changed project filters, provider commands, and workflow prompts to future work", async () => {
     const root = await makeTempRoot();
     await writeProject(root, {
@@ -446,6 +479,26 @@ async function writeProject(
     path.join(root, "WORKFLOW.md"),
     options.workflowBody ?? "Work on {{issue.title}}.\n"
   );
+}
+
+async function writeProjectWithoutProviders(
+  root: string,
+  options: { pollingIntervalMs: number }
+): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      `  interval_ms: ${options.pollingIntervalMs}`,
+      "projects:",
+      "  - name: symphonika",
+      ""
+    ].join("\n")
+  );
+  await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
 }
 
 function preparedWorkspaceFixture(

--- a/tests/http-app.test.ts
+++ b/tests/http-app.test.ts
@@ -106,6 +106,13 @@ describe("HTTP app", () => {
         projects: []
       },
       projectStates: [],
+      reload: {
+        errors: [],
+        lastAttemptedAt: null,
+        lastLoadedAt: null,
+        ok: true,
+        usingLastKnownGood: false
+      },
       runs: [],
       scheduled: [],
       service: "symphonika",


### PR DESCRIPTION
## Summary

- add a daemon runtime config reloader with last-known-good snapshots for service config and workflow contracts
- reschedule polling intervals and thread refreshed project filters, provider commands, workflow prompts, and PR follow-up policy into future work
- surface reload status in CLI/API status and document defensive re-read semantics

## Validation

- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #81