### PR TITLE
Walk multi-state raw FSM workflows via state-advance dispatch

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,10 @@ _Avoid_: issue when referring to execution status
 A follow-up run for the same issue after a provider completed successfully but the issue remains eligible.
 _Avoid_: retry when the prior run succeeded
 
+**State Advance**:
+The dispatch path that runs the next state of a raw FSM workflow after the current state advances to a non-terminal next state. State Advance bypasses the Continuation cap and label eligibility re-check; the state machine, not the issue label set, decides what runs next.
+_Avoid_: continuation when describing FSM state walking
+
 **Bootstrap Slice**:
 The first usable implementation slice that lets Symphonika run this repository as one real Project well enough to help implement later Symphonika issues.
 _Avoid_: prototype, toy
@@ -126,6 +130,7 @@ _Avoid_: chat session
 - A **Run Store** records durable orchestration state across process restarts
 - A **Run** can succeed even when its **Issue** remains open
 - A **Continuation** is capped so an eligible issue cannot loop forever
+- A **State Advance** is not capped by the continuation cap; the FSM bounds the walk via terminal states
 - A **Bootstrap Slice** operates on one real **Project** before full multi-project behavior is complete
 - A **Project Cursor** belongs to exactly one **Project**
 - **Full-Permission Agent Execution** is the default and assumed provider posture

--- a/SPEC.md
+++ b/SPEC.md
@@ -381,7 +381,9 @@ Each provider attempt stores:
   `workflow-graph.json` next to `prompt-metadata.json`. Retries write
   `workflow-graph.attempt-<N>.json` so prior attempts' graphs remain inspectable. Markdown
   `WORKFLOW.md` workflows record their one-state compatibility graph; explicit raw FSM YAML
-  workflows record their parsed expanded graph without enabling multi-state dispatch.
+  workflows record their parsed expanded graph. Multi-state raw FSM walks advance through the
+  state machine via a `state_advance` dispatch path that is distinct from label-driven
+  continuations; see ADR 0046.
 
 ## 8. Scheduling
 

--- a/docs/adr/0046-state-advance-vs-continuation.md
+++ b/docs/adr/0046-state-advance-vs-continuation.md
@@ -1,0 +1,38 @@
+# Multi-state raw FSM dispatch is distinct from continuations
+
+Symphonika executes raw FSM workflows by advancing one agent state per Run and linking sequential
+states through `continuation_parent_run_id`. After ADR 0045 raw FSM workflows could run a single
+agent state, but multi-state walking went through the same dispatch path as label-driven
+continuations, which gated state advancement on `lifecycle.continuation.cap` and re-evaluated the
+full issue eligibility filter (`labels_all` / `labels_none`) between states. Both gates are wrong
+for FSM walking: the state machine is the source of truth for "what runs next", not the issue
+labels, and the continuation cap is intended to bound repeated end-to-end attempts on the same
+workflow rather than the length of a single workflow walk.
+
+Symphonika models state advancement as a distinct dispatch kind, `state_advance`, scheduled by
+`RunController.executeStateAdvance` whenever an agent state finishes with `outcome=success`,
+`workflow.source.kind=raw_fsm`, and the FSM advanced to a non-terminal next state. State advance:
+
+- skips the continuation cap entirely (the FSM bounds the walk via terminal states);
+- skips the `labels_all` / `labels_none` re-check (the FSM, not the issue label set, decides the
+  next state). Only the issue's open/closed state is re-verified to avoid acting on a closed issue;
+- creates the next Run via the existing `createContinuationRun` helper so the new row inherits
+  `current_state_id` (the next state id was already persisted by `applyWorkflowOutcome`) and
+  records `continuation_parent_run_id`, keeping linkage compatible with existing status surfaces;
+- preserves the issue's `sym:claimed` label across the gap between states. Operational labels
+  remain the fresh-dispatch guard that prevents a second daemon polling tick from claiming the
+  same issue mid-walk.
+
+Label-driven continuations remain a distinct concept. They keep the cap, the eligibility re-check,
+and the `executeContinuation` path because their purpose is to re-dispatch the same workflow when
+an operator (or the workflow itself) decides the issue should run again, not to advance the state
+machine.
+
+When a raw FSM agent state succeeds but no transition's `when` predicates match the observed
+signals, the workflow instance is recorded as blocked: `terminal_state_id` is the stuck state id
+and `state_transition_reason` describes the missing predicates. The Run row itself stays
+`succeeded` because the agent state completed; the "blocked" status is a property of the workflow
+instance, not the agent execution. No further state advance or continuation is scheduled. This
+keeps the two-level model — Run is per-attempt evidence, workflow instance is the FSM walk —
+visible to operators inspecting `current_state_id`, `terminal_state_id`, and the run state column
+side by side.

