### PR TITLE
Add workflow graph validation and explain CLI

### DIFF
--- a/docs/specs/2026-05-07-state-machine-workflows-design.md
+++ b/docs/specs/2026-05-07-state-machine-workflows-design.md
@@ -1,0 +1,379 @@
+# State Machine Workflows
+
+Status: proposed
+Date: 2026-05-07
+
+## Context
+
+Symphonika currently treats a Project workflow as one repository-owned prompt contract. That is
+enough for the bootstrap path: pick an eligible issue, prepare a workspace, run one coding agent,
+expect it to test, commit, push, open a PR, and remove the readiness label. PR follow-up adds a
+second poll-driven loop for review feedback and clean auto-merge, but the higher-level lifecycle is
+still implicit.
+
+The desired daily-use model is broader: an issue should move through named phases such as planning,
+TDD implementation, simplification, review follow-up, and merge. These phases should be generic
+enough for different repositories to define their own agentic coding workflows, while Symphonika
+remains the durable runtime that runs agents, evaluates observable state, records evidence, and
+advances work safely.
+
+## Goals
+
+- Let repositories define issue-to-merge workflows as finite state machines.
+- Keep workflow behavior inspectable before dispatch.
+- Support repo-local reusable templates, similar in spirit to coding skills.
+- Preserve the current single-prompt workflow as a compatibility shorthand.
+- Keep v1 execution poll-based, local, and aligned with the existing daemon/run-store model.
+- Make the model compatible with a future visual canvas where nodes map to states and edges map to
+  transitions.
+
+## Non-Goals
+
+- Arbitrary code execution during workflow expansion.
+- A distributed workflow engine.
+- A separate visual-only workflow source of truth.
+- Remote template registries in the first implementation.
+- Replacing repository-owned agent skills or prompt conventions.
+
+## Design Summary
+
+Symphonika should introduce a repository-owned workflow definition DSL that compiles into an explicit
+finite state machine. Runtime execution uses only the expanded state machine.
+
+The layers are:
+
+1. Raw state machine: explicit states, actions, completion rules, and transitions.
+2. Repo-local workflow templates: pure reusable state-machine fragments with inputs and exits.
+3. Future visual builder: an editor for the same expanded graph, not a separate runtime model.
+
+Existing Markdown `WORKFLOW.md` files remain valid. A Markdown workflow compiles to a one-state
+agent workflow that preserves current behavior. A YAML workflow definition enables multi-stage
+orchestration.
+
+## Raw State Machine
+
+A raw workflow definition names an initial state and a set of states:
+
+```yaml
+workflow:
+  name: issue_to_merge
+  initial: planning
+
+  states:
+    planning:
+      action:
+        kind: agent
+        provider: codex
+        prompt: prompts/plan.md
+      complete_when:
+        artifact_exists: PLAN.md
+      transitions:
+        - to: implementing
+
+    implementing:
+      action:
+        kind: agent
+        provider: codex
+        prompt: prompts/implement-tdd.md
+      complete_when:
+        branch_ahead_of_base: true
+        pr_open: true
+      transitions:
+        - to: simplifying
+
+    simplifying:
+      action:
+        kind: agent
+        provider: claude
+        prompt: prompts/simplify.md
+      complete_when:
+        branch_pushed: true
+      transitions:
+        - to: waiting_for_review
+
+    waiting_for_review:
+      action:
+        kind: wait
+      transitions:
+        - to: autofixing
+          when:
+            unresolved_review_threads: ">0"
+        - to: merging
+          when:
+            checks: success
+            mergeable: true
+            unresolved_review_threads: 0
+
+    autofixing:
+      action:
+        kind: agent
+        provider: codex
+        prompt: prompts/autofix-pr.md
+        max_runs_per_fingerprint: 1
+        max_total_runs: 3
+      complete_when:
+        branch_pushed: true
+      transitions:
+        - to: waiting_for_review
+
+    merging:
+      action:
+        kind: merge_pr
+        method: squash
+      complete_when:
+        pr_merged: true
+      transitions:
+        - to: done
+
+    done:
+      terminal: success
+
+    needs_operator:
+      terminal: blocked
+```
+
+### State Shape
+
+Each state is one of:
+
+- Agent state: dispatches a coding agent in the prepared workspace and issue branch.
+- System state: evaluates or mutates external state without spending agent tokens.
+- Terminal state: ends the workflow instance.
+
+Initial action kinds:
+
+- `agent`
+- `wait`
+- `merge_pr`
+- `comment`
+- `label_issue`
+- `close_issue`
+- `fail`
+
+Initial completion predicates:
+
+- `provider_success`
+- `artifact_exists`
+- `branch_ahead_of_base`
+- `branch_pushed`
+- `pr_open`
+- `pr_merged`
+- `checks`
+- `mergeable`
+- `unresolved_review_threads`
+- `timeout`
+
+Completion predicates must be observable by the daemon from the workspace, run store, or GitHub.
+Agent self-reporting can be recorded as evidence, but it should not be the only success signal for a
+state that mutates code or merges work.
+
+### Transitions
+
+Transitions are evaluated in order after a state completes or whenever a wait state is rechecked on
+a daemon tick. The first matching transition wins. A transition without `when` is the default path.
+
+If no transition matches and the state is not terminal, Symphonika records the workflow instance as
+blocked with a deterministic reason. The workspace and evidence are preserved.
+
+## Runtime Model
+
+The run store should add a workflow instance record for each claimed issue. The instance records:
+
+- project name
+- issue number
+- workflow name and content hash
+- expanded workflow path or stored JSON
+- current state
+- terminal state, if reached
+- last transition reason
+- timestamps
+
+Agent state execution creates normal Runs with extra workflow metadata:
+
+- workflow instance id
+- state id
+- template instance id, when the state came from a template
+- parent state run id, when applicable
+
+Workspace-mutating states take the workspace/branch lock by default. This serializes implement,
+simplify, and autofix states against the same issue branch. Wait and merge states do not run
+concurrently with workspace-mutating agent states for the same workflow instance.
+
+## Workflow Templates
+
+Templates are repo-local reusable state-machine fragments. They are deliberately small: a template
+has inputs, one entry state, named exits, and internal states.
+
+Example:
+
+```yaml
+name: plan_tdd_pr
+
+inputs:
+  planner:
+    type: provider
+    default: codex
+  implementer:
+    type: provider
+    default: codex
+  plan_prompt:
+    type: path
+    default: prompts/plan.md
+  implement_prompt:
+    type: path
+    default: prompts/implement-tdd.md
+
+entry: planning
+
+exits:
+  success: pr_open
+  blocked: blocked
+
+states:
+  planning:
+    action:
+      kind: agent
+      provider: "{{ planner }}"
+      prompt: "{{ plan_prompt }}"
+    complete_when:
+      artifact_exists: PLAN.md
+    transitions:
+      - to: implementing
+
+  implementing:
+    action:
+      kind: agent
+      provider: "{{ implementer }}"
+      prompt: "{{ implement_prompt }}"
+    complete_when:
+      branch_ahead_of_base: true
+      pr_open: true
+    transitions:
+      - to: pr_open
+
+  pr_open:
+    exit: success
+
+  blocked:
+    exit: blocked
+```
+
+A workflow uses templates by naming an instance and mapping exits:
+
+```yaml
+workflow:
+  name: issue_to_merge
+  initial: build_pr
+
+  use:
+    build_pr:
+      template: .symphonika/workflow-templates/plan-tdd-pr.yml
+      with:
+        planner: codex
+        implementer: codex
+      exits:
+        success: simplify
+        blocked: needs_operator
+
+    simplify:
+      template: .symphonika/workflow-templates/simplify-pr.yml
+      exits:
+        success: review
+        blocked: needs_operator
+
+    review:
+      template: .symphonika/workflow-templates/autofix-until-clean.yml
+      exits:
+        success: merge
+        exhausted: needs_operator
+
+    merge:
+      template: builtin:merge-when-green
+      exits:
+        success: done
+        blocked: needs_operator
+```
+
+### Expansion Contract
+
+Expansion should stay simple:
+
+- Template inputs are typed scalar values: string, number, boolean, provider, path, or label.
+- Template interpolation is strict and side-effect free.
+- Internal state names are prefixed by the template instance name, such as
+  `build_pr.planning`.
+- Only declared exits may leave a template instance.
+- Exit mapping is required unless the exit targets a terminal state declared inside the template.
+- Template expansion happens during config/workflow reload.
+- The daemon stores and executes the expanded graph, not the template source.
+
+This keeps templates close to reusable workflow fragments rather than a general programming language.
+
+## Built-In Templates
+
+Symphonika may ship a small set of built-in templates once the raw FSM is implemented:
+
+- `builtin:single-agent-pr`
+- `builtin:plan-tdd-pr`
+- `builtin:autofix-until-clean`
+- `builtin:merge-when-green`
+
+Built-ins are conveniences. Repositories can replace them with local templates when they need a
+different workflow culture.
+
+## Operator Surface
+
+Add read-only commands before mutating workflow execution:
+
+```sh
+symphonika workflow validate --config symphonika.yml --project symphonika
+symphonika workflow explain --config symphonika.yml --project symphonika
+```
+
+`workflow explain` should show:
+
+- source workflow file
+- template files used
+- expanded states and transitions
+- action kind/provider/prompt for each state
+- completion predicates
+- locks
+- terminal states
+
+This gives operators a way to audit what the daemon will do before labeling issues ready.
+
+## Future Canvas
+
+A future visual builder should edit the same canonical graph:
+
+- canvas node = state or collapsed template instance
+- canvas edge = transition
+- node property panel = action and completion config
+- collapsed node expansion = template internals
+
+The visual tool should round-trip through the same YAML or through an equivalent normalized graph
+format. Runtime should not gain a visual-only execution model.
+
+## Implementation Slices
+
+1. Add workflow validation and explanation for explicit raw FSM YAML, without dispatch changes.
+2. Store expanded workflow metadata in run evidence.
+3. Add workflow instance state to SQLite and execute one agent state through the existing
+   RunController path.
+4. Add system wait and merge states, reusing the existing PR follow-up and merge predicates.
+5. Add repo-local template expansion with strict scalar inputs and named exits.
+6. Migrate current Markdown workflow handling to compile into the one-state compatibility graph.
+
+## Prior Art
+
+- Amazon States Language: explicit start state, named states, and transitions
+  (https://docs.aws.amazon.com/step-functions/latest/dg/statemachine-structure.html).
+- GitHub Actions reusable workflows and composite actions: repo-versioned reusable automation with
+  declared inputs (https://docs.github.com/en/actions/sharing-automations/reusing-workflows).
+- Argo WorkflowTemplates: reusable workflow fragments with parameters
+  (https://argo-workflows.readthedocs.io/en/latest/workflow-templates/).
+- Tekton Pipelines: reusable tasks composed into pipelines with parameters and results
+  (https://tekton.dev/docs/pipelines/pipelines/).
+
+The Symphonika design borrows the inspectable graph and reusable-template ideas, but keeps execution
+local, poll-driven, and centered on coding-agent workspaces.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ import {
 } from "./lifecycle/terminal-reason.js";
 import { resolveStateRoot } from "./state.js";
 import { VERSION } from "./version.js";
+import { explainWorkflow, loadProjectWorkflow } from "./workflow.js";
 
 export type CliDependencies = {
   fetch?: FetchFn;
@@ -282,6 +283,61 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
           writeOut(program, `terminal:     ${detail.terminalReason}\n`);
         }
       }
+    });
+
+  const workflowCommand = program
+    .command("workflow")
+    .description("validate and explain repository workflow definitions");
+
+  workflowCommand
+    .command("validate")
+    .description("validate the expanded workflow graph without dispatching work")
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .option("--project <name>", "project name from symphonika.yml")
+    .action(async (options: { config: string; project?: string }) => {
+      const report = await loadProjectWorkflow({
+        configPath: options.config,
+        ...(options.project === undefined ? {} : { projectName: options.project })
+      });
+
+      if (report.workflow === null || report.errors.length > 0) {
+        writeErr(program, "workflow validate failed:\n");
+        for (const error of report.errors) {
+          writeErr(program, `- ${error}\n`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      writeOut(
+        program,
+        `workflow validate ok: ${report.projectName ?? "(unknown project)"} -> ${report.workflow.name}\n`
+      );
+      writeOut(program, `source: ${report.workflowPath ?? report.workflow.source.path}\n`);
+      writeOut(program, `states: ${report.workflow.states.length}\n`);
+    });
+
+  workflowCommand
+    .command("explain")
+    .description("print the expanded workflow graph without dispatching work")
+    .option("--config <path>", "service config path", "symphonika.yml")
+    .option("--project <name>", "project name from symphonika.yml")
+    .action(async (options: { config: string; project?: string }) => {
+      const report = await loadProjectWorkflow({
+        configPath: options.config,
+        ...(options.project === undefined ? {} : { projectName: options.project })
+      });
+
+      if (report.workflow === null || report.errors.length > 0) {
+        writeErr(program, "workflow explain failed:\n");
+        for (const error of report.errors) {
+          writeErr(program, `- ${error}\n`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      writeOut(program, explainWorkflow(report.workflow));
     });
 
   program

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -71,6 +71,65 @@ export type WorkflowContract = {
   path: string;
 };
 
+export type WorkflowSourceKind = "markdown" | "raw_fsm";
+
+export type WorkflowActionKind =
+  | "agent"
+  | "close_issue"
+  | "comment"
+  | "fail"
+  | "label_issue"
+  | "merge_pr"
+  | "wait";
+
+export type WorkflowPredicateValue = boolean | number | string;
+
+export type WorkflowPredicateMap = Record<string, WorkflowPredicateValue>;
+
+export type WorkflowAction = {
+  kind: WorkflowActionKind;
+  method?: string;
+  prompt?: string;
+  provider?: "codex" | "claude";
+};
+
+export type WorkflowTransition = {
+  to: string;
+  when: WorkflowPredicateMap;
+};
+
+export type ExpandedWorkflowState = {
+  action?: WorkflowAction;
+  completeWhen: WorkflowPredicateMap;
+  id: string;
+  terminal?: string;
+  transitions: WorkflowTransition[];
+};
+
+export type ExpandedWorkflow = {
+  contentHash: string;
+  initial: string;
+  name: string;
+  source: {
+    kind: WorkflowSourceKind;
+    path: string;
+  };
+  states: ExpandedWorkflowState[];
+  templateFiles: string[];
+};
+
+export type ExpandedWorkflowLoadResult = {
+  errors: string[];
+  workflow: ExpandedWorkflow;
+};
+
+export type ProjectWorkflowLoadResult = {
+  errors: string[];
+  projectName: string | null;
+  workflow: ExpandedWorkflow | null;
+  workflowPath: string | null;
+};
+
 type PromptContext = {
   branch: PromptBranch;
   issue: IssueSnapshot;
@@ -111,6 +170,31 @@ const serviceDiscoveryFrontMatterKeys = new Set([
   "workflow",
   "workspace"
 ]);
+
+const actionKinds = new Set<WorkflowActionKind>([
+  "agent",
+  "close_issue",
+  "comment",
+  "fail",
+  "label_issue",
+  "merge_pr",
+  "wait"
+]);
+
+const completionPredicateKeys = new Set([
+  "artifact_exists",
+  "branch_ahead_of_base",
+  "branch_pushed",
+  "checks",
+  "mergeable",
+  "pr_merged",
+  "pr_open",
+  "provider_success",
+  "timeout",
+  "unresolved_review_threads"
+]);
+
+const terminalStates = new Set(["blocked", "failure", "success"]);
 
 const tagPattern = /{{\s*([^{}]+?)\s*}}/g;
 
@@ -166,6 +250,124 @@ export async function loadWorkflowContract(
 ): Promise<WorkflowContract> {
   const contents = await readFile(workflowPath, "utf8");
   return parseWorkflowContract(contents, workflowPath);
+}
+
+export async function loadExpandedWorkflow(
+  workflowPath: string
+): Promise<ExpandedWorkflowLoadResult> {
+  const contents = await readFile(workflowPath, "utf8");
+  return expandWorkflowDefinition(contents, workflowPath);
+}
+
+export async function loadProjectWorkflow(input: {
+  configPath: string;
+  projectName?: string;
+}): Promise<ProjectWorkflowLoadResult> {
+  const configPath = path.resolve(input.configPath);
+  const errors: string[] = [];
+  let contents: string;
+  try {
+    contents = await readFile(configPath, "utf8");
+  } catch (error) {
+    return {
+      errors: [`service config not found at ${configPath}: ${errorMessage(error)}`],
+      projectName: input.projectName ?? null,
+      workflow: null,
+      workflowPath: null
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parse(contents) ?? {};
+  } catch (error) {
+    return {
+      errors: [`service config could not be parsed: ${errorMessage(error)}`],
+      projectName: input.projectName ?? null,
+      workflow: null,
+      workflowPath: null
+    };
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.projects)) {
+    return {
+      errors: ["service config must define projects"],
+      projectName: input.projectName ?? null,
+      workflow: null,
+      workflowPath: null
+    };
+  }
+
+  const projects = projectWorkflowReferences(parsed.projects, configPath, errors);
+  const selected = selectProjectWorkflow(projects, input.projectName, configPath, errors);
+  if (selected === undefined) {
+    return {
+      errors,
+      projectName: input.projectName ?? null,
+      workflow: null,
+      workflowPath: null
+    };
+  }
+
+  const workflowPath = path.resolve(path.dirname(configPath), selected.workflowPath);
+  let result: ExpandedWorkflowLoadResult;
+  try {
+    result = await loadExpandedWorkflow(workflowPath);
+  } catch (error) {
+    return {
+      errors: [
+        ...errors,
+        `workflow contract not found at ${workflowPath}: ${errorMessage(error)}`
+      ],
+      projectName: selected.name,
+      workflow: null,
+      workflowPath
+    };
+  }
+
+  return {
+    errors: [...errors, ...result.errors],
+    projectName: selected.name,
+    workflow: result.workflow,
+    workflowPath
+  };
+}
+
+export function explainWorkflow(workflow: ExpandedWorkflow): string {
+  const lines = [
+    `workflow: ${workflow.name}`,
+    `source: ${workflow.source.path}`,
+    `source kind: ${workflow.source.kind}`,
+    `content hash: ${workflow.contentHash}`,
+    `initial: ${workflow.initial}`,
+    `template files: ${workflow.templateFiles.length === 0 ? "(none)" : workflow.templateFiles.join(", ")}`,
+    "states:"
+  ];
+
+  for (const state of workflow.states) {
+    lines.push(`  state: ${state.id}`);
+    if (state.action !== undefined) {
+      lines.push(`    action: ${formatWorkflowAction(state.action)}`);
+    }
+    if (Object.keys(state.completeWhen).length > 0) {
+      lines.push(`    complete_when: ${formatPredicateMap(state.completeWhen)}`);
+    }
+    if (state.transitions.length > 0) {
+      lines.push("    transitions:");
+      for (const transition of state.transitions) {
+        const predicate =
+          Object.keys(transition.when).length === 0
+            ? ""
+            : ` when ${formatPredicateMap(transition.when)}`;
+        lines.push(`      -> ${transition.to}${predicate}`);
+      }
+    }
+    if (state.terminal !== undefined) {
+      lines.push(`    terminal: ${state.terminal}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
 }
 
 export async function validateWorkflowContract(
@@ -254,6 +456,442 @@ export function validateWorkflowTemplate(
   }
 
   return errors;
+}
+
+function expandWorkflowDefinition(
+  contents: string,
+  workflowPath: string
+): ExpandedWorkflowLoadResult {
+  const errors: string[] = [];
+  const explicit = parseExplicitWorkflowDefinition(contents, workflowPath, errors);
+  if (explicit !== undefined) {
+    return expandRawStateMachineWorkflow(explicit, workflowPath, contentHash(contents), errors);
+  }
+
+  const workflow = parseWorkflowContract(contents, workflowPath);
+  errors.push(...workflow.errors);
+  if (workflow.body.trim().length === 0) {
+    errors.push(`workflow contract at ${workflowPath} must not be empty`);
+  }
+  errors.push(...validateWorkflowTemplate(workflow.body, workflowPath));
+  return {
+    errors,
+    workflow: markdownCompatibilityWorkflow(workflow)
+  };
+}
+
+function projectWorkflowReferences(
+  rawProjects: unknown[],
+  configPath: string,
+  errors: string[]
+): Array<{ name: string; workflowPath: string }> {
+  const projects: Array<{ name: string; workflowPath: string }> = [];
+  for (const [index, rawProject] of rawProjects.entries()) {
+    if (!isRecord(rawProject)) {
+      errors.push(`projects.${index} in ${configPath} must be a mapping`);
+      continue;
+    }
+    const name = stringProperty(rawProject, "name");
+    if (name === undefined) {
+      errors.push(`projects.${index}.name in ${configPath} must be a non-empty string`);
+      continue;
+    }
+    const workflowPath = stringProperty(rawProject, "workflow");
+    if (workflowPath === undefined) {
+      errors.push(
+        `projects.${name}.workflow in ${configPath} must be a non-empty path`
+      );
+      continue;
+    }
+    projects.push({
+      name,
+      workflowPath
+    });
+  }
+  return projects;
+}
+
+function selectProjectWorkflow(
+  projects: Array<{ name: string; workflowPath: string }>,
+  requestedProject: string | undefined,
+  configPath: string,
+  errors: string[]
+): { name: string; workflowPath: string } | undefined {
+  if (requestedProject !== undefined) {
+    const selected = projects.find((project) => project.name === requestedProject);
+    if (selected === undefined) {
+      errors.push(
+        `project ${requestedProject} is not defined in service config ${configPath}`
+      );
+    }
+    return selected;
+  }
+
+  if (projects.length === 1) {
+    return projects[0];
+  }
+
+  if (projects.length === 0) {
+    errors.push(`service config ${configPath} does not contain a project workflow`);
+  } else {
+    errors.push(
+      `service config ${configPath} has ${projects.length} projects; pass --project`
+    );
+  }
+  return undefined;
+}
+
+function parseExplicitWorkflowDefinition(
+  contents: string,
+  workflowPath: string,
+  errors: string[]
+): Record<string, unknown> | undefined {
+  let parsed: unknown;
+  try {
+    parsed = parse(contents) ?? {};
+  } catch (error) {
+    if (looksLikeYamlPath(workflowPath)) {
+      errors.push(
+        `workflow definition at ${workflowPath} could not be parsed: ${errorMessage(error)}`
+      );
+    }
+    return undefined;
+  }
+
+  if (!isRecord(parsed) || !isRecord(parsed.workflow)) {
+    return undefined;
+  }
+
+  return parsed.workflow;
+}
+
+function expandRawStateMachineWorkflow(
+  rawWorkflow: Record<string, unknown>,
+  workflowPath: string,
+  workflowContentHash: string,
+  errors: string[]
+): ExpandedWorkflowLoadResult {
+  const name = stringProperty(rawWorkflow, "name");
+  if (name === undefined) {
+    errors.push(`workflow definition at ${workflowPath} must define workflow.name`);
+  }
+
+  const initial = stringProperty(rawWorkflow, "initial");
+  if (initial === undefined) {
+    errors.push(`workflow definition at ${workflowPath} must define workflow.initial`);
+  }
+
+  const rawStates = recordProperty(rawWorkflow, "states");
+  if (rawStates === undefined) {
+    errors.push(`workflow definition at ${workflowPath} must define workflow.states`);
+  }
+
+  const states: ExpandedWorkflowState[] = [];
+  if (rawStates !== undefined) {
+    for (const [stateId, rawState] of Object.entries(rawStates)) {
+      states.push(parseWorkflowState(stateId, rawState, workflowPath, errors));
+    }
+  }
+
+  const stateIds = new Set(states.map((state) => state.id));
+  if (initial !== undefined && !stateIds.has(initial)) {
+    errors.push(
+      `workflow definition at ${workflowPath} initial state ${initial} is not declared`
+    );
+  }
+  for (const state of states) {
+    for (const transition of state.transitions) {
+      if (!stateIds.has(transition.to)) {
+        errors.push(
+          `workflow state ${state.id} at ${workflowPath} transitions to unknown state ${transition.to}`
+        );
+      }
+    }
+  }
+
+  return {
+    errors,
+    workflow: {
+      contentHash: workflowContentHash,
+      initial: initial ?? "",
+      name: name ?? path.basename(workflowPath, path.extname(workflowPath)),
+      source: {
+        kind: "raw_fsm",
+        path: workflowPath
+      },
+      states,
+      templateFiles: []
+    }
+  };
+}
+
+function parseWorkflowState(
+  stateId: string,
+  rawState: unknown,
+  workflowPath: string,
+  errors: string[]
+): ExpandedWorkflowState {
+  if (!/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(stateId)) {
+    errors.push(
+      `workflow state ${stateId} at ${workflowPath} must use a path-safe identifier`
+    );
+  }
+
+  if (!isRecord(rawState)) {
+    errors.push(`workflow state ${stateId} at ${workflowPath} must be a mapping`);
+    return {
+      completeWhen: {},
+      id: stateId,
+      transitions: []
+    };
+  }
+
+  const action = parseWorkflowAction(stateId, rawState.action, workflowPath, errors);
+  const completeWhen = parsePredicateMap(
+    stateId,
+    "complete_when",
+    rawState.complete_when,
+    workflowPath,
+    errors
+  );
+  const transitions = parseWorkflowTransitions(
+    stateId,
+    rawState.transitions,
+    workflowPath,
+    errors
+  );
+  const terminal = stringProperty(rawState, "terminal");
+  if (rawState.terminal !== undefined && !terminalStates.has(terminal ?? "")) {
+    errors.push(
+      `workflow state ${stateId} at ${workflowPath} terminal must be success, blocked, or failure`
+    );
+  }
+  if (action === undefined && terminal === undefined) {
+    errors.push(
+      `workflow state ${stateId} at ${workflowPath} must define action or terminal`
+    );
+  }
+
+  return {
+    ...(action === undefined ? {} : { action }),
+    completeWhen,
+    id: stateId,
+    ...(terminal === undefined ? {} : { terminal }),
+    transitions
+  };
+}
+
+function parseWorkflowAction(
+  stateId: string,
+  rawAction: unknown,
+  workflowPath: string,
+  errors: string[]
+): WorkflowAction | undefined {
+  if (rawAction === undefined) {
+    return undefined;
+  }
+  if (!isRecord(rawAction)) {
+    errors.push(`workflow state ${stateId} at ${workflowPath} action must be a mapping`);
+    return undefined;
+  }
+
+  const rawKind = stringProperty(rawAction, "kind");
+  if (rawKind === undefined || !actionKinds.has(rawKind as WorkflowActionKind)) {
+    errors.push(
+      `workflow state ${stateId} at ${workflowPath} action.kind must be one of ${[...actionKinds].join(", ")}`
+    );
+    return undefined;
+  }
+
+  const kind = rawKind as WorkflowActionKind;
+  const provider = stringProperty(rawAction, "provider");
+  const prompt = stringProperty(rawAction, "prompt");
+  const method = stringProperty(rawAction, "method");
+
+  if (kind === "agent") {
+    if (provider !== "codex" && provider !== "claude") {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} agent action must define provider codex or claude`
+      );
+    }
+    if (prompt === undefined) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} agent action must define prompt`
+      );
+    }
+  }
+
+  return {
+    kind,
+    ...(method === undefined ? {} : { method }),
+    ...(prompt === undefined ? {} : { prompt }),
+    ...(provider === "codex" || provider === "claude" ? { provider } : {})
+  };
+}
+
+function parseWorkflowTransitions(
+  stateId: string,
+  rawTransitions: unknown,
+  workflowPath: string,
+  errors: string[]
+): WorkflowTransition[] {
+  if (rawTransitions === undefined) {
+    return [];
+  }
+  if (!Array.isArray(rawTransitions)) {
+    errors.push(
+      `workflow state ${stateId} at ${workflowPath} transitions must be a sequence`
+    );
+    return [];
+  }
+
+  const transitions: WorkflowTransition[] = [];
+  for (const [index, rawTransition] of rawTransitions.entries()) {
+    if (!isRecord(rawTransition)) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} transition ${index} must be a mapping`
+      );
+      continue;
+    }
+    const to = stringProperty(rawTransition, "to");
+    if (to === undefined) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} transition ${index} must define to`
+      );
+      continue;
+    }
+    transitions.push({
+      to,
+      when: parsePredicateMap(
+        stateId,
+        `transitions[${index}].when`,
+        rawTransition.when,
+        workflowPath,
+        errors
+      )
+    });
+  }
+  return transitions;
+}
+
+function parsePredicateMap(
+  stateId: string,
+  field: string,
+  rawValue: unknown,
+  workflowPath: string,
+  errors: string[]
+): WorkflowPredicateMap {
+  if (rawValue === undefined) {
+    return {};
+  }
+  if (!isRecord(rawValue)) {
+    errors.push(`workflow state ${stateId} at ${workflowPath} ${field} must be a mapping`);
+    return {};
+  }
+
+  const predicates: WorkflowPredicateMap = {};
+  for (const [key, value] of Object.entries(rawValue)) {
+    if (!completionPredicateKeys.has(key)) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} ${field} uses unknown predicate ${key}`
+      );
+      continue;
+    }
+    if (
+      typeof value !== "boolean" &&
+      typeof value !== "number" &&
+      typeof value !== "string"
+    ) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} ${field}.${key} must be a scalar`
+      );
+      continue;
+    }
+    predicates[key] = value;
+  }
+  return predicates;
+}
+
+function markdownCompatibilityWorkflow(
+  workflow: WorkflowContract
+): ExpandedWorkflow {
+  return {
+    contentHash: workflow.contentHash,
+    initial: "run_agent",
+    name: "single_agent_workflow",
+    source: {
+      kind: "markdown",
+      path: workflow.path
+    },
+    states: [
+      {
+        action: {
+          kind: "agent"
+        },
+        completeWhen: {
+          branch_ahead_of_base: true,
+          provider_success: true
+        },
+        id: "run_agent",
+        transitions: [
+          {
+            to: "done",
+            when: {}
+          }
+        ]
+      },
+      {
+        completeWhen: {},
+        id: "done",
+        terminal: "success",
+        transitions: []
+      }
+    ],
+    templateFiles: []
+  };
+}
+
+function formatWorkflowAction(action: WorkflowAction): string {
+  const parts = [`${action.kind}`];
+  if (action.provider !== undefined) {
+    parts.push(`provider=${action.provider}`);
+  }
+  if (action.prompt !== undefined) {
+    parts.push(`prompt=${action.prompt}`);
+  }
+  if (action.method !== undefined) {
+    parts.push(`method=${action.method}`);
+  }
+  return parts.join(" ");
+}
+
+function formatPredicateMap(predicates: WorkflowPredicateMap): string {
+  return Object.entries(predicates)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(", ");
+}
+
+function stringProperty(
+  record: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function recordProperty(
+  record: Record<string, unknown>,
+  key: string
+): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function looksLikeYamlPath(workflowPath: string): boolean {
+  const extension = path.extname(workflowPath).toLowerCase();
+  return extension === ".yaml" || extension === ".yml";
 }
 
 export async function persistRunEvidence(

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -671,6 +671,18 @@ function parseWorkflowState(
       `workflow state ${stateId} at ${workflowPath} terminal must be success, blocked, or failure`
     );
   }
+  if (terminal !== undefined) {
+    const disallowedFields = [
+      ...(rawState.action === undefined ? [] : ["action"]),
+      ...(rawState.complete_when === undefined ? [] : ["complete_when"]),
+      ...(rawState.transitions === undefined ? [] : ["transitions"])
+    ];
+    if (disallowedFields.length > 0) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} terminal states must not define ${formatTerminalStateDisallowedFields(disallowedFields)}`
+      );
+    }
+  }
   if (action === undefined && terminal === undefined) {
     errors.push(
       `workflow state ${stateId} at ${workflowPath} must define action or terminal`
@@ -684,6 +696,15 @@ function parseWorkflowState(
     ...(terminal === undefined ? {} : { terminal }),
     transitions
   };
+}
+
+function formatTerminalStateDisallowedFields(fields: string[]): string {
+  if (fields.length < 2) {
+    return fields[0] ?? "";
+  }
+  const prefix = fields.slice(0, -1).join(", ");
+  const last = fields[fields.length - 1] ?? "";
+  return fields.length === 2 ? `${prefix} or ${last}` : `${prefix}, or ${last}`;
 }
 
 function parseWorkflowAction(

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -559,6 +559,11 @@ function parseExplicitWorkflowDefinition(
   }
 
   if (!isRecord(parsed) || !isRecord(parsed.workflow)) {
+    if (looksLikeYamlPath(workflowPath)) {
+      errors.push(
+        `workflow definition at ${workflowPath} must define a top-level workflow mapping`
+      );
+    }
     return undefined;
   }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { buildCli } from "../src/cli.js";
 import type { StartDaemonOptions } from "../src/daemon.js";
@@ -8,6 +11,22 @@ import type {
   InitProjectOptions
 } from "../src/doctor.js";
 import type { SmokeOptions, SmokeReport } from "../src/smoke.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-cli-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
 
 describe("CLI", () => {
   it("starts the daemon with the selected config path and port", async () => {
@@ -465,5 +484,134 @@ describe("CLI", () => {
     expect(output.stderr).toContain("will create operational labels");
     expect(output.stdout).toContain("init-project ok");
     expect(output.stdout).toContain("sym:running");
+  });
+
+  it("explains the expanded workflow graph for a selected project", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeFile(
+      configPath,
+      [
+        "projects:",
+        "  - name: symphonika",
+        "    workflow: ./workflow.yml",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: agent",
+        "        provider: codex",
+        "        prompt: prompts/plan.md",
+        "      complete_when:",
+        "        artifact_exists: PLAN.md",
+        "      transitions:",
+        "        - to: done",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({ registerSignalHandlers: false });
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "workflow",
+      "explain",
+      "--config",
+      configPath,
+      "--project",
+      "symphonika"
+    ]);
+
+    expect(output.stderr).toBe("");
+    expect(output.stdout).toContain("workflow: issue_to_merge");
+    expect(output.stdout).toContain(`source: ${path.join(root, "workflow.yml")}`);
+    expect(output.stdout).toContain("state: planning");
+    expect(output.stdout).toContain(
+      "action: agent provider=codex prompt=prompts/plan.md"
+    );
+    expect(output.stdout).toContain("terminal: success");
+  });
+
+  it("validates the selected workflow graph and reports state-machine errors", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeFile(
+      configPath,
+      [
+        "projects:",
+        "  - name: symphonika",
+        "    workflow: ./workflow.yml",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: agent",
+        "        provider: codex",
+        "        prompt: prompts/plan.md",
+        "      transitions:",
+        "        - to: missing_state",
+        ""
+      ].join("\n")
+    );
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({ registerSignalHandlers: false });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    try {
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "workflow",
+        "validate",
+        "--config",
+        configPath,
+        "--project",
+        "symphonika"
+      ]);
+
+      expect(process.exitCode).toBe(1);
+      expect(output.stdout).toBe("");
+      expect(output.stderr).toContain("workflow validate failed");
+      expect(output.stderr).toContain("missing_state");
+    } finally {
+      process.exitCode = previousExitCode;
+    }
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -673,4 +673,72 @@ describe("CLI", () => {
       process.exitCode = previousExitCode;
     }
   });
+
+  it("rejects terminal workflow states that declare work", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeFile(
+      configPath,
+      [
+        "projects:",
+        "  - name: symphonika",
+        "    workflow: ./workflow.yml",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: done",
+        "  states:",
+        "    done:",
+        "      terminal: success",
+        "      action:",
+        "        kind: wait",
+        "      complete_when:",
+        "        provider_success: true",
+        "      transitions:",
+        "        - to: next",
+        "    next:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({ registerSignalHandlers: false });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    try {
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "workflow",
+        "validate",
+        "--config",
+        configPath,
+        "--project",
+        "symphonika"
+      ]);
+
+      expect(process.exitCode).toBe(1);
+      expect(output.stdout).toBe("");
+      expect(output.stderr).toContain("workflow validate failed");
+      expect(output.stderr).toContain(
+        "terminal states must not define action, complete_when, or transitions"
+      );
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -614,4 +614,63 @@ describe("CLI", () => {
       process.exitCode = previousExitCode;
     }
   });
+
+  it("rejects YAML workflow files that omit the top-level workflow mapping", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeFile(
+      configPath,
+      [
+        "projects:",
+        "  - name: symphonika",
+        "    workflow: ./workflow.yml",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflows:",
+        "  name: typo",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: wait",
+        ""
+      ].join("\n")
+    );
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({ registerSignalHandlers: false });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    try {
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "workflow",
+        "validate",
+        "--config",
+        configPath,
+        "--project",
+        "symphonika"
+      ]);
+
+      expect(process.exitCode).toBe(1);
+      expect(output.stdout).toBe("");
+      expect(output.stderr).toContain("workflow validate failed");
+      expect(output.stderr).toContain("top-level workflow mapping");
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
 });

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  explainWorkflow,
+  loadExpandedWorkflow,
   loadWorkflowContract,
   persistRunEvidence,
   renderAutonomousPrompt
@@ -299,6 +301,140 @@ describe("workflow prompt rendering", () => {
     );
     expect(rendered.prompt).not.toContain("max_turns");
     expect(rendered.workflowContentHash).toBe(workflow.contentHash);
+  });
+});
+
+describe("state machine workflow definitions", () => {
+  it("compiles Markdown workflow contracts to the single-agent compatibility graph", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(workflowPath, "Work on {{issue.title}}.\n");
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow).toMatchObject({
+      initial: "run_agent",
+      name: "single_agent_workflow",
+      source: {
+        kind: "markdown",
+        path: workflowPath
+      },
+      states: [
+        {
+          action: {
+            kind: "agent"
+          },
+          completeWhen: {
+            branch_ahead_of_base: true,
+            provider_success: true
+          },
+          id: "run_agent",
+          transitions: [
+            {
+              to: "done"
+            }
+          ]
+        },
+        {
+          id: "done",
+          terminal: "success"
+        }
+      ]
+    });
+  });
+
+  it("loads and explains an explicit raw FSM workflow", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: agent",
+        "        provider: codex",
+        "        prompt: prompts/plan.md",
+        "      complete_when:",
+        "        artifact_exists: PLAN.md",
+        "      transitions:",
+        "        - to: implementing",
+        "    implementing:",
+        "      action:",
+        "        kind: agent",
+        "        provider: codex",
+        "        prompt: prompts/implement-tdd.md",
+        "      complete_when:",
+        "        branch_ahead_of_base: true",
+        "        pr_open: true",
+        "      transitions:",
+        "        - to: done",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+    const explanation = explainWorkflow(result.workflow);
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow).toMatchObject({
+      initial: "planning",
+      name: "issue_to_merge",
+      source: {
+        kind: "raw_fsm",
+        path: workflowPath
+      }
+    });
+    expect(explanation).toContain("workflow: issue_to_merge");
+    expect(explanation).toContain(`source: ${workflowPath}`);
+    expect(explanation).toContain("initial: planning");
+    expect(explanation).toContain("state: planning");
+    expect(explanation).toContain(
+      "action: agent provider=codex prompt=prompts/plan.md"
+    );
+    expect(explanation).toContain("complete_when: artifact_exists=PLAN.md");
+    expect(explanation).toContain("-> implementing");
+    expect(explanation).toContain("state: done");
+    expect(explanation).toContain("terminal: success");
+  });
+
+  it("reports invalid raw FSM transitions and predicates", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: agent",
+        "        provider: codex",
+        "        prompt: prompts/plan.md",
+        "      complete_when:",
+        "        local_guess: true",
+        "      transitions:",
+        "        - to: missing_state",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toContain(
+      `workflow state planning at ${workflowPath} complete_when uses unknown predicate local_guess`
+    );
+    expect(result.errors).toContain(
+      `workflow state planning at ${workflowPath} transitions to unknown state missing_state`
+    );
   });
 });
 

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -437,6 +437,37 @@ describe("state machine workflow definitions", () => {
     );
   });
 
