### PR TITLE
Execute raw FSM workflows through the state machine dispatcher

### DIFF
--- a/src/config-schemas.ts
+++ b/src/config-schemas.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+const workflowPathSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => !value.includes("\0"), "path must not contain NUL bytes");
+
+export const workflowFormatSchema = z.enum(["markdown", "raw_fsm", "auto"]);
+export type WorkflowFormat = z.infer<typeof workflowFormatSchema>;
+
+export const workflowReferenceSchema = z.union([
+  workflowPathSchema.transform((value) => ({
+    format: "auto" as const,
+    path: value
+  })),
+  z
+    .object({
+      format: workflowFormatSchema.default("auto"),
+      path: workflowPathSchema
+    })
+    .strict()
+]);
+
+export type WorkflowReference = z.infer<typeof workflowReferenceSchema>;

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { parse } from "yaml";
 import { z } from "zod";
 
+import { workflowReferenceSchema } from "./config-schemas.js";
 import type {
   GitHubIssueLabelInput,
   GitHubIssuesApi,
@@ -103,7 +104,7 @@ const dispatchProjectSchema = z
         provider: providerNameSchema
       })
       .passthrough(),
-    workflow: z.string().trim().min(1)
+    workflow: workflowReferenceSchema
   })
   .passthrough();
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,6 +4,7 @@ import { Octokit } from "@octokit/rest";
 import { parse } from "yaml";
 import { z } from "zod";
 
+import { workflowReferenceSchema } from "./config-schemas.js";
 import {
   DEFAULT_GITHUB_ISSUES_API,
   type GitHubIssuesApi
@@ -200,7 +201,7 @@ const projectSchema = z
         provider: providerNameSchema
       })
       .passthrough(),
-    workflow: pathStringSchema
+    workflow: workflowReferenceSchema
   })
   .passthrough();
 
@@ -259,7 +260,7 @@ export async function runDoctor(
       errors,
       githubApi
     );