--- a/docs/adr/0046-state-advance-vs-continuation.md
+++ b/docs/adr/0046-state-advance-vs-continuation.md
@@ -15,7 +15,10 @@ Symphonika models state advancement as a distinct dispatch kind, `state_advance`
 
 - skips the continuation cap entirely (the FSM bounds the walk via terminal states);
 - skips the `labels_all` / `labels_none` re-check (the FSM, not the issue label set, decides the
-  next state). Only the issue's open/closed state is re-verified to avoid acting on a closed issue;
+  next state). Only the issue's open/closed state is re-verified to avoid acting on a closed issue.
+  `reconcileActiveRuns` honors the same rule for in-flight state-advance runs: it still cancels
+  with `CLOSED_ISSUE` when the issue closes, but skips the labels re-check that would otherwise
+  cancel the run with `ELIGIBILITY_LOSS` mid-walk;
 - creates the next Run via the existing `createContinuationRun` helper so the new row inherits
   `current_state_id` (the next state id was already persisted by `applyWorkflowOutcome`) and
   records `continuation_parent_run_id`, keeping linkage compatible with existing status surfaces;

--- a/docs/adr/0046-state-advance-vs-continuation.md
+++ b/docs/adr/0046-state-advance-vs-continuation.md
@@ -16,9 +16,10 @@ Symphonika models state advancement as a distinct dispatch kind, `state_advance`
 - skips the continuation cap entirely (the FSM bounds the walk via terminal states);
 - skips the `labels_all` / `labels_none` re-check (the FSM, not the issue label set, decides the
   next state). Only the issue's open/closed state is re-verified to avoid acting on a closed issue.
