### PR TITLE
Dispatch Markdown workflows through reload-compiled graph

### DIFF
--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -51,6 +51,7 @@ import { buildCapReachedReason } from "./terminal-reason.js";
 export type WorkflowSnapshot = {
   body: string;
   contentHash: string;
+  expandedWorkflow: ExpandedWorkflow;
   path: string;
 };
 
@@ -1042,12 +1043,11 @@ export class RunController {
       };
     }
 
-    const expanded = expandWorkflowDefinition(workflow.body, workflow.path);
     return {
       body: workflow.body,
       contentHash: workflow.contentHash,
-      errors: expanded.errors,
-      expandedWorkflow: { ...expanded.workflow, contentHash: workflow.contentHash },
+      errors: [],
+      expandedWorkflow: workflow.expandedWorkflow,
       path: workflow.path
     };
   }

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -356,6 +356,7 @@ async function readWorkflowSnapshot(
   return {
     body: workflow.body,
     contentHash: workflow.contentHash,
+    expandedWorkflow: expanded.workflow,
     path: workflow.path
   };
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -741,4 +741,99 @@ describe("CLI", () => {
       process.exitCode = previousExitCode;
     }
   });
+
+  it("reports the compatibility graph when validating a Markdown WORKFLOW.md", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeFile(
+      configPath,
+      [
+        "projects:",
+        "  - name: symphonika",
+        "    workflow: ./WORKFLOW.md",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}}.\n"
+    );
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({ registerSignalHandlers: false });
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "workflow",
+      "validate",
+      "--config",
+      configPath,
+      "--project",
+      "symphonika"
+    ]);
+
+    expect(output.stderr).toBe("");
+    expect(output.stdout).toContain(
+      "workflow validate ok: symphonika -> single_agent_workflow"
+    );
+    expect(output.stdout).toContain(`source: ${path.join(root, "WORKFLOW.md")}`);
+    expect(output.stdout).toContain("states: 2");
+  });
+
+  it("explains the compatibility graph for a Markdown WORKFLOW.md", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeFile(
+      configPath,
+      [
+        "projects:",
+        "  - name: symphonika",
+        "    workflow: ./WORKFLOW.md",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}}.\n"
+    );
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({ registerSignalHandlers: false });
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "workflow",
+      "explain",
+      "--config",
+      configPath,
+      "--project",
+      "symphonika"
+    ]);
+
+    expect(output.stderr).toBe("");
+    expect(output.stdout).toContain("workflow: single_agent_workflow");
+    expect(output.stdout).toContain(`source: ${path.join(root, "WORKFLOW.md")}`);
+    expect(output.stdout).toContain("initial: run_agent");
+    expect(output.stdout).toContain("state: run_agent");
+    expect(output.stdout).toContain("state: done");
+    expect(output.stdout).toContain("terminal: success");
+  });
 });

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -6,11 +6,20 @@ import pino from "pino";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { startDaemon } from "../src/daemon.js";
+import { ActiveRunRegistry } from "../src/lifecycle/active-runs.js";
+import {
+  RunController,
+  type RunControllerProjectConfig,
+  type WorkflowSnapshot
+} from "../src/lifecycle/run-controller.js";
 import type {
   AgentProvider,
   ProviderEvent,
   ProviderRunInput
 } from "../src/provider.js";