+  it("rejects terminal states that also declare work or outgoing transitions", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: done",
+        "  states:",
+        "    done:",
+        "      terminal: success",
+        "      action:",
+        "        kind: wait",
+        "      complete_when:",
+        "        provider_success: true",
+        "      transitions:",
+        "        - to: next",
+        "    next:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toContain(
+      `workflow state done at ${workflowPath} terminal states must not define action, complete_when, or transitions`
+    );
+  });
+
   it("rejects YAML workflow files that are missing the top-level workflow mapping", async () => {
     const root = await makeTempRoot();
     const workflowPath = path.join(root, "workflow.yml");

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -436,6 +436,30 @@ describe("state machine workflow definitions", () => {
       `workflow state planning at ${workflowPath} transitions to unknown state missing_state`
     );
   });
+
+  it("rejects YAML workflow files that are missing the top-level workflow mapping", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflows:",
+        "  name: typo",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: wait",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toContain(
+      `workflow definition at ${workflowPath} must define a top-level workflow mapping`
+    );
+  });
 });
 
 function issueSnapshot() {


### PR DESCRIPTION
## Summary
- add the state-machine workflow design document
- compile raw FSM workflow YAML into an expanded graph for validation and explanation
- add read-only `symphonika workflow validate` and `symphonika workflow explain` commands
- keep existing Markdown workflow contracts valid through a single-agent compatibility graph

## Validation
- npm test
- npm run typecheck
- npm run lint
- npm run build
- git diff --check
- npm run dev -- workflow validate --config symphonika.yml --project symphonika