-  `reconcileActiveRuns` honors the same rule for in-flight state-advance runs: it still cancels
-  with `CLOSED_ISSUE` when the issue closes, but skips the labels re-check that would otherwise
-  cancel the run with `ELIGIBILITY_LOSS` mid-walk;
+  `reconcileActiveRuns` honors the same rule for in-flight state-advance runs, and `executeRetry`
+  honors it for scheduled retries of state-advance runs: both still cancel with `CLOSED_ISSUE`
+  when the issue closes, but skip the labels re-check that would otherwise cancel the run with
+  `ELIGIBILITY_LOSS` mid-walk;
 - creates the next Run via the existing `createContinuationRun` helper so the new row inherits
   `current_state_id` (the next state id was already persisted by `applyWorkflowOutcome`) and
   records `continuation_parent_run_id`, keeping linkage compatible with existing status surfaces;

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -65,7 +65,7 @@ export type HttpAppOptions = {
   getReloadStatus?: () => RuntimeReloadStatus;
   getScheduled?: () => Array<{
     dueAt: number;
-    kind: "retry" | "continuation";
+    kind: "retry" | "continuation" | "state_advance";
     runId: string;
   }>;
   getStatusSnapshot?: () => StatusSnapshot;

--- a/src/lifecycle/active-runs.ts
+++ b/src/lifecycle/active-runs.ts
@@ -60,7 +60,7 @@ export type RegisterInput = {
   runId: string;
 };
 
-export type ScheduledWorkKind = "retry" | "continuation";
+export type ScheduledWorkKind = "retry" | "continuation" | "state_advance";
 
 export type ScheduledWorkInput = {
   delayMs: number;

--- a/src/lifecycle/active-runs.ts
+++ b/src/lifecycle/active-runs.ts
@@ -49,6 +49,11 @@ export type ActiveRunEntry = {
   issueNumber: number;
   projectName: string;
   provider?: AgentProvider;
+  // When false, this run is part of an FSM walk where the state machine — not
+  // the issue label set — decides whether to keep running. Reconcile uses this
+  // to skip the labels_all / labels_none re-check while still honoring
+  // CLOSED_ISSUE. See ADR 0046.
+  respectsIssueLabels: boolean;
   runId: string;
 };
 
@@ -57,6 +62,7 @@ export type RegisterInput = {
   issueNumber: number;
   projectName: string;
   provider?: AgentProvider;
+  respectsIssueLabels?: boolean;
   runId: string;
 };
 
@@ -91,6 +97,7 @@ export class ActiveRunRegistry {
       cancelRequested: false,
       issueNumber: input.issueNumber,
       projectName: input.projectName,
+      respectsIssueLabels: input.respectsIssueLabels ?? true,
       runId: input.runId
     };
     if (input.provider !== undefined) {

--- a/src/lifecycle/reconcile.ts
+++ b/src/lifecycle/reconcile.ts
@@ -48,6 +48,13 @@ export async function reconcileActiveRuns(input: ReconcileInput): Promise<void> 
       continue;
     }
 
+    // State-advance runs (raw FSM walks) intentionally do not re-evaluate
+    // labels_all / labels_none — the state machine owns transitions while the
+    // walk is in flight. CLOSED_ISSUE above is still honored. See ADR 0046.
+    if (!entry.respectsIssueLabels) {
+      continue;
+    }
+
     const eligibility = evaluateProjectEligibility(snapshot, project, {
       ignoreOperationalLabels: true
     });

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -948,11 +948,20 @@ export class RunController {
         state: "running"
       });
       attemptCreated = true;
+      // Raw FSM continuations are state-advance runs: the FSM, not the issue
+      // labels, decides whether the next state runs. Signal that to
+      // reconcileActiveRuns so it skips the labels_all / labels_none re-check
+      // for this run while still honoring CLOSED_ISSUE. See ADR 0046.
+      const respectsIssueLabels = !(
+        input.isContinuation &&
+        loadedWorkflow.expandedWorkflow.source.kind === "raw_fsm"
+      );
       this.activeRuns.register({
         cancel: () => input.provider.cancel(input.runId),
         issueNumber: input.issue.number,
         projectName: input.project.name,
         provider: input.provider,
+        respectsIssueLabels,
         runId: input.runId
       });
       registered = true;

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -92,7 +92,7 @@ export type ScheduleHandler = (input: {
   delayMs: number;
   fire: () => Promise<void>;
   issueNumber: number;
-  kind: "retry" | "continuation";
+  kind: "retry" | "continuation" | "state_advance";
   projectName: string;
   runId: string;
 }) => void;
@@ -190,6 +190,18 @@ type ContinuationPayload = {
   issue: IssueSnapshot;
   parentRunId: string;
   projectName: string;
+};
+
+type StateAdvancePayload = {
+  issue: IssueSnapshot;
+  parentRunId: string;
+  projectName: string;
+};
+
+type WorkflowOutcomeResult = {
+  advancedToState: string | null;
+  advancedToTerminal: boolean;
+  blocked: boolean;
 };
 
 export class RunController {
@@ -419,6 +431,73 @@ export class RunController {
       outcome: { kind: "cancelled", reason: input.reason },
       repository: input.repository,
       willRetry: false
+    });
+  }
+
+  async executeStateAdvance(payload: StateAdvancePayload): Promise<void> {
+    const projects = await this.projectsLoader();
+    const project = projects.get(payload.projectName);
+    if (project === undefined || project.disabled === true) {
+      this.logger?.warn(
+        { projectName: payload.projectName, parentRunId: payload.parentRunId },
+        "symphonika state advance dropped: project disabled or removed"
+      );
+      return;
+    }
+
+    const provider = this.agentProviders[project.agent.provider];
+    if (provider === undefined) {
+      return;
+    }
+
+    const providersConfig = await this.providersLoader();
+    const providerCommand = providersConfig[project.agent.provider].command;
+
+    if (!isLabelWritingGitHubIssuesApi(this.githubIssuesApi)) {
+      return;
+    }
+
+    const token = resolveTokenFromEnv(project.tracker.token, this.env);
+    if (token === undefined) {
+      return;
+    }
+    const repository = {
+      owner: project.tracker.owner,
+      repo: project.tracker.repo,
+      token
+    };
+
+    // State advance only re-checks that the issue is still open. The
+    // labels_all / labels_none filter is intentionally skipped: the FSM, not
+    // the issue label set, decides whether the next state runs. See ADR 0046.
+    const refreshed = await this.refreshIssue({
+      project,
+      issueNumber: payload.issue.number,
+      repository
+    });
+    if (refreshed === undefined) {
+      this.logger?.warn(
+        { projectName: payload.projectName, parentRunId: payload.parentRunId },
+        "symphonika state advance dropped: issue refresh unavailable"
+      );
+      return;
+    }
+    if (refreshed === null || refreshed.state !== "open") {
+      return;
+    }
+
+    const runId = this.createRunId();
+    await this.runFreshLifecycle({
+      attemptNumber: 1,
+      isContinuation: true,
+      issue: refreshed,
+      parentRunId: payload.parentRunId,
+      project,
+      provider,
+      providerCommand,
+      providerName: project.agent.provider,
+      repository,
+      runId
     });
   }
 
@@ -925,18 +1004,26 @@ export class RunController {
         terminal.reason,
         terminal.classification
       );
-      let advancedToTerminal = false;
+      let workflowOutcome: WorkflowOutcomeResult = {
+        advancedToState: null,
+        advancedToTerminal: false,
+        blocked: false
+      };
       if (currentState !== undefined) {
-        ({ advancedToTerminal } = this.applyWorkflowOutcome({
+        workflowOutcome = this.applyWorkflowOutcome({
           currentState,
           runId: input.runId,
           terminal,
           workflow: loadedWorkflow.expandedWorkflow
-        }));
+        });
       }
+      const sourceKind = loadedWorkflow.expandedWorkflow.source.kind;
+      const isRawFsm = sourceKind === "raw_fsm";
       const suppressContinuation =
-        advancedToTerminal &&
-        loadedWorkflow.expandedWorkflow.source.kind === "raw_fsm";
+        isRawFsm &&
+        (workflowOutcome.advancedToTerminal ||
+          workflowOutcome.blocked ||
+          workflowOutcome.advancedToState !== null);
       this.runStore.updateRunState(input.runId, outcomeState);
 
       const willRetry =