-    const workflowPath = path.resolve(path.dirname(configPath), project.workflow);
+    const workflowPath = path.resolve(path.dirname(configPath), project.workflow.path);
     const workflowErrors = await validateWorkflowContract(workflowPath);
     errors.push(...workflowErrors);
     const staleIssues = await fetchStaleIssues(

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,6 +4,7 @@ import { Octokit } from "@octokit/rest";
 import { parse } from "yaml";
 import { z } from "zod";
 
+import type { WorkflowFormat } from "./config-schemas.js";
 import { workflowReferenceSchema } from "./config-schemas.js";
 import {
   DEFAULT_GITHUB_ISSUES_API,
@@ -12,7 +13,7 @@ import {
 import { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
-import { validateWorkflowContract } from "./workflow.js";
+import { loadExpandedWorkflow } from "./workflow.js";
 
 export { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
 
@@ -261,7 +262,10 @@ export async function runDoctor(
       githubApi
     );
     const workflowPath = path.resolve(path.dirname(configPath), project.workflow.path);
-    const workflowErrors = await validateWorkflowContract(workflowPath);
+    const workflowErrors = await collectWorkflowErrors(
+      workflowPath,
+      project.workflow.format
+    );
     errors.push(...workflowErrors);
     const staleIssues = await fetchStaleIssues(
       project,
@@ -277,6 +281,19 @@ export async function runDoctor(
   }
 
   return report(configPath, errors, projects);
+}
+
+async function collectWorkflowErrors(
+  workflowPath: string,
+  format: WorkflowFormat
+): Promise<string[]> {
+  try {
+    const expanded = await loadExpandedWorkflow(workflowPath, format);
+    return expanded.errors;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return [`workflow contract not found at ${workflowPath}: ${message}`];
+  }
 }
 
 async function fetchStaleIssues(

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -900,14 +900,18 @@ export class RunController {
         terminal.reason,
         terminal.classification
       );
+      let advancedToTerminal = false;
       if (currentState !== undefined) {
-        this.applyWorkflowOutcome({
+        ({ advancedToTerminal } = this.applyWorkflowOutcome({
           currentState,
           runId: input.runId,
           terminal,
           workflow: loadedWorkflow.expandedWorkflow
-        });
+        }));
       }
+      const suppressContinuation =
+        advancedToTerminal &&
+        loadedWorkflow.expandedWorkflow.source.kind === "raw_fsm";
       this.runStore.updateRunState(input.runId, outcomeState);
 
       const willRetry =
@@ -956,7 +960,8 @@ export class RunController {
           project: input.project,
           repository: input.repository,
           runId: input.runId,
-          runtimeAttemptNumber: input.attemptNumber
+          runtimeAttemptNumber: input.attemptNumber,
+          suppressContinuation
         });
       } catch (scheduleError) {
         this.logger?.error(
@@ -1075,7 +1080,7 @@ export class RunController {
     runId: string;
     terminal: ClassifiedTerminal;
     workflow: ExpandedWorkflow;
-  }): void {
+  }): { advancedToTerminal: boolean } {
     const signals = signalsFromTerminal(input.terminal);
     const decision = decideNextStep({
       actionExecuted: true,
@@ -1090,10 +1095,10 @@ export class RunController {
           terminalStateId: next.id,
           transitionReason: decision.reason
         });
-        return;
+        return { advancedToTerminal: true };
       }
       this.runStore.setRunCurrentState(input.runId, decision.to);
-      return;
+      return { advancedToTerminal: false };
     }
 
     if (decision.kind === "blocked") {
@@ -1101,7 +1106,7 @@ export class RunController {
         terminalStateId: input.currentState.id,
         transitionReason: decision.reason
       });
-      return;
+      return { advancedToTerminal: false };
     }
 
     if (decision.kind === "terminate") {
@@ -1109,7 +1114,10 @@ export class RunController {
         terminalStateId: decision.stateId,
         transitionReason: `entered terminal state ${decision.terminal}`
       });
+      return { advancedToTerminal: true };
     }
+
+    return { advancedToTerminal: false };
   }
 
   private async loadWorkflow(
@@ -1321,6 +1329,7 @@ export class RunController {
     repository: GitHubIssueRepositoryInput;
     runId: string;
     runtimeAttemptNumber: number;
+    suppressContinuation?: boolean;
   }): Promise<void> {
     if (input.outcome.kind === "cancelled" || input.outcome.kind === "input_required") {
       return;
@@ -1357,6 +1366,14 @@ export class RunController {
     }
 
     // success path: re-check eligibility, schedule continuation, enforce cap.
+    // For raw FSM workflows that reached an explicit terminal node, "terminal"
+    // means the workflow is done — do not schedule another continuation even
+    // if the issue still matches `agent-ready`. Markdown compatibility-graph
+    // workflows keep the legacy "loop on agent-ready" behavior.
+    if (input.suppressContinuation === true) {
+      return;
+    }
+
     const refreshed = await this.refreshIssue({
       project: input.project,
       issueNumber: input.issue.number,

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -832,7 +832,8 @@ export class RunController {
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           throw new Error(
-            `workflow state ${currentState.id} prompt not found at ${promptPath}: ${message}`
+            `workflow state ${currentState.id} prompt not found at ${promptPath}: ${message}`,
+            { cause: error }
           );
         }
       }

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -29,13 +29,18 @@ import type {
 import { prepareIssueWorkspace as defaultPrepareIssueWorkspace } from "../workspace.js";
 import { readFile } from "node:fs/promises";
 
+import type { WorkflowReference } from "../config-schemas.js";
 import {
   expandWorkflowDefinition,
   parseWorkflowContract,
   persistRunEvidence,
   renderAutonomousPrompt
 } from "../workflow.js";
-import type { ExpandedWorkflow } from "../workflow.js";
+import type {
+  ExpandedWorkflow,
+  ExpandedWorkflowState,
+  WorkflowPredicateMap
+} from "../workflow.js";
 
 import {
   ActiveRunRegistry,
@@ -46,6 +51,10 @@ import {
 } from "./active-runs.js";
 import { classifyCapReachedOutcome } from "./cap-reached-context.js";
 import { classifyFailure, type ClassifiedTerminal } from "./classify-failure.js";
+import {
+  decideNextStep,
+  findWorkflowState
+} from "./state-machine-dispatch.js";
 import { buildCapReachedReason } from "./terminal-reason.js";
 
 export type WorkflowSnapshot = {
@@ -64,7 +73,7 @@ type LoadedWorkflow = {
 };
 
 export type RunControllerProjectConfig = PollingProjectConfig & {
-  workflow: string | WorkflowSnapshot;
+  workflow: WorkflowReference | WorkflowSnapshot;
   workspace: {
     git: {
       base_branch: string;
@@ -777,6 +786,33 @@ export class RunController {
 
     this.runStore.updateRunState(input.runId, "preparing_workspace");
 
+    const loadedWorkflow = await this.loadWorkflow(input.project.workflow);
+    let projectForAttempt = input.project;
+    let currentState = undefined as
+      | ReturnType<typeof findWorkflowState>
+      | undefined;
+    if (loadedWorkflow.errors.length === 0) {
+      const persistedStateId = this.runStore.getRun(input.runId)?.currentStateId;
+      const startStateId =
+        persistedStateId ?? loadedWorkflow.expandedWorkflow.initial;
+      currentState = findWorkflowState(
+        loadedWorkflow.expandedWorkflow,
+        startStateId
+      );
+      if (currentState !== undefined) {
+        this.runStore.setRunCurrentState(input.runId, currentState.id);
+      }
+      projectForAttempt = {
+        ...input.project,
+        workflow: {
+          body: loadedWorkflow.body,
+          contentHash: loadedWorkflow.contentHash,
+          expandedWorkflow: loadedWorkflow.expandedWorkflow,
+          path: loadedWorkflow.path
+        }
+      };
+    }
+
     try {
       started = await this.startAttempt({
         attemptId,
@@ -786,7 +822,7 @@ export class RunController {
           : { extraInstructions: input.extraInstructions }),
         isContinuation: input.isContinuation,
         issue: input.issue,
-        project: input.project,
+        project: projectForAttempt,
         providerCommand: input.providerCommand,
         providerName: input.providerName,
         runId: input.runId
@@ -864,6 +900,14 @@ export class RunController {
         terminal.reason,
         terminal.classification
       );
+      if (currentState !== undefined) {
+        this.applyWorkflowOutcome({
+          currentState,
+          runId: input.runId,
+          terminal,
+          workflow: loadedWorkflow.expandedWorkflow
+        });
+      }
       this.runStore.updateRunState(input.runId, outcomeState);
 
       const willRetry =
@@ -1026,14 +1070,60 @@ export class RunController {
     };
   }
 
+  private applyWorkflowOutcome(input: {
+    currentState: ExpandedWorkflowState;
+    runId: string;
+    terminal: ClassifiedTerminal;
+    workflow: ExpandedWorkflow;
+  }): void {
+    const signals = signalsFromTerminal(input.terminal);
+    const decision = decideNextStep({
+      actionExecuted: true,
+      signals,
+      state: input.currentState
+    });
+
+    if (decision.kind === "advance") {
+      const next = findWorkflowState(input.workflow, decision.to);
+      if (next?.terminal !== undefined) {
+        this.runStore.recordWorkflowTerminal(input.runId, {
+          terminalStateId: next.id,
+          transitionReason: decision.reason
+        });
+        return;
+      }
+      this.runStore.setRunCurrentState(input.runId, decision.to);
+      return;
+    }
+
+    if (decision.kind === "blocked") {
+      this.runStore.recordWorkflowTerminal(input.runId, {
+        terminalStateId: input.currentState.id,
+        transitionReason: decision.reason
+      });
+      return;
+    }
+
+    if (decision.kind === "terminate") {
+      this.runStore.recordWorkflowTerminal(input.runId, {
+        terminalStateId: decision.stateId,
+        transitionReason: `entered terminal state ${decision.terminal}`
+      });
+    }
+  }
+
   private async loadWorkflow(
-    workflow: string | WorkflowSnapshot
+    workflow: WorkflowReference | WorkflowSnapshot
   ): Promise<LoadedWorkflow> {
-    if (typeof workflow === "string") {
-      const workflowPath = path.resolve(this.configDir, workflow);
+    if (!("expandedWorkflow" in workflow)) {
+      const workflowPath = path.resolve(this.configDir, workflow.path);
       const contents = await readFile(workflowPath, "utf8");
       const contract = parseWorkflowContract(contents, workflowPath);
-      const expanded = expandWorkflowDefinition(contents, workflowPath);
+      const expanded = expandWorkflowDefinition(
+        contents,
+        workflowPath,
+        workflow.format
+      );
       return {
         body: contract.body,
         contentHash: contract.contentHash,
@@ -1560,4 +1650,16 @@ function normalizeProjectWeight(weight: number | undefined): number {
     return 1;
   }
   return weight;
+}
+
+function signalsFromTerminal(
+  terminal: ClassifiedTerminal
+): WorkflowPredicateMap {
+  if (terminal.kind === "success") {
+    return { branch_ahead_of_base: true, provider_success: true };
+  }
+  if (terminal.kind === "failed" && terminal.reason === "no_workspace_changes") {
+    return { branch_ahead_of_base: false, provider_success: true };
+  }
+  return { branch_ahead_of_base: false, provider_success: false };
 }

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -814,6 +814,29 @@ export class RunController {
     }
 
     try {
+      // For raw FSM workflows, the agent action's `prompt` field points at the
+      // template file to send to the provider for this state. Resolve it here
+      // so startAttempt renders the right prompt (rather than the YAML body of
+      // the workflow file, which is meaningless input for the agent).
+      let promptTemplate: string | undefined;
+      if (
+        currentState !== undefined &&
+        loadedWorkflow.expandedWorkflow.source.kind === "raw_fsm" &&
+        currentState.action?.kind === "agent" &&
+        currentState.action.prompt !== undefined
+      ) {
+        const workflowDir = path.dirname(loadedWorkflow.path);
+        const promptPath = path.resolve(workflowDir, currentState.action.prompt);
+        try {
+          promptTemplate = await readFile(promptPath, "utf8");
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `workflow state ${currentState.id} prompt not found at ${promptPath}: ${message}`
+          );
+        }
+      }
+
       started = await this.startAttempt({
         attemptId,
         attemptNumber: input.attemptNumber,
@@ -825,6 +848,7 @@ export class RunController {
         project: projectForAttempt,
         providerCommand: input.providerCommand,
         providerName: input.providerName,
+        ...(promptTemplate === undefined ? {} : { promptTemplate }),
         runId: input.runId
       });
       await input.provider.validate(input.providerCommand);
@@ -985,6 +1009,7 @@ export class RunController {
     isContinuation: boolean;
     issue: IssueSnapshot;
     project: RunControllerProjectConfig;
+    promptTemplate?: string;
     providerCommand: string;
     providerName: AgentProviderName;
     runId: string;
@@ -1023,7 +1048,7 @@ export class RunController {
         continuation: input.isContinuation,
         id: input.runId
       },
-      template: workflow.body,
+      template: input.promptTemplate ?? workflow.body,
       workflowContentHash: workflow.contentHash,
       workflowPath,
       workspace: {
@@ -1102,8 +1127,8 @@ export class RunController {
     }
 
     if (decision.kind === "blocked") {
-      this.runStore.recordWorkflowTerminal(input.runId, {
-        terminalStateId: input.currentState.id,
+      this.runStore.recordWorkflowBlocked(input.runId, {
+        stateId: input.currentState.id,
         transitionReason: decision.reason
       });
       return { advancedToTerminal: false };
@@ -1126,12 +1151,25 @@ export class RunController {
     if (!("expandedWorkflow" in workflow)) {
       const workflowPath = path.resolve(this.configDir, workflow.path);
       const contents = await readFile(workflowPath, "utf8");
-      const contract = parseWorkflowContract(contents, workflowPath);
       const expanded = expandWorkflowDefinition(
         contents,
         workflowPath,
         workflow.format
       );
+      // Raw FSM YAML files commonly open with the `---` document marker; the
+      // markdown contract parser would reject those as missing a closing
+      // delimiter. Skip it entirely for raw FSM — per-state `action.prompt`
+      // files supply the actual prompt at dispatch time.
+      if (expanded.workflow.source.kind === "raw_fsm") {
+        return {
+          body: "",
+          contentHash: expanded.workflow.contentHash,
+          errors: expanded.errors,
+          expandedWorkflow: expanded.workflow,
+          path: workflowPath
+        };
+      }
+      const contract = parseWorkflowContract(contents, workflowPath);
       return {
         body: contract.body,
         contentHash: contract.contentHash,

--- a/src/lifecycle/state-machine-dispatch.ts
+++ b/src/lifecycle/state-machine-dispatch.ts
@@ -1,0 +1,109 @@
+import type {
+  ExpandedWorkflow,
+  ExpandedWorkflowState,
+  WorkflowAction,
+  WorkflowPredicateMap,
+  WorkflowPredicateValue
+} from "../workflow.js";
+
+export type StateMachineDecision =
+  | { action: WorkflowAction; kind: "execute_action"; stateId: string }
+  | { kind: "terminate"; stateId: string; terminal: string }
+  | { kind: "advance"; reason: string; to: string }
+  | { kind: "blocked"; reason: string };
+
+export type StateMachineSignals = WorkflowPredicateMap;
+
+export function findWorkflowState(
+  workflow: ExpandedWorkflow,
+  stateId: string
+): ExpandedWorkflowState | undefined {
+  return workflow.states.find((state) => state.id === stateId);
+}
+
+export function decideNextStep(input: {
+  actionExecuted: boolean;
+  signals: StateMachineSignals;
+  state: ExpandedWorkflowState;
+}): StateMachineDecision {
+  const { actionExecuted, signals, state } = input;
+
+  if (state.terminal !== undefined) {
+    return { kind: "terminate", stateId: state.id, terminal: state.terminal };
+  }
+
+  if (!actionExecuted && state.action !== undefined) {
+    return { action: state.action, kind: "execute_action", stateId: state.id };
+  }
+
+  const unmet = unmetPredicate(state.completeWhen, signals);
+  if (unmet !== undefined) {
+    return {
+      kind: "blocked",
+      reason: `state ${state.id} complete_when predicate ${unmet.key} not satisfied (expected ${describeValue(unmet.expected)}, got ${describeValue(unmet.actual)})`
+    };
+  }
+
+  for (const transition of state.transitions) {
+    if (predicateMapMatches(transition.when, signals)) {
+      return {
+        kind: "advance",
+        reason: describeTransition(state.id, transition.when, transition.to),
+        to: transition.to
+      };
+    }
+  }
+
+  return {
+    kind: "blocked",
+    reason: `state ${state.id} has no transition matching observed signals`
+  };
+}
+
+function unmetPredicate(
+  predicates: WorkflowPredicateMap,
+  signals: StateMachineSignals
+):
+  | {
+      actual: WorkflowPredicateValue | undefined;
+      expected: WorkflowPredicateValue;
+      key: string;
+    }
+  | undefined {
+  for (const [key, expected] of Object.entries(predicates)) {
+    const actual = signals[key];
+    if (actual !== expected) {
+      return { actual, expected, key };
+    }
+  }
+  return undefined;
+}
+
+function predicateMapMatches(
+  predicates: WorkflowPredicateMap,
+  signals: StateMachineSignals
+): boolean {
+  return unmetPredicate(predicates, signals) === undefined;
+}
+
+function describeTransition(
+  fromStateId: string,
+  when: WorkflowPredicateMap,
+  to: string
+): string {
+  const entries = Object.entries(when);
+  if (entries.length === 0) {
+    return `state ${fromStateId} advanced to ${to}`;
+  }
+  const predicates = entries
+    .map(([key, value]) => `${key}=${describeValue(value)}`)
+    .join(", ");
+  return `state ${fromStateId} advanced to ${to} via ${predicates}`;
+}
+
+function describeValue(value: WorkflowPredicateValue | undefined): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  return JSON.stringify(value);
+}

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -349,8 +349,25 @@ async function readWorkflowSnapshot(
     return undefined;
   }
 
-  const workflow = parseWorkflowContract(contents, workflowPath);
   const expanded = expandWorkflowDefinition(contents, workflowPath, format);
+  // Raw FSM YAML files can open with `---` (the YAML document marker); the
+  // markdown contract parser would mistake that for unterminated front matter,
+  // so skip it. The expanded workflow's contentHash is sufficient for snapshot
+  // equality; the body is unused for raw FSM (per-state action.prompt drives
+  // the actual prompt).
+  if (expanded.workflow.source.kind === "raw_fsm") {
+    if (expanded.errors.length > 0) {
+      errors.push(...expanded.errors);
+      return undefined;
+    }
+    return {
+      body: "",
+      contentHash: expanded.workflow.contentHash,
+      expandedWorkflow: expanded.workflow,
+      path: workflowPath
+    };
+  }
+  const workflow = parseWorkflowContract(contents, workflowPath);
   const workflowErrors = [...workflow.errors, ...expanded.errors];
   if (workflowErrors.length > 0) {
     errors.push(...workflowErrors);

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -5,6 +5,8 @@ import type { Logger } from "pino";
 import { parse } from "yaml";
 import { z } from "zod";
 
+import type { WorkflowFormat } from "./config-schemas.js";
+import { workflowReferenceSchema } from "./config-schemas.js";
 import type {
   PollingProjectConfig,
   PollingServiceConfig
@@ -103,7 +105,7 @@ const runtimeProjectDetailSchema = z
           .passthrough()
       })
       .passthrough(),
-    workflow: z.string().trim().min(1)
+    workflow: workflowReferenceSchema
   })
   .passthrough();
 
@@ -269,7 +271,8 @@ async function loadRuntimeConfigSnapshot(input: {
     }
 
     const workflow = await readWorkflowSnapshot(
-      path.resolve(input.configDir, detail.data.workflow),
+      path.resolve(input.configDir, detail.data.workflow.path),
+      detail.data.workflow.format,
       errors
     );
     if (workflow === undefined) {
@@ -335,6 +338,7 @@ async function readRawServiceConfig(
 
 async function readWorkflowSnapshot(
   workflowPath: string,
+  format: WorkflowFormat,
   errors: string[]
 ): Promise<WorkflowSnapshot | undefined> {
   let contents: string;
@@ -346,7 +350,7 @@ async function readWorkflowSnapshot(
   }
 
   const workflow = parseWorkflowContract(contents, workflowPath);
-  const expanded = expandWorkflowDefinition(contents, workflowPath);
+  const expanded = expandWorkflowDefinition(contents, workflowPath, format);
   const workflowErrors = [...workflow.errors, ...expanded.errors];
   if (workflowErrors.length > 0) {
     errors.push(...workflowErrors);

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -26,6 +26,7 @@ export type RunStatus = {
   cancelRequested: boolean;
   continuationParentRunId: string | null;
   createdAt: string;
+  currentStateId: string | null;
   failureClassification: FailureClassification | null;
   id: string;
   isContinuation: boolean;
@@ -40,7 +41,9 @@ export type RunStatus = {
   rawLogPath: string;
   retryCount: number;
   state: RunState;
+  stateTransitionReason: string | null;
   terminalReason: string | null;
+  terminalStateId: string | null;
   updatedAt: string;
   workflowGraphPath: string;
   workspacePath: string;
@@ -220,6 +223,7 @@ type RunRow = {
   cancel_requested: number;
   continuation_parent_run_id: string | null;
   created_at: string;
+  current_state_id: string | null;
   failure_classification: string | null;
   id: string;
   is_continuation: number;
@@ -234,7 +238,9 @@ type RunRow = {
   raw_log_path: string | null;
   retry_count: number;
   state: RunState;
+  state_transition_reason: string | null;
   terminal_reason: string | null;
+  terminal_state_id: string | null;
   updated_at: string;
   workflow_graph_path: string | null;
   workspace_path: string | null;
@@ -392,6 +398,32 @@ export class RunStore {
         "update runs set terminal_reason = ?, failure_classification = ?, updated_at = ? where id = ?"
       )
       .run(reason, classification, timestamp(), runId);
+  }
+
+  setRunCurrentState(runId: string, currentStateId: string): void {
+    this.database
+      .prepare(
+        "update runs set current_state_id = ?, updated_at = ? where id = ?"
+      )
+      .run(currentStateId, timestamp(), runId);
+  }
+
+  recordWorkflowTerminal(
+    runId: string,
+    input: { terminalStateId: string; transitionReason: string }
+  ): void {
+    this.database
+      .prepare(
+        [
+          "update runs set",
+          "current_state_id = null,",
+          "terminal_state_id = ?,",
+          "state_transition_reason = ?,",
+          "updated_at = ?",
+          "where id = ?"
+        ].join(" ")
+      )
+      .run(input.terminalStateId, input.transitionReason, timestamp(), runId);
   }
 
   incrementRetryCount(runId: string): number {
@@ -779,6 +811,7 @@ export class RunStore {
           "workspace_path, branch_name, prompt_path, metadata_path,",
           "issue_snapshot_path, raw_log_path, normalized_log_path,",
           "workflow_graph_path,",
+          "current_state_id, terminal_state_id, state_transition_reason,",
           "is_continuation, continuation_parent_run_id, retry_count,",
           "failure_classification, terminal_reason, cancel_requested, cancel_reason,",
           "created_at, updated_at",
@@ -803,6 +836,7 @@ export class RunStore {
           "workspace_path, branch_name, prompt_path, metadata_path,",
           "issue_snapshot_path, raw_log_path, normalized_log_path,",
           "workflow_graph_path,",
+          "current_state_id, terminal_state_id, state_transition_reason,",
           "is_continuation, continuation_parent_run_id, retry_count,",
           "failure_classification, terminal_reason, cancel_requested, cancel_reason,",
           "created_at, updated_at",
@@ -1244,6 +1278,9 @@ export class RunStore {
       ["runs", "cancel_reason", "text"],
       ["runs", "pr_discovery_attempts", "integer not null default 0"],
       ["runs", "workflow_graph_path", "text"],
+      ["runs", "current_state_id", "text"],
+      ["runs", "terminal_state_id", "text"],
+      ["runs", "state_transition_reason", "text"],
       ["attempts", "failure_classification", "text"],
       ["attempts", "workflow_graph_path", "text"]
     ];
@@ -1311,6 +1348,7 @@ function mapRunRow(row: RunRow): RunStatus {
     cancelRequested: row.cancel_requested === 1,
     continuationParentRunId: row.continuation_parent_run_id ?? null,
     createdAt: row.created_at,
+    currentStateId: row.current_state_id ?? null,
     failureClassification:
       (row.failure_classification as FailureClassification | null) ?? null,
     id: row.id,
@@ -1326,7 +1364,9 @@ function mapRunRow(row: RunRow): RunStatus {
     rawLogPath: row.raw_log_path ?? "",
     retryCount: row.retry_count ?? 0,
     state: row.state,
+    stateTransitionReason: row.state_transition_reason ?? null,
     terminalReason: row.terminal_reason ?? null,
+    terminalStateId: row.terminal_state_id ?? null,
     updatedAt: row.updated_at,
     workflowGraphPath: row.workflow_graph_path ?? "",
     workspacePath: row.workspace_path ?? ""

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -432,6 +432,26 @@ export class RunStore {
       .run(input.terminalStateId, input.transitionReason, timestamp(), runId);
   }
 
+  recordWorkflowBlocked(
+    runId: string,
+    input: { stateId: string; transitionReason: string }
+  ): void {
+    // `current_state_id` is intentionally preserved so a transient retry
+    // (which reuses this run row) resumes at the stuck state instead of
+    // falling back to `expandedWorkflow.initial`.
+    this.database
+      .prepare(
+        [
+          "update runs set",
+          "terminal_state_id = ?,",
+          "state_transition_reason = ?,",
+          "updated_at = ?",
+          "where id = ?"
+        ].join(" ")
+      )
+      .run(input.stateId, input.transitionReason, timestamp(), runId);
+  }
+
   incrementRetryCount(runId: string): number {
     const updated = this.database
       .prepare(

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -355,6 +355,12 @@ export class RunStore {
       providerName: input.providerName,
       state: "queued"
     });
+    const parent = this.database
+      .prepare("select current_state_id from runs where id = ?")
+      .get(input.parentRunId) as { current_state_id: string | null } | undefined;
+    if (parent?.current_state_id != null) {
+      this.setRunCurrentState(input.id, parent.current_state_id);
+    }
   }
 
   createCapReachedFailureRun(input: {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parse } from "yaml";
+import type { WorkflowFormat } from "./config-schemas.js";
 import type { IssueSnapshot } from "./issue-polling.js";
 import { isPathInside } from "./path-safety.js";
 
@@ -256,10 +257,11 @@ export async function loadWorkflowContract(
 }
 
 export async function loadExpandedWorkflow(
-  workflowPath: string
+  workflowPath: string,
+  format: WorkflowFormat = "auto"
 ): Promise<ExpandedWorkflowLoadResult> {
   const contents = await readFile(workflowPath, "utf8");
-  return expandWorkflowDefinition(contents, workflowPath);
+  return expandWorkflowDefinition(contents, workflowPath, format);
 }
 
 export async function loadProjectWorkflow(input: {
@@ -315,7 +317,7 @@ export async function loadProjectWorkflow(input: {
   const workflowPath = path.resolve(path.dirname(configPath), selected.workflowPath);
   let result: ExpandedWorkflowLoadResult;
   try {
-    result = await loadExpandedWorkflow(workflowPath);
+    result = await loadExpandedWorkflow(workflowPath, selected.workflowFormat);
   } catch (error) {
     return {
       errors: [
@@ -463,14 +465,35 @@ export function validateWorkflowTemplate(
 
 export function expandWorkflowDefinition(
   contents: string,
-  workflowPath: string
+  workflowPath: string,
+  format: WorkflowFormat = "auto"
 ): ExpandedWorkflowLoadResult {
-  const errors: string[] = [];
-  const explicit = parseExplicitWorkflowDefinition(contents, workflowPath, errors);
-  if (explicit !== undefined) {
-    return expandRawStateMachineWorkflow(explicit, workflowPath, contentHash(contents), errors);
+  const resolved = resolveWorkflowFormat(format, workflowPath);
+  if (resolved.kind === "error") {
+    return {
+      errors: [resolved.error],
+      workflow: emptyExpandedWorkflow(contents, workflowPath, "markdown")
+    };
   }
 
+  if (resolved.kind === "raw_fsm") {
+    const errors: string[] = [];
+    const explicit = parseExplicitWorkflowDefinition(contents, workflowPath, errors);
+    if (explicit === undefined) {
+      return {
+        errors,
+        workflow: emptyExpandedWorkflow(contents, workflowPath, "raw_fsm")
+      };
+    }
+    return expandRawStateMachineWorkflow(
+      explicit,
+      workflowPath,
+      contentHash(contents),
+      errors
+    );
+  }
+
+  const errors: string[] = [];
   const workflow = parseWorkflowContract(contents, workflowPath);
   errors.push(...workflow.errors);
   if (workflow.body.trim().length === 0) {
@@ -483,12 +506,58 @@ export function expandWorkflowDefinition(
   };
 }
 
+type ResolvedWorkflowFormat =
+  | { kind: "markdown" | "raw_fsm" }
+  | { error: string; kind: "error" };
+
+function resolveWorkflowFormat(
+  format: WorkflowFormat,
+  workflowPath: string
+): ResolvedWorkflowFormat {
+  if (format === "markdown") {
+    return { kind: "markdown" };
+  }
+  if (format === "raw_fsm") {
+    return { kind: "raw_fsm" };
+  }
+  const extension = path.extname(workflowPath).toLowerCase();
+  if (extension === ".md") {
+    return { kind: "markdown" };
+  }
+  if (extension === ".yaml" || extension === ".yml" || extension === ".json") {
+    return { kind: "raw_fsm" };
+  }
+  return {
+    error: `workflow at ${workflowPath} has no recognized extension (.md, .yaml, .yml, .json); declare format explicitly`,
+    kind: "error"
+  };
+}
+
+function emptyExpandedWorkflow(
+  contents: string,
+  workflowPath: string,
+  kind: WorkflowSourceKind
+): ExpandedWorkflow {
+  return {
+    contentHash: contentHash(contents),
+    initial: "",
+    name: path.basename(workflowPath, path.extname(workflowPath)),
+    source: { kind, path: workflowPath },
+    states: [],
+    templateFiles: []
+  };
+}
+
 function projectWorkflowReferences(
   rawProjects: unknown[],
   configPath: string,
   errors: string[]
-): Array<{ name: string; workflowPath: string }> {
-  const projects: Array<{ name: string; workflowPath: string }> = [];
+): Array<{ name: string; workflowFormat: WorkflowFormat; workflowPath: string }> {
+  const projects: Array<{
+    name: string;
+    workflowFormat: WorkflowFormat;
+    workflowPath: string;
+  }> = [];
   for (const [index, rawProject] of rawProjects.entries()) {
     if (!isRecord(rawProject)) {
       errors.push(`projects.${index} in ${configPath} must be a mapping`);
@@ -499,27 +568,78 @@ function projectWorkflowReferences(
       errors.push(`projects.${index}.name in ${configPath} must be a non-empty string`);
       continue;
     }
-    const workflowPath = stringProperty(rawProject, "workflow");
-    if (workflowPath === undefined) {
-      errors.push(
-        `projects.${name}.workflow in ${configPath} must be a non-empty path`
-      );
+    const reference = parseWorkflowReference(
+      rawProject.workflow,
+      `projects.${name}.workflow`,
+      configPath,
+      errors
+    );
+    if (reference === undefined) {
       continue;
     }
     projects.push({
       name,
-      workflowPath
+      workflowFormat: reference.format,
+      workflowPath: reference.path
     });
   }
   return projects;
 }
 
+function parseWorkflowReference(
+  rawWorkflow: unknown,
+  fieldLabel: string,
+  configPath: string,
+  errors: string[]
+): { format: WorkflowFormat; path: string } | undefined {
+  if (typeof rawWorkflow === "string") {
+    const trimmed = rawWorkflow.trim();
+    if (trimmed.length === 0) {
+      errors.push(`${fieldLabel} in ${configPath} must be a non-empty path`);
+      return undefined;
+    }
+    return { format: "auto", path: trimmed };
+  }
+  if (isRecord(rawWorkflow)) {
+    const pathValue = stringProperty(rawWorkflow, "path");
+    if (pathValue === undefined) {
+      errors.push(`${fieldLabel}.path in ${configPath} must be a non-empty path`);
+      return undefined;
+    }
+    const formatRaw = rawWorkflow.format;
+    let format: WorkflowFormat = "auto";
+    if (formatRaw !== undefined) {
+      if (
+        formatRaw === "markdown" ||
+        formatRaw === "raw_fsm" ||
+        formatRaw === "auto"
+      ) {
+        format = formatRaw;
+      } else {
+        errors.push(
+          `${fieldLabel}.format in ${configPath} must be one of markdown, raw_fsm, auto`
+        );
+        return undefined;
+      }
+    }
+    return { format, path: pathValue };
+  }
+  errors.push(`${fieldLabel} in ${configPath} must be a non-empty path or mapping`);
+  return undefined;
+}
+
 function selectProjectWorkflow(
-  projects: Array<{ name: string; workflowPath: string }>,
+  projects: Array<{
+    name: string;
+    workflowFormat: WorkflowFormat;
+    workflowPath: string;
+  }>,
   requestedProject: string | undefined,
   configPath: string,
   errors: string[]
-): { name: string; workflowPath: string } | undefined {
+):
+  | { name: string; workflowFormat: WorkflowFormat; workflowPath: string }
+  | undefined {
   if (requestedProject !== undefined) {
     const selected = projects.find((project) => project.name === requestedProject);
     if (selected === undefined) {
@@ -553,20 +673,16 @@ function parseExplicitWorkflowDefinition(
   try {
     parsed = parse(contents) ?? {};
   } catch (error) {
-    if (looksLikeYamlPath(workflowPath)) {
-      errors.push(
-        `workflow definition at ${workflowPath} could not be parsed: ${errorMessage(error)}`
-      );
-    }
+    errors.push(
+      `workflow definition at ${workflowPath} could not be parsed: ${errorMessage(error)}`
+    );
     return undefined;
   }
 
   if (!isRecord(parsed) || !isRecord(parsed.workflow)) {
-    if (looksLikeYamlPath(workflowPath)) {
-      errors.push(
-        `workflow definition at ${workflowPath} must define a top-level workflow mapping`
-      );
-    }
+    errors.push(
+      `workflow definition at ${workflowPath} must define a top-level workflow mapping`
+    );
     return undefined;
   }
 
@@ -916,11 +1032,6 @@ function recordProperty(
 ): Record<string, unknown> | undefined {
   const value = record[key];
   return isRecord(value) ? value : undefined;
-}
-
-function looksLikeYamlPath(workflowPath: string): boolean {
-  const extension = path.extname(workflowPath).toLowerCase();
-  return extension === ".yaml" || extension === ".yml";
 }
 
 export async function persistRunEvidence(

--- a/tests/config-schemas.test.ts
+++ b/tests/config-schemas.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { workflowReferenceSchema } from "../src/config-schemas.js";
+
+describe("workflowReferenceSchema", () => {
+  it("normalizes a bare string into { path, format: 'auto' }", () => {
+    const result = workflowReferenceSchema.parse("WORKFLOW.md");
+    expect(result).toEqual({ format: "auto", path: "WORKFLOW.md" });
+  });
+
+  it("trims surrounding whitespace from the string shorthand", () => {
+    const result = workflowReferenceSchema.parse("  workflow.yml  ");
+    expect(result).toEqual({ format: "auto", path: "workflow.yml" });
+  });
+
+  it("rejects an empty string shorthand", () => {
+    expect(() => workflowReferenceSchema.parse("")).toThrow();
+    expect(() => workflowReferenceSchema.parse("   ")).toThrow();
+  });
+
+  it("rejects a path containing NUL bytes", () => {
+    expect(() => workflowReferenceSchema.parse("workflow\0.md")).toThrow();
+  });
+
+  it("accepts the tagged object form and defaults format to 'auto'", () => {
+    const result = workflowReferenceSchema.parse({ path: "WORKFLOW.md" });
+    expect(result).toEqual({ format: "auto", path: "WORKFLOW.md" });
+  });
+
+  it("accepts explicit markdown, raw_fsm, and auto format values", () => {
+    expect(
+      workflowReferenceSchema.parse({ format: "markdown", path: "WORKFLOW.md" })
+    ).toEqual({ format: "markdown", path: "WORKFLOW.md" });
+    expect(
+      workflowReferenceSchema.parse({ format: "raw_fsm", path: "workflow.yml" })
+    ).toEqual({ format: "raw_fsm", path: "workflow.yml" });
+    expect(
+      workflowReferenceSchema.parse({ format: "auto", path: "WORKFLOW.md" })
+    ).toEqual({ format: "auto", path: "WORKFLOW.md" });
+  });
+
+  it("rejects an unknown format value", () => {
+    expect(() =>
+      workflowReferenceSchema.parse({ format: "xml", path: "workflow.xml" })
+    ).toThrow();
+  });
+
+  it("rejects unknown keys on the tagged object form", () => {
+    expect(() =>
+      workflowReferenceSchema.parse({
+        format: "markdown",
+        kind: "raw_fsm",
+        path: "WORKFLOW.md"
+      })
+    ).toThrow();
+  });
+
+  it("rejects an object form with a missing path", () => {
+    expect(() =>
+      workflowReferenceSchema.parse({ format: "markdown" })
+    ).toThrow();
+  });
+});

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -921,6 +921,17 @@ describe("daemon dispatch", () => {
         workspacePath
       });
 
+      // The rendered prompt should use the agent action's prompt file
+      // (prompt.md) rather than the YAML workflow body. The template
+      // substitutes {{issue.title}} so the resulting prompt contains the
+      // issue title verbatim and does NOT contain the raw YAML keywords.
+      const promptContents = await readFile(run.promptPath, "utf8");
+      expect(promptContents).toContain(
+        "Dispatch an end-to-end run through a test provider"
+      );
+      expect(promptContents).not.toContain("complete_when:");
+      expect(promptContents).not.toContain("workflow:\n  name:");
+
       const graphContents = JSON.parse(
         await readFile(run.workflowGraphPath, "utf8")
       ) as Record<string, unknown>;
@@ -1026,7 +1037,9 @@ describe("daemon dispatch", () => {
           )
           .get("run-raw-fsm-failed");
         expect(storedRun).toMatchObject({
-          current_state_id: null,
+          // Preserved so a transient retry (if scheduled) resumes at the
+          // stuck state instead of falling back to expandedWorkflow.initial.
+          current_state_id: "run_agent",
           terminal_state_id: "run_agent"
         });
         const reason = stringColumn(storedRun, "state_transition_reason");
@@ -1182,6 +1195,10 @@ async function writeRawFsmProject(root: string): Promise<void> {
       "      terminal: success",
       ""
     ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "prompt.md"),
+    "Work on #{{issue.number}}: {{issue.title}}.\n"
   );
 }
 

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -788,7 +788,7 @@ describe("daemon dispatch", () => {
       throw new Error("expected reloader to expose symphonika project");
     }
     const snapshot = project.workflow;
-    if (typeof snapshot === "string") {
+    if (!("expandedWorkflow" in snapshot)) {
       throw new Error("expected reloader to expose a workflow snapshot");
     }
     const sentinelTemplate = "sentinel-only-in-snapshot.txt";
@@ -872,6 +872,174 @@ describe("daemon dispatch", () => {
       runStore.close();
     }
   });
+
+  it("walks a raw FSM workflow from the initial agent state to a terminal success state", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "8-dispatch-an-end-to-end-run-through-a-test-provider"
+    );
+    await writeRawFsmProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 8,
+          title: "Dispatch an end-to-end run through a test provider"
+        })
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => "run-raw-fsm-success",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "succeeded");
+      const run = firstRun(status);
+      expect(run).toMatchObject({
+        id: "run-raw-fsm-success",
+        issueNumber: 8,
+        state: "succeeded",
+        workspacePath
+      });
+
+      const graphContents = JSON.parse(
+        await readFile(run.workflowGraphPath, "utf8")
+      ) as Record<string, unknown>;
+      expect(graphContents).toMatchObject({
+        initial: "run_agent",
+        name: "tracer_bullet",
+        source: { kind: "raw_fsm" }
+      });
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const storedRun = database
+          .prepare(
+            "select current_state_id, terminal_state_id, state_transition_reason from runs where id = ?"
+          )
+          .get("run-raw-fsm-success");
+        expect(storedRun).toMatchObject({
+          current_state_id: null,
+          terminal_state_id: "done"
+        });
+        const reason = stringColumn(storedRun, "state_transition_reason");
+        expect(reason).toContain("run_agent advanced to done");
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("records terminal_state_id at the stuck agent state when a raw FSM run fails", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "8-dispatch-an-end-to-end-run-through-a-test-provider"
+    );
+    await mkdir(workspacePath, { recursive: true });
+    await writeRawFsmProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 8,
+          title: "Dispatch an end-to-end run through a test provider"
+        })
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex" as const,
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: { exitCode: 1, type: "process_exit" },
+          raw: { code: 1, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => "run-raw-fsm-failed",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 0 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "failed");
+      const run = firstRun(status);
+      expect(run).toMatchObject({
+        id: "run-raw-fsm-failed",
+        state: "failed"
+      });
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const storedRun = database
+          .prepare(
+            "select current_state_id, terminal_state_id, state_transition_reason from runs where id = ?"
+          )
+          .get("run-raw-fsm-failed");
+        expect(storedRun).toMatchObject({
+          current_state_id: null,
+          terminal_state_id: "run_agent"
+        });
+        const reason = stringColumn(storedRun, "state_transition_reason");
+        expect(reason).toContain("run_agent");
+        expect(reason).toContain("provider_success");
+        expect(reason).toContain("not satisfied");
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
 });
 
 function issueFixture(overrides: {
@@ -950,6 +1118,71 @@ function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
     reused: false,
     workspacePath
   };
+}
+
+async function writeRawFsmProject(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      `    command: "${DEFAULT_CODEX_COMMAND}"`,
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels:",
+      '        "priority:critical": 0',
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./workflow.yml",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: tracer_bullet",
+      "  initial: run_agent",
+      "  states:",
+      "    run_agent:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
 }
 
 async function writeValidProject(

--- a/tests/dispatch-continuation.test.ts
+++ b/tests/dispatch-continuation.test.ts
@@ -540,4 +540,8 @@ async function writeRawFsmTracerBulletProject(root: string): Promise<void> {
       ""
     ].join("\n")
   );
+  await writeFile(
+    path.join(root, "prompt.md"),
+    "Work on #{{issue.number}}: {{issue.title}}.\n"
+  );
 }

--- a/tests/dispatch-continuation.test.ts
+++ b/tests/dispatch-continuation.test.ts
@@ -402,4 +402,142 @@ describe("dispatch continuation cap", () => {
       await daemon.stop();
     }
   });
+
+  it("suppresses continuations after a raw FSM workflow reaches a terminal node", async () => {
+    const root = await makeTempRoot();
+    const prepared = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(prepared);
+    await writeRawFsmTracerBulletProject(root);
+
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    // Issue stays agent-ready after the run — without the raw-FSM terminal
+    // suppression, scheduleNext would refresh, see the label, and dispatch a
+    // continuation. We want the workflow's explicit `terminal: success` to
+    // mean "done" regardless of the label state.
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue({
+        ...baseIssue,
+        labels: ["agent-ready"]
+      }),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([{ ...baseIssue, labels: ["agent-ready"] }])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> => Promise.resolve(prepared)
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-fsm-terminal",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: fastContinuationPolicy,
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      await waitForCondition(daemon.url, ({ runs }) =>
+        runs.some((run) => run["state"] === "succeeded")
+      );
+
+      // Wait beyond the continuation delay (5ms in fastContinuationPolicy) to
+      // confirm no continuation gets dispatched.
+      await new Promise((resolve) => setTimeout(resolve, 80));
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) => r.json())) as {
+        runs: Array<Record<string, unknown>>;
+      };
+      expect(status.runs).toHaveLength(1);
+      expect(status.runs[0]?.["isContinuation"]).toBe(false);
+      expect(status.runs[0]?.["state"]).toBe("succeeded");
+      // getIssue should not have been called — suppression short-circuits
+      // scheduleNext before the refresh.
+      expect(githubIssuesApi.getIssue).not.toHaveBeenCalled();
+    } finally {
+      await daemon.stop();
+    }
+  });
 });
+
+async function writeRawFsmTracerBulletProject(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 25",
+      "providers:",
+      "  codex:",
+      `    command: "codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server"`,
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./workflow.yml",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: tracer_bullet",
+      "  initial: run_agent",
+      "  states:",
+      "    run_agent:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+}

--- a/tests/pull-request-followup.test.ts
+++ b/tests/pull-request-followup.test.ts
@@ -304,7 +304,7 @@ function projectConfig(): RunControllerProjectConfig {
       repo: "symphonika",
       token: "$GITHUB_TOKEN"
     },
-    workflow: "./WORKFLOW.md",
+    workflow: { format: "auto", path: "./WORKFLOW.md" },
     workspace: {
       git: {
         base_branch: "main",

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -157,7 +157,7 @@ describe("RuntimeConfigReloader workflow validation", () => {
     expect(project).toBeDefined();
     const workflow = project?.workflow;
     expect(typeof workflow).toBe("object");
-    if (typeof workflow === "string" || workflow === undefined) {
+    if (workflow === undefined || !("expandedWorkflow" in workflow)) {
       throw new Error("expected workflow snapshot to be an object");
     }
 

--- a/tests/run-store-lifecycle.test.ts
+++ b/tests/run-store-lifecycle.test.ts
@@ -217,6 +217,76 @@ describe("run-store lifecycle CRUD", () => {
     }
   });
 
+  it("createContinuationRun inherits the parent run's current FSM state", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      const parentId = seedRun(store, { id: "parent-fsm", issueNumber: 11 });
+      store.setRunCurrentState(parentId, "implementing");
+
+      store.createContinuationRun({
+        id: "cont-fsm",
+        issue: {
+          body: "",
+          created_at: "2025-01-01T00:00:00Z",
+          id: 2011,
+          labels: ["agent-ready"],
+          number: 11,
+          priority: 1,
+          state: "open",
+          title: "fixture",
+          updated_at: "2025-01-01T00:00:00Z",
+          url: "https://example/11"
+        },
+        parentRunId: parentId,
+        projectName: "symphonika",
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+
+      const continuation = store.getRun("cont-fsm");
+      expect(continuation?.currentStateId).toBe("implementing");
+      expect(continuation?.isContinuation).toBe(true);
+      expect(continuation?.continuationParentRunId).toBe(parentId);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("createContinuationRun leaves current_state_id null when the parent never recorded one", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      const parentId = seedRun(store, { id: "parent-no-fsm", issueNumber: 12 });
+      // Never call setRunCurrentState — simulates a Markdown workflow path that
+      // exits before applyWorkflowOutcome runs, or a parent that walked to a terminal.
+      store.createContinuationRun({
+        id: "cont-no-fsm",
+        issue: {
+          body: "",
+          created_at: "2025-01-01T00:00:00Z",
+          id: 2012,
+          labels: ["agent-ready"],
+          number: 12,
+          priority: 1,
+          state: "open",
+          title: "fixture",
+          updated_at: "2025-01-01T00:00:00Z",
+          url: "https://example/12"
+        },
+        parentRunId: parentId,
+        projectName: "symphonika",
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+
+      const continuation = store.getRun("cont-no-fsm");
+      expect(continuation?.currentStateId).toBeNull();
+    } finally {
+      store.close();
+    }
+  });
+
   it("incrementRetryCount returns the new value across calls", async () => {
     const root = await makeTempRoot();
     const store = openRunStore({ stateRoot: root });

--- a/tests/state-machine-dispatch.test.ts
+++ b/tests/state-machine-dispatch.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decideNextStep,
+  findWorkflowState
+} from "../src/lifecycle/state-machine-dispatch.js";
+import type {
+  ExpandedWorkflow,
+  ExpandedWorkflowState
+} from "../src/workflow.js";
+
+function makeWorkflow(states: ExpandedWorkflowState[]): ExpandedWorkflow {
+  return {
+    contentHash: "sha256:test",
+    initial: states[0]?.id ?? "",
+    name: "test_workflow",
+    source: { kind: "raw_fsm", path: "/tmp/test.yml" },
+    states,
+    templateFiles: []
+  };
+}
+
+const runAgentState: ExpandedWorkflowState = {
+  action: { kind: "agent", provider: "codex" },
+  completeWhen: { branch_ahead_of_base: true, provider_success: true },
+  id: "run_agent",
+  transitions: [{ to: "done", when: {} }]
+};
+
+const doneState: ExpandedWorkflowState = {
+  completeWhen: {},
+  id: "done",
+  terminal: "success",
+  transitions: []
+};
+
+describe("state-machine-dispatch", () => {
+  describe("decideNextStep", () => {
+    it("returns terminate when state has a terminal label", () => {
+      const decision = decideNextStep({
+        actionExecuted: false,
+        signals: {},
+        state: doneState
+      });
+      expect(decision).toEqual({
+        kind: "terminate",
+        stateId: "done",
+        terminal: "success"
+      });
+    });
+
+    it("returns execute_action when the action has not yet run", () => {
+      const decision = decideNextStep({
+        actionExecuted: false,
+        signals: {},
+        state: runAgentState
+      });
+      expect(decision).toEqual({
+        action: { kind: "agent", provider: "codex" },
+        kind: "execute_action",
+        stateId: "run_agent"
+      });
+    });
+
+    it("advances when complete_when satisfied and a transition matches", () => {
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: { branch_ahead_of_base: true, provider_success: true },
+        state: runAgentState
+      });
+      expect(decision).toEqual({
+        kind: "advance",
+        reason: "state run_agent advanced to done",
+        to: "done"
+      });
+    });
+
+    it("blocks when a complete_when predicate is unmet", () => {
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: { branch_ahead_of_base: false, provider_success: true },
+        state: runAgentState
+      });
+      expect(decision.kind).toBe("blocked");
+      if (decision.kind === "blocked") {
+        expect(decision.reason).toContain("branch_ahead_of_base");
+        expect(decision.reason).toContain("expected true");
+        expect(decision.reason).toContain("got false");
+      }
+    });
+
+    it("blocks when a complete_when predicate is missing from signals", () => {
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: { provider_success: true },
+        state: runAgentState
+      });
+      expect(decision.kind).toBe("blocked");
+      if (decision.kind === "blocked") {
+        expect(decision.reason).toContain("branch_ahead_of_base");
+        expect(decision.reason).toContain("got undefined");
+      }
+    });
+
+    it("picks the first transition whose when predicates all match", () => {
+      const state: ExpandedWorkflowState = {
+        action: { kind: "agent", provider: "codex" },
+        completeWhen: { provider_success: true },
+        id: "branching",
+        transitions: [
+          { to: "no_match", when: { unresolved_review_threads: true } },
+          { to: "match", when: { branch_ahead_of_base: true } },
+          { to: "also_matches", when: {} }
+        ]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: { branch_ahead_of_base: true, provider_success: true },
+        state
+      });
+      expect(decision.kind).toBe("advance");
+      if (decision.kind === "advance") {
+        expect(decision.to).toBe("match");
+      }
+    });
+
+    it("blocks when no transition's when predicates all match the signals", () => {
+      const state: ExpandedWorkflowState = {
+        action: { kind: "agent", provider: "codex" },
+        completeWhen: { provider_success: true },
+        id: "branching",
+        transitions: [{ to: "needs_extra", when: { pr_open: true } }]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: { provider_success: true },
+        state
+      });
+      expect(decision.kind).toBe("blocked");
+      if (decision.kind === "blocked") {
+        expect(decision.reason).toContain("no transition matching");
+      }
+    });
+
+    it("treats a state with no action as ready to evaluate transitions on entry", () => {
+      const state: ExpandedWorkflowState = {
+        completeWhen: {},
+        id: "passthrough",
+        transitions: [{ to: "next", when: {} }]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: false,
+        signals: {},
+        state
+      });
+      expect(decision.kind).toBe("advance");
+      if (decision.kind === "advance") {
+        expect(decision.to).toBe("next");
+      }
+    });
+  });
+
+  describe("findWorkflowState", () => {
+    it("returns the state with the given id", () => {
+      const workflow = makeWorkflow([runAgentState, doneState]);
+      expect(findWorkflowState(workflow, "done")).toBe(doneState);
+    });
+
+    it("returns undefined for an unknown id", () => {
+      const workflow = makeWorkflow([runAgentState, doneState]);
+      expect(findWorkflowState(workflow, "nope")).toBeUndefined();
+    });
+  });
+});

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -687,6 +687,131 @@ describe("state machine workflow definitions", () => {
   });
 });
 
+describe("workflow format routing", () => {
+  it("auto-routes a .md file to the Markdown loader regardless of body content", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: looks_like_yaml",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: agent",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath, "auto");
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow.source.kind).toBe("markdown");
+    expect(result.workflow.states.map((state) => state.id)).toEqual([
+      "run_agent",
+      "done"
+    ]);
+  });
+
+  it("auto-routes .yaml, .yml, and .json paths to the raw FSM loader", async () => {
+    const root = await makeTempRoot();
+    for (const extension of [".yaml", ".yml", ".json"]) {
+      const workflowPath = path.join(root, `workflow${extension}`);
+      const contents =
+        extension === ".json"
+          ? JSON.stringify({
+              workflow: {
+                initial: "done",
+                name: "json_workflow",
+                states: { done: { terminal: "success" } }
+              }
+            })
+          : [
+              "workflow:",
+              "  name: yaml_workflow",
+              "  initial: done",
+              "  states:",
+              "    done:",
+              "      terminal: success",
+              ""
+            ].join("\n");
+      await writeFile(workflowPath, contents);
+
+      const result = await loadExpandedWorkflow(workflowPath, "auto");
+      expect(result.errors).toEqual([]);
+      expect(result.workflow.source.kind).toBe("raw_fsm");
+      expect(result.workflow.states.map((state) => state.id)).toEqual(["done"]);
+    }
+  });
+
+  it("auto rejects an unknown extension and reports the supported set", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.txt");
+    await writeFile(workflowPath, "doesn't matter\n");
+
+    const result = await loadExpandedWorkflow(workflowPath, "auto");
+
+    expect(result.errors).toContain(
+      `workflow at ${workflowPath} has no recognized extension (.md, .yaml, .yml, .json); declare format explicitly`
+    );
+  });
+
+  it("explicit markdown format treats a YAML-shaped .yml file as Markdown content", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "---",
+        "name: explicit_markdown",
+        "---",
+        "",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath, "markdown");
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow.source.kind).toBe("markdown");
+    expect(result.workflow.states.map((state) => state.id)).toEqual([
+      "run_agent",
+      "done"
+    ]);
+  });
+
+  it("explicit raw_fsm format errors when a .md file is not valid raw FSM YAML", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(workflowPath, "# Just a markdown file\n");
+
+    const result = await loadExpandedWorkflow(workflowPath, "raw_fsm");
+
+    expect(result.errors).toContain(
+      `workflow definition at ${workflowPath} must define a top-level workflow mapping`
+    );
+  });
+
+  it("explicit raw_fsm format surfaces YAML parse errors regardless of extension", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.json");
+    await writeFile(workflowPath, "{ bogus yaml here: : :");
+
+    const result = await loadExpandedWorkflow(workflowPath, "raw_fsm");
+
+    expect(
+      result.errors.some((message) =>
+        message.startsWith(
+          `workflow definition at ${workflowPath} could not be parsed:`
+        )
+      )
+    ).toBe(true);
+  });
+});
+
 function issueSnapshot() {
   return {
     body: "Implement prompt evidence.",


### PR DESCRIPTION
Closes #94.

## Summary

- Wires an explicit raw FSM workflow (YAML/JSON) through the same expanded-graph runtime that Markdown workflows already use. Tracer bullet scope: one `agent` state + one terminal `success` state.
- New `state-machine-dispatch` module is a pure decision engine (execute / advance / terminate / blocked) over any `ExpandedWorkflow`; the runtime only adds the effects.
- Closes a content-sniffing footgun in `expandWorkflowDefinition` by routing on declared `format` (auto / markdown / raw_fsm); `auto` resolves via file extension and rejects unknown extensions instead of silently falling back to Markdown.

## Notable changes

- **Schema** — `src/config-schemas.ts` exports `workflowReferenceSchema` accepting either a string (legacy `workflow: WORKFLOW.md`) or an object (`workflow: { path: …, format: … }`). String form normalizes to `{ path, format: "auto" }` so downstream code sees one shape.
- **Loader** — `expandWorkflowDefinition` / `loadExpandedWorkflow` now take a `WorkflowFormat`. Extension routing under `auto`: `.md` → markdown, `.yaml|.yml|.json` → raw FSM, anything else → error. Explicit `markdown`/`raw_fsm` bypass extension entirely.
- **Persistence** — additive nullable columns on `runs`: `current_state_id`, `terminal_state_id`, `state_transition_reason`. Two new `RunStore` writers (`setRunCurrentState`, `recordWorkflowTerminal`).
- **Runtime** — `RunController.runAttemptLifecycle` loads the workflow up front, sets `current_state_id` on entry, and after `classifyFailure` translates the verdict into predicate signals (`provider_success`, `branch_ahead_of_base`) and asks the dispatcher what's next. Success advances to the terminal state; failure records `terminal_state_id` at the stuck state plus the unmet-predicate reason.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 309 passing (38 test files)
- [x] New unit tests: `tests/config-schemas.test.ts` (schema normalization + rejection paths), `tests/state-machine-dispatch.test.ts` (pure dispatcher decisions including the multi-transition selection case).
- [x] New routing tests in `tests/workflow.test.ts` cover `auto` extension routing, explicit `markdown` ignoring YAML-shaped content, and explicit `raw_fsm` surfacing parse/shape errors for `.md` and `.json`.
- [x] New integration tests in `tests/daemon-dispatch.test.ts`:
  - Happy path: raw FSM YAML config, fake provider exits 0 with branch ahead → run `succeeded`, `terminal_state_id="done"`, `state_transition_reason` records the `run_agent → done` advance.
  - Failure path: same workflow, fake provider exits 1 → run `failed`, `terminal_state_id="run_agent"`, reason names the unmet `provider_success` predicate.