+import { RuntimeConfigReloader } from "../src/reload.js";
+import { openRunStore } from "../src/run-store.js";
+import { loadExpandedWorkflow } from "../src/workflow.js";
 import type {
   PreparedIssueWorkspace,
   PrepareIssueWorkspaceInput
@@ -243,6 +252,12 @@ describe("daemon dispatch", () => {
       expect(path.relative(workspacePath, run.workflowGraphPath)).toMatch(
         /^\.\./
       );
+
+      const canonicalGraph = await loadExpandedWorkflow(
+        path.join(root, "WORKFLOW.md")
+      );
+      expect(canonicalGraph.errors).toEqual([]);
+      expect(graphContents).toEqual(canonicalGraph.workflow);
 
       const promptMetadataPath = path.join(
         root,
@@ -755,6 +770,106 @@ describe("daemon dispatch", () => {
       }
     } finally {
       await daemon.stop();
+    }
+  });
+
+  it("dispatches using the snapshot graph rather than re-expanding the workflow", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    const reloader = new RuntimeConfigReloader({
+      configPath: path.join(root, "symphonika.yml")
+    });
+    await reloader.reload();
+    const project = reloader.projectsByName().get("symphonika");
+    if (project === undefined) {
+      throw new Error("expected reloader to expose symphonika project");
+    }
+    const snapshot = project.workflow;
+    if (typeof snapshot === "string") {
+      throw new Error("expected reloader to expose a workflow snapshot");
+    }
+    const sentinelTemplate = "sentinel-only-in-snapshot.txt";
+    const mutatedSnapshot: WorkflowSnapshot = {
+      ...snapshot,
+      expandedWorkflow: {
+        ...snapshot.expandedWorkflow,
+        templateFiles: [...snapshot.expandedWorkflow.templateFiles, sentinelTemplate]
+      }
+    };
+    const mutatedProject: RunControllerProjectConfig = {
+      ...project,
+      workflow: mutatedSnapshot
+    };
+
+    const codexProvider = successfulCodexProvider();
+    const runStore = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const controller = new RunController({
+        activeRuns: new ActiveRunRegistry(),
+        agentProviders: { codex: codexProvider },
+        configDir: root,
+        createRunId: () => "run-sentinel",
+        env: { GITHUB_TOKEN: "secret-token" },
+        githubIssuesApi: {
+          addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+          listOpenIssues: vi.fn().mockResolvedValue([]),
+          removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+        },
+        lifecyclePolicy: {
+          continuation: { cap: 0, delayMs: 0 },
+          retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+        },
+        logger: pino({ enabled: false }),
+        prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace),
+        projectsLoader: () =>
+          Promise.resolve(new Map([[mutatedProject.name, mutatedProject]])),
+        providersLoader: () => Promise.resolve(reloader.providersConfig()),
+        runStore,
+        schedule: () => undefined,
+        stateRoot: path.join(root, ".symphonika")
+      });
+
+      const result = await controller.dispatchOneFresh({
+        candidateIssues: [
+          {
+            issue: {
+              body: "irrelevant",
+              created_at: "2026-05-01T10:00:00Z",
+              id: 5008,
+              labels: ["agent-ready"],
+              number: 8,
+              priority: 99,
+              state: "open",
+              title: "Dispatch an end-to-end run through a test provider",
+              updated_at: "2026-05-02T11:00:00Z",
+              url: "https://github.com/pmatos/symphonika/issues/8"
+            },
+            project: mutatedProject.name
+          }
+        ],
+        errors: [],
+        filteredIssues: [],
+        projects: []
+      });
+      expect(result).toEqual({ dispatched: true, runId: "run-sentinel" });
+
+      const graphPath = path.join(
+        root,
+        ".symphonika",
+        "logs",
+        "runs",
+        "run-sentinel",
+        "workflow-graph.json"
+      );
+      const graph = JSON.parse(await readFile(graphPath, "utf8")) as {
+        templateFiles: string[];
+      };
+      expect(graph.templateFiles).toContain(sentinelTemplate);
+    } finally {
+      runStore.close();
     }
   });
 });

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -138,5 +139,40 @@ describe("RuntimeConfigReloader workflow validation", () => {
     expect(status.errors).toEqual([]);
     expect(status.ok).toBe(true);
     expect(reloader.projectsByName().has("symphonika")).toBe(true);
+  });
+
+  it("exposes the expanded compatibility graph for a Markdown WORKFLOW.md", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md");
+    const workflowBody = "Work on {{issue.title}}.\n";
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(workflowPath, workflowBody, "utf8");
+
+    const reloader = new RuntimeConfigReloader({
+      configPath: path.join(root, "symphonika.yml")
+    });
+    await reloader.reload();
+
+    const project = reloader.projectsByName().get("symphonika");
+    expect(project).toBeDefined();
+    const workflow = project?.workflow;
+    expect(typeof workflow).toBe("object");
+    if (typeof workflow === "string" || workflow === undefined) {
+      throw new Error("expected workflow snapshot to be an object");
+    }
+
+    const onDisk = await readFile(workflowPath, "utf8");
+    const expectedHash = `sha256:${createHash("sha256").update(onDisk).digest("hex")}`;
+
+    expect(workflow.expandedWorkflow).toMatchObject({
+      initial: "run_agent",
+      name: "single_agent_workflow",
+      source: { kind: "markdown", path: workflowPath }
+    });
+    expect(workflow.expandedWorkflow.contentHash).toBe(expectedHash);
+    expect(workflow.expandedWorkflow.states.map((state) => state.id)).toEqual([
+      "run_agent",
+      "done"
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- `WorkflowSnapshot` now carries `expandedWorkflow`, populated once by `readWorkflowSnapshot` during reload from the full file contents (so the front-matter `contentHash` override workaround is gone).
- `RunController.loadWorkflow` consumes the snapshot-borne graph directly instead of calling `expandWorkflowDefinition` a second time per dispatch attempt. The one-shot CLI string-input path is unchanged.
- Resolves #93.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (282 passing)
- [x] `npm run build`
- [x] New `tests/reload.test.ts` case: snapshot exposes `expandedWorkflow` with `initial: run_agent`, `name: single_agent_workflow`, markdown source, and sha256 matching the on-disk file.
- [x] New `tests/daemon-dispatch.test.ts` sentinel case: mutating snapshot `templateFiles` is reflected in the persisted `workflow-graph.json`, proving dispatch uses the snapshot graph.
- [x] Added regression assertion in the existing Markdown dispatch test that the persisted `workflow-graph.json` deep-equals `loadExpandedWorkflow(WORKFLOW.md)`.
- [x] New `tests/cli.test.ts` cases: `workflow validate` and `workflow explain` against a Markdown `WORKFLOW.md` report the one-state compatibility graph.