@@ -986,6 +1073,10 @@ export class RunController {
           repository: input.repository,
           runId: input.runId,
           runtimeAttemptNumber: input.attemptNumber,
+          stateAdvance:
+            isRawFsm && workflowOutcome.advancedToState !== null
+              ? { toStateId: workflowOutcome.advancedToState }
+              : null,
           suppressContinuation
         });
       } catch (scheduleError) {
@@ -1106,7 +1197,7 @@ export class RunController {
     runId: string;
     terminal: ClassifiedTerminal;
     workflow: ExpandedWorkflow;
-  }): { advancedToTerminal: boolean } {
+  }): WorkflowOutcomeResult {
     const signals = signalsFromTerminal(input.terminal);
     const decision = decideNextStep({
       actionExecuted: true,
@@ -1121,10 +1212,17 @@ export class RunController {
           terminalStateId: next.id,
           transitionReason: decision.reason
         });
-        return { advancedToTerminal: true };
+        return { advancedToState: null, advancedToTerminal: true, blocked: false };
       }
-      this.runStore.setRunCurrentState(input.runId, decision.to);
-      return { advancedToTerminal: false };
+      this.runStore.recordWorkflowStateAdvance(input.runId, {
+        nextStateId: decision.to,
+        transitionReason: decision.reason
+      });
+      return {
+        advancedToState: decision.to,
+        advancedToTerminal: false,
+        blocked: false
+      };
     }
 
     if (decision.kind === "blocked") {
@@ -1132,7 +1230,7 @@ export class RunController {
         stateId: input.currentState.id,
         transitionReason: decision.reason
       });
-      return { advancedToTerminal: false };
+      return { advancedToState: null, advancedToTerminal: false, blocked: true };
     }
 
     if (decision.kind === "terminate") {
@@ -1140,10 +1238,10 @@ export class RunController {
         terminalStateId: decision.stateId,
         transitionReason: `entered terminal state ${decision.terminal}`
       });
-      return { advancedToTerminal: true };
+      return { advancedToState: null, advancedToTerminal: true, blocked: false };
     }
 
-    return { advancedToTerminal: false };
+    return { advancedToState: null, advancedToTerminal: false, blocked: false };
   }
 
   private async loadWorkflow(
@@ -1368,6 +1466,7 @@ export class RunController {
     repository: GitHubIssueRepositoryInput;
     runId: string;
     runtimeAttemptNumber: number;
+    stateAdvance?: { toStateId: string } | null;
     suppressContinuation?: boolean;
   }): Promise<void> {
     if (input.outcome.kind === "cancelled" || input.outcome.kind === "input_required") {
@@ -1404,11 +1503,54 @@ export class RunController {
       return;
     }
 
+    // Raw FSM mid-walk: the state machine — not the issue label set — decides
+    // what runs next. Dispatch a state advance that skips the continuation cap
+    // and skips the labels_all / labels_none re-check; only require that the
+    // issue is still open. See ADR 0046.
+    if (input.stateAdvance != null) {
+      const refreshedForAdvance = await this.refreshIssue({
+        project: input.project,
+        issueNumber: input.issue.number,
+        repository: input.repository
+      });
+      if (refreshedForAdvance === undefined) {
+        return;
+      }
+      if (refreshedForAdvance === null || refreshedForAdvance.state !== "open") {
+        return;
+      }
+      this.logger?.info(
+        {
+          delayMs: this.lifecyclePolicy.continuation.delayMs,
+          issueNumber: refreshedForAdvance.number,
+          parentRunId: input.runId,
+          project: input.project.name,
+          toStateId: input.stateAdvance.toStateId
+        },
+        "symphonika scheduling state advance"
+      );
+      this.schedule({
+        delayMs: this.lifecyclePolicy.continuation.delayMs,
+        fire: () =>
+          this.executeStateAdvance({
+            issue: refreshedForAdvance,
+            parentRunId: input.runId,
+            projectName: input.project.name
+          }),
+        issueNumber: refreshedForAdvance.number,
+        kind: "state_advance",
+        projectName: input.project.name,
+        runId: input.runId
+      });
+      return;
+    }
+
     // success path: re-check eligibility, schedule continuation, enforce cap.
-    // For raw FSM workflows that reached an explicit terminal node, "terminal"
-    // means the workflow is done — do not schedule another continuation even
-    // if the issue still matches `agent-ready`. Markdown compatibility-graph
-    // workflows keep the legacy "loop on agent-ready" behavior.
+    // For raw FSM workflows that reached an explicit terminal node or blocked
+    // on a missing transition, the FSM owns the decision to stop — do not
+    // schedule another continuation even if the issue still matches
+    // `agent-ready`. Markdown compatibility-graph workflows keep the legacy
+    // "loop on agent-ready" behavior.
     if (input.suppressContinuation === true) {
       return;
     }

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -183,6 +183,11 @@ type RetryPayload = {
   extraInstructions?: string;
   issue: IssueSnapshot;
   projectName: string;
+  // When false (raw FSM mid-walk runs), executeRetry skips the labels_all /
+  // labels_none re-check so a transient provider failure stays recoverable
+  // even when labels drift during the FSM walk. CLOSED_ISSUE still cancels.
+  // See ADR 0046.
+  respectsIssueLabels?: boolean;
   runId: string;
 };
 
@@ -370,17 +375,23 @@ export class RunController {
       });
       return;
     }
-    const eligibility = evaluateProjectEligibility(refreshed, project, {
-      ignoreOperationalLabels: true
-    });
-    if (!eligibility.eligible) {
-      await this.cancelScheduledLifecycleWork({
-        issueNumber: payload.issue.number,
-        reason: CANCEL_REASONS.ELIGIBILITY_LOSS,
-        repository,
-        runId: payload.runId
+    // Raw FSM mid-walk runs: the FSM, not the issue labels, decides whether
+    // the agent keeps running. A transient retry of such a run must not be
+    // cancelled by label drift during the retry backoff. CLOSED_ISSUE above is
+    // still honored. See ADR 0046.
+    if (payload.respectsIssueLabels !== false) {
+      const eligibility = evaluateProjectEligibility(refreshed, project, {
+        ignoreOperationalLabels: true
       });
-      return;
+      if (!eligibility.eligible) {
+        await this.cancelScheduledLifecycleWork({
+          issueNumber: payload.issue.number,
+          reason: CANCEL_REASONS.ELIGIBILITY_LOSS,
+          repository,
+          runId: payload.runId
+        });
+        return;
+      }
     }
 
     // Re-assert sym:claimed best-effort in case operator clear-stale ran between attempts.
@@ -891,6 +902,15 @@ export class RunController {
         }
       };
     }
+    // Raw FSM continuations are state-advance runs: the FSM, not the issue
+    // labels, decides whether the agent keeps running. Computed here so both
+    // activeRuns.register (in the try block) and scheduleNext (in finally)
+    // can carry the same label-immunity guarantee — including into retry
+    // scheduling. See ADR 0046.
+    const respectsIssueLabels = !(
+      input.isContinuation &&
+      loadedWorkflow.expandedWorkflow.source.kind === "raw_fsm"
+    );
 
     try {
       // For raw FSM workflows, the agent action's `prompt` field points at the
@@ -948,14 +968,6 @@ export class RunController {
         state: "running"
       });
       attemptCreated = true;
-      // Raw FSM continuations are state-advance runs: the FSM, not the issue
-      // labels, decides whether the next state runs. Signal that to
-      // reconcileActiveRuns so it skips the labels_all / labels_none re-check
-      // for this run while still honoring CLOSED_ISSUE. See ADR 0046.
-      const respectsIssueLabels = !(
-        input.isContinuation &&
-        loadedWorkflow.expandedWorkflow.source.kind === "raw_fsm"
-      );
       this.activeRuns.register({
         cancel: () => input.provider.cancel(input.runId),
         issueNumber: input.issue.number,
@@ -1080,6 +1092,7 @@ export class RunController {
           outcome: terminal,
           project: input.project,
           repository: input.repository,
+          respectsIssueLabels,
           runId: input.runId,
           runtimeAttemptNumber: input.attemptNumber,
           stateAdvance:
@@ -1473,6 +1486,7 @@ export class RunController {
     outcome: ClassifiedTerminal;
     project: RunControllerProjectConfig;
     repository: GitHubIssueRepositoryInput;
+    respectsIssueLabels?: boolean;
     runId: string;
     runtimeAttemptNumber: number;
     stateAdvance?: { toStateId: string } | null;
@@ -1502,6 +1516,14 @@ export class RunController {
               : { extraInstructions: input.extraInstructions }),
             issue: input.issue,
             projectName: input.project.name,
+            // Carry the FSM mid-walk label-immunity bit into the retry. Without
+            // this a transient provider failure during a raw FSM walk would be
+            // cancelled with ELIGIBILITY_LOSS the moment labels drift, even
+            // though the in-flight attempt and the success-to-next-state path
+            // are both label-immune. See ADR 0046.
+            ...(input.respectsIssueLabels === false
+              ? { respectsIssueLabels: false }
+              : {}),
             runId: input.runId
           }),
         issueNumber: input.issue.number,

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -414,6 +414,23 @@ export class RunStore {
       .run(currentStateId, timestamp(), runId);
   }
 
+  recordWorkflowStateAdvance(
+    runId: string,
+    input: { nextStateId: string; transitionReason: string }
+  ): void {
+    this.database
+      .prepare(
+        [
+          "update runs set",
+          "current_state_id = ?,",
+          "state_transition_reason = ?,",
+          "updated_at = ?",
+          "where id = ?"
+        ].join(" ")
+      )
+      .run(input.nextStateId, input.transitionReason, timestamp(), runId);
+  }
+
   recordWorkflowTerminal(
     runId: string,
     input: { terminalStateId: string; transitionReason: string }

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -965,6 +965,320 @@ describe("daemon dispatch", () => {
     }
   });
 
+  it("walks a multi-state raw FSM workflow through sequential agent states on the same workspace", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "8-dispatch-an-end-to-end-run-through-a-test-provider"
+    );
+    await writeMultiStateRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      // listOpenIssues only sees the issue on the first poll; subsequent polls
+      // return nothing so polling cannot dispatch a parallel claim. State
+      // advance uses getIssue to refresh.
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => `run-fsm-multi-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      // cap=0 proves state advance bypasses the continuation cap: if the FSM
+      // walk went through the continuation path it would be blocked.
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      // Wait until the implementing run reaches terminal_state_id=done.
+      const deadline = Date.now() + 15_000;
+      const databasePath = path.join(root, ".symphonika", "symphonika.db");
+      while (Date.now() < deadline) {
+        try {
+          const database = new Database(databasePath, { readonly: true });
+          try {
+            const row = database
+              .prepare(
+                "select count(*) as c from runs where terminal_state_id = 'done'"
+              )
+              .get() as { c: number };
+            if (row.c >= 1) {
+              break;
+            }
+          } finally {
+            database.close();
+          }
+        } catch {
+          // database may not be readable yet during startup
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const rows = database
+          .prepare(
+            [
+              "select id, state, is_continuation, current_state_id,",
+              "terminal_state_id, state_transition_reason, branch_name,",
+              "workspace_path, continuation_parent_run_id",
+              "from runs order by created_at"
+            ].join(" ")
+          )
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toHaveLength(2);
+
+        const planningRun = rows[0]!;
+        const implementingRun = rows[1]!;
+
+        // Planning ran as the fresh dispatch, advanced to implementing, and
+        // recorded the advance in its row.
+        expect(planningRun).toMatchObject({
+          id: "run-fsm-multi-1",
+          state: "succeeded",
+          is_continuation: 0,
+          current_state_id: "implementing",
+          terminal_state_id: null
+        });
+        expect(stringColumn(planningRun, "state_transition_reason")).toContain(
+          "planning advanced to implementing"
+        );
+
+        // Implementing ran as a state-advance continuation, inherited the
+        // parent's current_state_id, and advanced into the terminal.
+        expect(implementingRun).toMatchObject({
+          id: "run-fsm-multi-2",
+          state: "succeeded",
+          is_continuation: 1,
+          current_state_id: null,
+          terminal_state_id: "done",
+          continuation_parent_run_id: "run-fsm-multi-1"
+        });
+        expect(
+          stringColumn(implementingRun, "state_transition_reason")
+        ).toContain("implementing advanced to done");
+
+        // Both runs share the same workspace and branch — they are two states
+        // of one workflow walk, not two parallel issue claims.
+        expect(planningRun["workspace_path"]).toBe(workspacePath);
+        expect(implementingRun["workspace_path"]).toBe(workspacePath);
+        expect(planningRun["branch_name"]).toBe(implementingRun["branch_name"]);
+      } finally {
+        database.close();
+      }
+
+      // The rendered prompts should reflect each state's prompt file (and not
+      // the YAML workflow body or each other).
+      const planningPrompt = await readFile(
+        path.join(
+          root,
+          ".symphonika",
+          "logs",
+          "runs",
+          "run-fsm-multi-1",
+          "prompt.md"
+        ),
+        "utf8"
+      );
+      expect(planningPrompt).toContain("Draft a plan");
+      expect(planningPrompt).not.toContain("Implement the plan");
+
+      const implementingPrompt = await readFile(
+        path.join(
+          root,
+          ".symphonika",
+          "logs",
+          "runs",
+          "run-fsm-multi-2",
+          "prompt.md"
+        ),
+        "utf8"
+      );
+      expect(implementingPrompt).toContain("Implement the plan");
+      expect(implementingPrompt).not.toContain("Draft a plan");
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("picks the first transition in YAML order when multiple transitions match the observed signals", async () => {
+    const root = await makeTempRoot();
+    await writeTransitionOrderRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => "run-fsm-order",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForRun(daemon.url, "succeeded");
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        // Both `first_match` (when: branch_ahead_of_base) and `unconditional`
+        // (when: {}) match the success signals. The state machine must take
+        // the YAML-first match.
+        const storedRun = database
+          .prepare(
+            "select current_state_id, terminal_state_id, state_transition_reason from runs where id = ?"
+          )
+          .get("run-fsm-order");
+        expect(storedRun).toMatchObject({
+          current_state_id: null,
+          terminal_state_id: "first_match"
+        });
+        const reason = stringColumn(storedRun, "state_transition_reason");
+        expect(reason).toContain("advanced to first_match");
+        expect(reason).not.toContain("advanced to unconditional");
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("records the workflow as blocked when an agent state succeeds but no transition's when predicates match", async () => {
+    const root = await makeTempRoot();
+    await writeNoMatchingTransitionRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => "run-fsm-blocked",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForRun(daemon.url, "succeeded");
+      // Wait beyond the continuation delay to confirm no state advance fires.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((r) =>
+        r.json()
+      )) as { runs: Array<Record<string, unknown>> };
+      // Exactly one run row: no state advance and no continuation dispatched
+      // because the workflow blocked.
+      expect(status.runs).toHaveLength(1);
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const storedRun = database
+          .prepare(
+            [
+              "select state, current_state_id, terminal_state_id,",
+              "state_transition_reason from runs where id = ?"
+            ].join(" ")
+          )
+          .get("run-fsm-blocked");
+        expect(storedRun).toMatchObject({
+          // Agent succeeded; only the workflow instance is blocked.
+          state: "succeeded",
+          // Preserved on block so a future retry resumes at the stuck state
+          // instead of restarting the FSM at the initial state.
+          current_state_id: "planning",
+          terminal_state_id: "planning"
+        });
+        const reason = stringColumn(storedRun, "state_transition_reason");
+        expect(reason).toContain("no transition matching");
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("records terminal_state_id at the stuck agent state when a raw FSM run fails", async () => {
     const root = await makeTempRoot();
     const workspacePath = path.join(
@@ -1199,6 +1513,161 @@ async function writeRawFsmProject(root: string): Promise<void> {
   await writeFile(
     path.join(root, "prompt.md"),
     "Work on #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+async function writeTransitionOrderRawFsmProject(root: string): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: ordered_transitions",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: first_match",
+      "          when:",
+      "            branch_ahead_of_base: true",
+      "        - to: unconditional",
+      "    first_match:",
+      "      terminal: success",
+      "    unconditional:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "prompt.md"),
+    "Work on #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+async function writeNoMatchingTransitionRawFsmProject(
+  root: string
+): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: requires_pr_open",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: review",
+      "          when:",
+      "            pr_open: true",
+      "    review:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "prompt.md"),
+    "Work on #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+async function writeRawFsmProjectConfig(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      `    command: "${DEFAULT_CODEX_COMMAND}"`,
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./workflow.yml",
+      ""
+    ].join("\n")
+  );
+}
+
+async function writeMultiStateRawFsmProject(root: string): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: plan_then_implement",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: implementing",
+      "    implementing:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: implement-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Draft a plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+  await writeFile(
+    path.join(root, "implement-prompt.md"),
+    "Implement the plan for #{{issue.number}}: {{issue.title}}.\n"
   );
 }
 

--- a/tests/dispatch-retry.test.ts
+++ b/tests/dispatch-retry.test.ts
@@ -115,6 +115,88 @@ async function writeProject(root: string): Promise<string> {
   return path.join(root, "symphonika.yml");
 }
 
+async function writeMultiStateRawFsmProject(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      `    command: "codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server"`,
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./workflow.yml",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: plan_then_implement",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: implementing",
+      "    implementing:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: implement-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Draft a plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+  await writeFile(
+    path.join(root, "implement-prompt.md"),
+    "Implement the plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
 async function waitForCondition(
   url: string,
   predicate: (body: { runs: Array<Record<string, unknown>>; active?: unknown[] }) => boolean,
@@ -312,6 +394,141 @@ describe("dispatch retry policy", () => {
         ([call]) => call as { labels: string[] }
       );
       expect(removeCalls.some((call) => call.labels[0] === "sym:claimed")).toBe(true);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("does not cancel a state-advance retry when the issue loses eligibility during backoff", async () => {
+    const root = await makeTempRoot();
+    const prepared = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(prepared);
+    await writeMultiStateRawFsmProject(root);
+
+    let attempts = 0;
+    const provider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        attempts += 1;
+        // call 1: state-1 (planning) succeeds and triggers state_advance.
+        // call 2: state-2 (implementing) attempt 1 — transient failure.
+        // call 3: state-2 (implementing) attempt 2 — succeeds. This must run
+        // even though labels drifted, because the FSM owns the walk.
+        if (attempts === 2) {
+          yield {
+            normalized: { exitCode: 1, type: "process_exit" },
+            raw: { code: 1, kind: "exit" }
+          };
+          return;
+        }
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+
+    // After the first poll, getIssue returns the issue with the required
+    // label removed AND an excluded label added. Under the broken behavior
+    // executeRetry would cancel the state-advance retry with eligibility_loss.
+    // Under the fix, the retry runs because the run is mid-FSM-walk.
+    let listCalls = 0;
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue({
+        ...baseIssue,
+        labels: ["needs-human", "sym:claimed"]
+      }),
+      listOpenIssues: vi.fn(() => {
+        listCalls += 1;
+        if (listCalls === 1) {
+          return Promise.resolve([{ ...baseIssue, labels: ["agent-ready"] }]);
+        }
+        return Promise.resolve([]);
+      }),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const prepareIssueWorkspace = vi.fn(
+      (): Promise<PreparedIssueWorkspace> => Promise.resolve(prepared)
+    );
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => `run-fsm-retry-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        // cap=0 keeps the markdown-style continuation path off so we are
+        // exclusively testing state_advance + retry behavior.
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 3, delaysMs: [10, 20, 30], maxBackoffMs: 100 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      // Wait until two runs exist and the second one succeeds.
+      const deadline = Date.now() + 15_000;
+      const databasePath = path.join(root, ".symphonika", "symphonika.db");
+      while (Date.now() < deadline) {
+        try {
+          const database = new Database(databasePath, { readonly: true });
+          try {
+            const row = database
+              .prepare(
+                "select count(*) as c from runs where id = 'run-fsm-retry-2' and state = 'succeeded'"
+              )
+              .get() as { c: number };
+            if (row.c >= 1) {
+              break;
+            }
+          } finally {
+            database.close();
+          }
+        } catch {
+          // database may not be readable yet during startup
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const runs = database
+          .prepare(
+            "select id, state, is_continuation, cancel_reason, retry_count from runs order by created_at"
+          )
+          .all() as Array<Record<string, unknown>>;
+        // run-1 (planning, fresh dispatch) succeeded; run-2 (implementing,
+        // state-advance) needed one retry and then succeeded — proving the
+        // retry path didn't cancel on the label drift.
+        expect(runs).toHaveLength(2);
+        expect(runs[0]).toMatchObject({
+          id: "run-fsm-retry-1",
+          state: "succeeded",
+          is_continuation: 0
+        });
+        expect(runs[1]).toMatchObject({
+          id: "run-fsm-retry-2",
+          state: "succeeded",
+          is_continuation: 1,
+          retry_count: 1
+        });
+        expect(runs[1]?.["cancel_reason"]).toBeNull();
+      } finally {
+        database.close();
+      }
+
+      expect(attempts).toBe(3);
     } finally {
       await daemon.stop();
     }

--- a/tests/reconcile.test.ts
+++ b/tests/reconcile.test.ts
@@ -158,6 +158,85 @@ describe("reconcileActiveRuns", () => {
     });
   });
 
+  it("does not cancel a state-advance run when the issue loses required labels mid-walk", async () => {
+    await withRunStore(async (store) => {
+      store.createRun({
+        id: "run-a",
+        issue: snapshot(),
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const registry = new ActiveRunRegistry();
+      registry.register({
+        cancel,
+        issueNumber: 7,
+        projectName: project.name,
+        // Raw FSM mid-walk run: the FSM owns whether the agent keeps running,
+        // not the issue label set. See ADR 0046.
+        respectsIssueLabels: false,
+        runId: "run-a"
+      });
+
+      // Poll snapshot: agent-ready removed AND needs-human added. Under the
+      // default flag this would cancel with ELIGIBILITY_LOSS.
+      const status = pollStatus([
+        snapshot({ labels: ["needs-human", "sym:claimed", "sym:running"] })
+      ]);
+
+      await reconcileActiveRuns({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: { listOpenIssues: vi.fn().mockResolvedValue([]) },
+        logger,
+        pollStatus: status,
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(cancel).not.toHaveBeenCalled();
+      expect(registry.get("run-a")?.cancelReason).toBeUndefined();
+    });
+  });
+
+  it("still cancels a state-advance run with closed_issue when the issue is closed", async () => {
+    await withRunStore(async (store) => {
+      store.createRun({
+        id: "run-a",
+        issue: snapshot(),
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const registry = new ActiveRunRegistry();
+      registry.register({
+        cancel,
+        issueNumber: 7,
+        projectName: project.name,
+        respectsIssueLabels: false,
+        runId: "run-a"
+      });
+
+      const status = pollStatus([snapshot({ state: "closed" })]);
+
+      await reconcileActiveRuns({
+        activeRuns: registry,
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: { listOpenIssues: vi.fn().mockResolvedValue([]) },
+        logger,
+        pollStatus: status,
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      // Label-immunity does not extend to closed issues — the run still cancels.
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(registry.get("run-a")?.cancelReason).toBe(CANCEL_REASONS.CLOSED_ISSUE);
+    });
+  });
+
   it("does not cancel when project is removed from config", async () => {
     await withRunStore(async (store) => {
       store.createRun({


### PR DESCRIPTION
## Summary

- Adds a distinct `state_advance` dispatch path so a raw FSM workflow can walk through multiple sequential agent states on the same workspace and branch. State advance bypasses the continuation cap and the `labels_all`/`labels_none` re-check; only the issue's open/closed state is re-verified. Label-driven continuations keep their existing semantics for markdown workflows.
- Records a `state_transition_reason` on every state advance (not only on terminate/block) so the run row carries auditable evidence of the transition taken.
- When an agent state succeeds but no transition matches the observed signals, the workflow instance is marked blocked (`terminal_state_id` + reason) while the run itself stays `succeeded`, and no further dispatch is scheduled.
- Documents the design in `docs/adr/0046-state-advance-vs-continuation.md` and adds the State Advance term to `CONTEXT.md`.

Closes #95

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 315 passing, including three new daemon-level tests:
  - multi-state planning → implementation walk on one workspace under `continuation.cap=0` (proves the cap is bypassed)
  - first-matching transition wins in YAML order when multiple `when`s match
  - agent-succeeded + no-matching-transition records `terminal_state_id` + reason and dispatches nothing further
- [x] `npm run build`