### PR TITLE
Add poll-driven wait states for raw FSM workflows

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -639,6 +639,7 @@ Normalized lifecycle states:
 - `succeeded`
 - `cancelled`
 - `stale`
+- `waiting`
 
 Terminal run state does not necessarily match GitHub issue state.
 
@@ -718,6 +719,42 @@ tracked. For each tracked open PR:
 Default PR follow-up policy: poll enabled, at most `3` review dispatches per PR, squash merge,
 require successful status checks, and do not require an explicit approval unless repository rules
 surface `REVIEW_REQUIRED`.
+
+### 12.5 Wait States
+
+Raw FSM workflows may declare `action.kind: "wait"` states that pause the workflow walk until
+observable pull-request conditions change. A wait state does not launch a provider; instead the
+daemon re-evaluates it on every tick and on `/poll-now`.
+
+Lifecycle:
+
+1. When an agent state succeeds and the FSM advances into a wait state, Symphonika persists a new
+   Run row with `state = "waiting"`, `current_state_id` set to the wait state id, and
+   `continuation_parent_run_id` set to the parent agent run. The parent run records the advance via
+   `state_transition_reason` exactly like any other state advance (per ADR 0046).
+2. On each daemon tick (and on `/poll-now`), the reconciliation phase calls
+   `reconcileWaitingRuns`, which iterates the rows in `state = "waiting"`, refreshes the issue,
+   looks up the tracked pull request, fetches its follow-up state, projects predicates
+   (`pr_open`, `pr_merged`, `mergeable`, `checks`, `unresolved_review_threads`) and emits a static
+   `provider_success: true`, then evaluates the wait state's transitions in file order.
+3. The first matching transition wins. If the destination is an agent state, Symphonika schedules
+   a `state_advance` that runs the agent through `runFreshLifecycle`. If the destination is another
+   wait state, Symphonika creates a new waiting Run row and schedules a `wait_park` re-evaluation.
+   If the destination is terminal, the waiting Run records `terminal_state_id` and transitions to
+   `succeeded`.
+4. If no transition matches and the wait state's `complete_when` is not violated, the wait stays
+   parked (`stay_waiting`); reconciliation will re-evaluate it on the next tick.
+5. Issue close cancels a waiting Run with `cancel_reason = "closed_issue"`. Operator cancel marks
+   the cancel reason; the next re-evaluation tick observes the cancel-requested flag and
+   transitions the Run to `cancelled`.
+6. Label drift does not cancel a waiting Run. Mid-walk runs are immune to `labels_all` and
+   `labels_none` re-checks; the FSM owns transitions while the walk is in flight (ADR 0046,
+   carried over to wait states by ADR 0047).
+
+Mergeability `UNKNOWN`/`null` is intentionally projected as the predicate key omitted — workflow
+transitions writing `mergeable: false` will not match on unknown values, so the wait stays parked
+until GitHub resolves the mergeability. The `timeout` predicate is reserved in the schema but
+unimplemented in v1.
 
 ## 13. CLI
 

--- a/docs/adr/0047-poll-driven-wait-states.md
+++ b/docs/adr/0047-poll-driven-wait-states.md
@@ -1,0 +1,66 @@
+# Poll-driven wait states are reconciled, not dispatched
+
+Symphonika's raw FSM workflow contract allows `action.kind: "wait"` states whose purpose is to pause
+a workflow walk until observable pull-request conditions change (status-check rollup, mergeability,
+unresolved review threads). Unlike `action.kind: "agent"` states, a wait state must not launch a
+provider — it only re-evaluates predicates against externally-observed GitHub state and either
+advances to the next workflow state or stays parked.
+
+Two design choices follow from that contract.
+
+First, a parked wait state needs its own lifecycle status. Reusing `blocked` (which is reserved for
+the workflow-instance property recorded when an agent state finishes with no matching transition,
+per ADR 0046) would conflate "operator should look at this" with "the daemon is correctly waiting
+for external GitHub state to change". Symphonika introduces a new `RunState` value `"waiting"`,
+distinct from `succeeded`, `cancelled`, and the failure states. Waiting rows show up in
+`ACTIVE_STATES` (so status surfaces still list them) and in `KNOWN_RUN_STATES` (so the HTTP filter
+admits them) but stay out of `TERMINAL_RUN_STATES` — operators can still cancel a waiting run, and
+the daemon will keep re-evaluating it on every tick until it advances or is cancelled.
+
+Second, wait re-evaluation does not go through the dispatch path. `executeStateAdvance` always
+prepares a workspace and launches a provider via `runFreshLifecycle`; that contract is correct for
+agent states but wrong for wait states, which by definition must not start a provider. Symphonika
+adds a no-provider tick handler `reconcileWaitingRuns` that lives alongside `reconcileActiveRuns`
+in the reconciliation phase of each daemon tick. For each row in `state = "waiting"` the handler
+refreshes the issue, looks up the tracked pull request, projects the raw GitHub follow-up state
+into the same `WorkflowPredicateMap` shape that agent states produce, and calls `decideNextStep`
+to either advance, stay parked, or terminate. `decideNextStep` is taught a new
+`stay_waiting` decision so a wait state with no matching transition is distinguishable from a
+non-wait state in the same condition.
+
+Wait re-evaluation runs outside `dispatchMutex`. The mutex protects fresh-run dispatch and PR
+follow-up dispatch — both of which create new rows or mutate `tracked_pull_requests` — not
+reconciliation of existing run rows. Tick serialization is provided by `enqueueScheduledWork`,
+which already chains daemon ticks through a single promise queue, so two reconciliation passes
+cannot overlap. Manual `/poll-now` calls `tick()` like the periodic timer, so the handler runs
+the same way under operator-triggered polls.
+
+The waiting row is persisted synchronously the moment the parent agent run terminates and the FSM
+decides to advance into a wait state. `applyWorkflowOutcome` calls `createWaitingRun` inside the
+same code path that records the parent's `state_transition_reason`. This places the wait state on
+disk before any scheduler callback fires, so a daemon restart between the agent finishing and the
+first re-evaluation firing only costs one tick of latency rather than losing the wait entirely —
+single-daemon v1 (ADR 0012) keeps scheduler callbacks in memory, so durability has to live in the
+run-store row itself.
+
+Label immunity carries over from ADR 0046. A waiting run skips the `labels_all` / `labels_none`
+re-check because the FSM, not the issue label set, decides when the wait advances; the
+`sym:claimed` label remains set across the wait, which keeps the existing fresh-dispatch guard
+against starting a second parallel agent on the same issue. Issue close is still honored — a
+waiting row whose issue transitions to `closed` is cancelled with `cancel_reason="closed_issue"`,
+matching the cancellation semantics of in-flight agent runs.
+
+Two predicates are intentionally out of scope for this slice. `timeout` stays defined in the
+predicate set but unimplemented; adding it requires tracking a wait-entered-at timestamp and a
+clock signal, which belongs in a follow-up issue. Webhook-driven wake-ups are also out of scope —
+the wait predicate set is intentionally observation-based, so the same daemon tick cadence that
+already drives PR follow-up drives wait re-evaluation, with no second event path to maintain.
+
+Projection of `mergeable` deliberately omits the predicate key when GitHub reports
+`UNKNOWN` or `null`. A workflow author writing `when: { mergeable: false }` will not match on
+UNKNOWN — the wait state stays parked until GitHub resolves the value. This is the correct
+behavior: matching unknown against either branch would race the GitHub mergeability computation
+that runs right after a push.
+
+The PR follow-up logic in `src/pull-request-followup.ts` shares `projectPullRequestSignals` with
+the wait handler so the two paths cannot drift in how they interpret a given GitHub state.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -255,14 +255,25 @@ export async function startDaemon(
       logger.error({ err: error }, "symphonika reconcile failed");
     }
 
-    try {
-      await reconcileWaitingRuns({
-        logger,
-        runController,
-        runStore
-      });
-    } catch (error) {
-      logger.error({ err: error }, "symphonika waiting reconcile failed");
+    // Serialize against scheduled wait_park callbacks (and any other
+    // scheduled work that mutates run rows). Scheduled callbacks acquire
+    // `dispatchMutex` before firing; if one is in flight, skip this tick's
+    // wait reconciliation and let the callback handle the row it owns —
+    // the next tick will re-pick anything else. Acquiring the mutex here
+    // also prevents two concurrent waiting-run readers from both deciding
+    // to advance the same row.
+    if (dispatchMutex.tryAcquire()) {
+      try {
+        await reconcileWaitingRuns({
+          logger,
+          runController,
+          runStore
+        });
+      } catch (error) {
+        logger.error({ err: error }, "symphonika waiting reconcile failed");
+      } finally {
+        dispatchMutex.release();
+      }
     }
 
     if (dispatchMutex.held) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -24,7 +24,10 @@ import type {
   LifecyclePolicy,
   ScheduledWorkInput
 } from "./lifecycle/active-runs.js";
-import { reconcileActiveRuns } from "./lifecycle/reconcile.js";
+import {
+  reconcileActiveRuns,
+  reconcileWaitingRuns
+} from "./lifecycle/reconcile.js";
 import {
   RunController,
   type RunControllerProjectConfig,
@@ -250,6 +253,16 @@ export async function startDaemon(
       });
     } catch (error) {
       logger.error({ err: error }, "symphonika reconcile failed");
+    }
+
+    try {
+      await reconcileWaitingRuns({
+        logger,
+        runController,
+        runStore
+      });
+    } catch (error) {
+      logger.error({ err: error }, "symphonika waiting reconcile failed");
     }
 
     if (dispatchMutex.held) {

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -65,7 +65,7 @@ export type HttpAppOptions = {
   getReloadStatus?: () => RuntimeReloadStatus;
   getScheduled?: () => Array<{
     dueAt: number;
-    kind: "retry" | "continuation" | "state_advance";
+    kind: "retry" | "continuation" | "state_advance" | "wait_park";
     runId: string;
   }>;
   getStatusSnapshot?: () => StatusSnapshot;
@@ -86,7 +86,8 @@ const KNOWN_RUN_STATES: ReadonlySet<RunState> = new Set([
   "failed",
   "succeeded",
   "cancelled",
-  "stale"
+  "stale",
+  "waiting"
 ]);
 
 const TERMINAL_RUN_STATES: ReadonlySet<RunState> = new Set([

--- a/src/lifecycle/active-runs.ts
+++ b/src/lifecycle/active-runs.ts
@@ -66,7 +66,11 @@ export type RegisterInput = {
   runId: string;
 };
 
-export type ScheduledWorkKind = "retry" | "continuation" | "state_advance";
+export type ScheduledWorkKind =
+  | "retry"
+  | "continuation"
+  | "state_advance"
+  | "wait_park";
 
 export type ScheduledWorkInput = {
   delayMs: number;

--- a/src/lifecycle/active-runs.ts
+++ b/src/lifecycle/active-runs.ts
@@ -133,6 +133,23 @@ export class ActiveRunRegistry {
     return this.issueLocks.has(issueLockKey(projectName, issueNumber));
   }
 
+  // Companion to `isIssueInFlight`: returns true when there is scheduled work
+  // (a delayed retry / continuation / state_advance / wait_park) pending for
+  // the issue. Dispatchers that gate on liveness should check both — a
+  // scheduled state_advance is not yet "in flight" but the issue is reserved
+  // for it. Mirrors the liveness precedent in stale-claims `collectLiveKeys`.
+  isIssueScheduled(projectName: string, issueNumber: number): boolean {
+    for (const item of this.scheduled) {
+      if (
+        item.projectName === projectName &&
+        item.issueNumber === issueNumber
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   async requestCancel(runId: string, reason: CancelReason): Promise<void> {
     const entry = this.entries.get(runId);
     if (entry === undefined || entry.cancelRequested) {

--- a/src/lifecycle/pr-signal-projection.ts
+++ b/src/lifecycle/pr-signal-projection.ts
@@ -1,0 +1,53 @@
+import type { RawGitHubPullRequestFollowupState } from "../issue-polling.js";
+import type { WorkflowPredicateMap } from "../workflow.js";
+
+// Wait-state re-evaluation uses these signals via decideNextStep. The PR
+// follow-up dispatcher in src/pull-request-followup.ts reads the same
+// `RawGitHubPullRequestFollowupState` but produces binary verdicts
+// (pullRequestNeedsReviewFollowup, pullRequestReadyToMerge) rather than a
+// predicate map. If either side changes how it interprets a given GitHub
+// state (e.g. mergeable=UNKNOWN), update both to keep them aligned. See
+// ADR 0047.
+export function projectPullRequestSignals(
+  state: RawGitHubPullRequestFollowupState
+): WorkflowPredicateMap {
+  const signals: WorkflowPredicateMap = {
+    pr_open: state.state === "OPEN"
+  };
+
+  if (state.merged === true) {
+    signals.pr_merged = true;
+  }
+
+  if (state.mergeable === "MERGEABLE") {
+    signals.mergeable = true;
+  } else if (state.mergeable === "CONFLICTING") {
+    signals.mergeable = false;
+  }
+
+  const checks = mapStatusCheckRollup(state.statusCheckRollupState);
+  if (checks !== null) {
+    signals.checks = checks;
+  }
+
+  signals.unresolved_review_threads = state.unresolvedReviewThreads.length;
+
+  return signals;
+}
+
+function mapStatusCheckRollup(
+  rollup: RawGitHubPullRequestFollowupState["statusCheckRollupState"]
+): "failure" | "pending" | "success" | null {
+  switch (rollup) {
+    case "SUCCESS":
+      return "success";
+    case "FAILURE":
+    case "ERROR":
+      return "failure";
+    case "PENDING":
+    case "EXPECTED":
+      return "pending";
+    default:
+      return null;
+  }
+}

--- a/src/lifecycle/reconcile.ts
+++ b/src/lifecycle/reconcile.ts
@@ -11,6 +11,7 @@ import {
 import type { RunStore } from "../run-store.js";
 
 import { ActiveRunRegistry, CANCEL_REASONS } from "./active-runs.js";
+import type { RunController } from "./run-controller.js";
 import { resolveToken } from "./token.js";
 
 export type ReconcileInput = {
@@ -131,5 +132,23 @@ function findIssueSnapshot(
     }
   }
   return undefined;
+}
+
+export async function reconcileWaitingRuns(input: {
+  logger?: Logger;
+  runController: RunController;
+  runStore: RunStore;
+}): Promise<void> {
+  const waiting = input.runStore.listWaitingRuns();
+  for (const row of waiting) {
+    try {
+      await input.runController.reEvaluateWaitingRun(row.runId);
+    } catch (error) {
+      input.logger?.warn(
+        { err: error, runId: row.runId },
+        "symphonika wait re-eval failed"
+      );
+    }
+  }
 }
 

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -518,12 +518,14 @@ export class RunController {
       return;
     }
 
-    const tracked = this.runStore
-      .listOpenTrackedPullRequests()
-      .find(
-        (pr) =>
-          pr.projectName === row.project && pr.issueNumber === row.issueNumber
-      );
+    // Use the all-states lookup: a wait state targeting `pr_merged: true` must
+    // still see the tracked row after PR follow-up has marked it "merged"; an
+    // open-only listing would strand the wait. The dispatcher's own open-only
+    // loop is unaffected — only wait re-evaluation widens the lookup.
+    const tracked = this.runStore.findTrackedPullRequestByIssue({
+      issueNumber: row.issueNumber,
+      projectName: row.project
+    });
     if (tracked === undefined) {
       this.logger?.debug(
         { runId, issueNumber: row.issueNumber },

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -13,7 +13,12 @@ import type {
   PollingProjectConfig,
   RawGitHubPullRequestReviewThread
 } from "../issue-polling.js";
-import { evaluateProjectEligibility, tryGetIssue } from "../issue-polling.js";
+import {
+  evaluateProjectEligibility,
+  tryGetIssue,
+  tryGetPullRequestFollowupState
+} from "../issue-polling.js";
+import { projectPullRequestSignals } from "./pr-signal-projection.js";
 import type {
   AgentProvider,
   AgentProviderName,
@@ -92,7 +97,7 @@ export type ScheduleHandler = (input: {
   delayMs: number;
   fire: () => Promise<void>;
   issueNumber: number;
-  kind: "retry" | "continuation" | "state_advance";
+  kind: "retry" | "continuation" | "state_advance" | "wait_park";
   projectName: string;
   runId: string;
 }) => void;
@@ -207,6 +212,12 @@ type WorkflowOutcomeResult = {
   advancedToState: string | null;
   advancedToTerminal: boolean;
   blocked: boolean;
+  parkAsWait?: boolean;
+  waitingRunId?: string;
+};
+
+type WaitParkPayload = {
+  waitingRunId: string;
 };
 
 export class RunController {
@@ -443,6 +454,191 @@ export class RunController {
       repository: input.repository,
       willRetry: false
     });
+  }
+
+  async executeWaitPark(payload: WaitParkPayload): Promise<void> {
+    await this.reEvaluateWaitingRun(payload.waitingRunId);
+  }
+
+  async reEvaluateWaitingRun(runId: string): Promise<void> {
+    const row = this.runStore.getRun(runId);
+    if (row === undefined || row.state !== "waiting") {
+      return;
+    }
+    if (row.cancelRequested) {
+      const reason: CancelReason = row.cancelReason ?? "operator";
+      this.runStore.markCancelRequested(runId, reason);
+      this.runStore.updateRunState(runId, "cancelled");
+      return;
+    }
+    if (row.currentStateId === null) {
+      return;
+    }
+
+    const projects = await this.projectsLoader();
+    const project = projects.get(row.project);
+    if (project === undefined || project.disabled === true) {
+      return;
+    }
+
+    const token = resolveTokenFromEnv(project.tracker.token, this.env);
+    if (token === undefined) {
+      return;
+    }
+    const repository: GitHubIssueRepositoryInput = {
+      owner: project.tracker.owner,
+      repo: project.tracker.repo,
+      token
+    };
+
+    const refreshed = await this.refreshIssue({
+      project,
+      issueNumber: row.issueNumber,
+      repository
+    });
+    if (refreshed === undefined) {
+      return;
+    }
+    if (refreshed === null || refreshed.state !== "open") {
+      this.runStore.markCancelRequested(runId, "closed_issue");
+      this.runStore.updateRunState(runId, "cancelled");
+      return;
+    }
+
+    const loaded = await this.loadWorkflow(project.workflow);
+    const waitState = findWorkflowState(
+      loaded.expandedWorkflow,
+      row.currentStateId
+    );
+    if (waitState === undefined) {
+      this.logger?.warn(
+        { runId, stateId: row.currentStateId },
+        "symphonika wait re-eval skipped: workflow state not found"
+      );
+      return;
+    }
+
+    const tracked = this.runStore
+      .listOpenTrackedPullRequests()
+      .find(
+        (pr) =>
+          pr.projectName === row.project && pr.issueNumber === row.issueNumber
+      );
+    if (tracked === undefined) {
+      this.logger?.debug(
+        { runId, issueNumber: row.issueNumber },
+        "symphonika wait re-eval skipped: no PR tracked yet"
+      );
+      return;
+    }
+
+    let prState;
+    try {
+      prState = await tryGetPullRequestFollowupState(this.githubIssuesApi, {
+        owner: repository.owner,
+        pullNumber: tracked.prNumber,
+        repo: repository.repo,
+        token: repository.token
+      });
+    } catch (error) {
+      this.logger?.warn(
+        { err: error, runId },
+        "symphonika wait re-eval skipped: PR state fetch failed"
+      );
+      return;
+    }
+    if (prState === undefined || prState === null) {
+      return;
+    }
+
+    const signals = {
+      provider_success: true,
+      ...projectPullRequestSignals(prState)
+    };
+
+    const decision = decideNextStep({
+      actionExecuted: true,
+      signals,
+      state: waitState
+    });
+
+    if (decision.kind === "stay_waiting") {
+      this.logger?.debug(
+        { reason: decision.reason, runId },
+        "symphonika wait re-eval: still waiting"
+      );
+      return;
+    }
+
+    if (decision.kind === "advance") {
+      const next = findWorkflowState(loaded.expandedWorkflow, decision.to);
+      if (next?.terminal !== undefined) {
+        this.runStore.recordWorkflowTerminal(runId, {
+          terminalStateId: next.id,
+          transitionReason: decision.reason
+        });
+        this.runStore.updateRunState(runId, "succeeded");
+        return;
+      }
+      this.runStore.recordWorkflowStateAdvance(runId, {
+        nextStateId: decision.to,
+        transitionReason: decision.reason
+      });
+      this.runStore.updateRunState(runId, "succeeded");
+
+      if (next?.action?.kind === "wait") {
+        const nextWaitingRunId = this.createRunId();
+        this.runStore.createWaitingRun({
+          currentStateId: decision.to,
+          id: nextWaitingRunId,
+          issue: refreshed,
+          parentRunId: runId,
+          projectName: project.name
+        });
+        this.schedule({
+          delayMs: this.lifecyclePolicy.continuation.delayMs,
+          fire: () =>
+            this.executeWaitPark({ waitingRunId: nextWaitingRunId }),
+          issueNumber: refreshed.number,
+          kind: "wait_park",
+          projectName: project.name,
+          runId
+        });
+        return;
+      }
+
+      this.schedule({
+        delayMs: this.lifecyclePolicy.continuation.delayMs,
+        fire: () =>
+          this.executeStateAdvance({
+            issue: refreshed,
+            parentRunId: runId,
+            projectName: project.name
+          }),
+        issueNumber: refreshed.number,
+        kind: "state_advance",
+        projectName: project.name,
+        runId
+      });
+      return;
+    }
+
+    if (decision.kind === "blocked") {
+      this.runStore.recordWorkflowBlocked(runId, {
+        stateId: waitState.id,
+        transitionReason: decision.reason
+      });
+      this.runStore.updateRunState(runId, "succeeded");
+      return;
+    }
+
+    if (decision.kind === "terminate") {
+      this.runStore.recordWorkflowTerminal(runId, {
+        terminalStateId: decision.stateId,
+        transitionReason: `entered terminal state ${decision.terminal}`
+      });
+      this.runStore.updateRunState(runId, "succeeded");
+    }
   }
 
   async executeStateAdvance(payload: StateAdvancePayload): Promise<void> {
@@ -1033,6 +1229,8 @@ export class RunController {
       if (currentState !== undefined) {
         workflowOutcome = this.applyWorkflowOutcome({
           currentState,
+          issue: input.issue,
+          project: input.project,
           runId: input.runId,
           terminal,
           workflow: loadedWorkflow.expandedWorkflow
@@ -1096,8 +1294,16 @@ export class RunController {
           runId: input.runId,
           runtimeAttemptNumber: input.attemptNumber,
           stateAdvance:
-            isRawFsm && workflowOutcome.advancedToState !== null
+            isRawFsm &&
+            workflowOutcome.advancedToState !== null &&
+            workflowOutcome.parkAsWait !== true
               ? { toStateId: workflowOutcome.advancedToState }
+              : null,
+          waitPark:
+            isRawFsm &&
+            workflowOutcome.parkAsWait === true &&
+            workflowOutcome.waitingRunId !== undefined
+              ? { waitingRunId: workflowOutcome.waitingRunId }
               : null,
           suppressContinuation
         });
@@ -1216,6 +1422,8 @@ export class RunController {
 
   private applyWorkflowOutcome(input: {
     currentState: ExpandedWorkflowState;
+    issue: IssueSnapshot;
+    project: RunControllerProjectConfig;
     runId: string;
     terminal: ClassifiedTerminal;
     workflow: ExpandedWorkflow;
@@ -1240,6 +1448,23 @@ export class RunController {
         nextStateId: decision.to,
         transitionReason: decision.reason
       });
+      if (next?.action?.kind === "wait") {
+        const waitingRunId = this.createRunId();
+        this.runStore.createWaitingRun({
+          currentStateId: decision.to,
+          id: waitingRunId,
+          issue: input.issue,
+          parentRunId: input.runId,
+          projectName: input.project.name
+        });
+        return {
+          advancedToState: decision.to,
+          advancedToTerminal: false,
+          blocked: false,
+          parkAsWait: true,
+          waitingRunId
+        };
+      }
       return {
         advancedToState: decision.to,
         advancedToTerminal: false,
@@ -1491,6 +1716,7 @@ export class RunController {
     runtimeAttemptNumber: number;
     stateAdvance?: { toStateId: string } | null;
     suppressContinuation?: boolean;
+    waitPark?: { waitingRunId: string } | null;
   }): Promise<void> {
     if (input.outcome.kind === "cancelled" || input.outcome.kind === "input_required") {
       return;
@@ -1570,6 +1796,33 @@ export class RunController {
           }),
         issueNumber: refreshedForAdvance.number,
         kind: "state_advance",
+        projectName: input.project.name,
+        runId: input.runId
+      });
+      return;
+    }
+
+    // Raw FSM advanced into a wait state: the waiting row was already created
+    // synchronously by applyWorkflowOutcome (so a daemon restart can recover
+    // it). Schedule a one-shot re-evaluation; subsequent re-evaluations come
+    // from the daemon tick's reconcileWaitingRuns pass.
+    if (input.waitPark != null) {
+      this.logger?.info(
+        {
+          delayMs: this.lifecyclePolicy.continuation.delayMs,
+          issueNumber: input.issue.number,
+          parentRunId: input.runId,
+          project: input.project.name,
+          waitingRunId: input.waitPark.waitingRunId
+        },
+        "symphonika scheduling wait re-evaluation"
+      );
+      const waitingRunId = input.waitPark.waitingRunId;
+      this.schedule({
+        delayMs: this.lifecyclePolicy.continuation.delayMs,
+        fire: () => this.executeWaitPark({ waitingRunId }),
+        issueNumber: input.issue.number,
+        kind: "wait_park",
         projectName: input.project.name,
         runId: input.runId
       });

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -805,6 +805,18 @@ export class RunController {
       };
     }
 
+    // Don't race a scheduled state_advance: a wait→agent transition may have
+    // just enqueued an autofix state for this issue in the same tick. The
+    // scheduled item is not yet in `activeRuns.entries`, so `isIssueInFlight`
+    // misses it. Consult `isIssueScheduled` to avoid dispatching a duplicate
+    // review-followup run on the same issue/branch.
+    if (this.activeRuns.isIssueScheduled(input.projectName, input.issueNumber)) {
+      return {
+        dispatched: false,
+        reason: "issue has scheduled work pending"
+      };
+    }
+
     const provider = this.agentProviders[project.agent.provider];
     if (provider === undefined) {
       return {

--- a/src/lifecycle/stale-claims.ts
+++ b/src/lifecycle/stale-claims.ts
@@ -109,6 +109,13 @@ function collectLiveKeys(input: DetectStaleClaimsInput): Set<string> {
   for (const entry of input.runStore.listActiveRunIds()) {
     keys.add(issueKey(entry.projectName, entry.issueNumber));
   }
+  // Parked wait rows keep their `sym:claimed` label across the wait but have
+  // no entry in `activeRuns` and no row in `listActiveRunIds`. Without this
+  // pass, a long wait between `wait_park` re-evaluations would be marked
+  // `sym:stale`. See ADR 0047.
+  for (const entry of input.runStore.listWaitingRunIds()) {
+    keys.add(issueKey(entry.projectName, entry.issueNumber));
+  }
   return keys;
 }
 

--- a/src/lifecycle/state-machine-dispatch.ts
+++ b/src/lifecycle/state-machine-dispatch.ts
@@ -10,7 +10,8 @@ export type StateMachineDecision =
   | { action: WorkflowAction; kind: "execute_action"; stateId: string }
   | { kind: "terminate"; stateId: string; terminal: string }
   | { kind: "advance"; reason: string; to: string }
-  | { kind: "blocked"; reason: string };
+  | { kind: "blocked"; reason: string }
+  | { kind: "stay_waiting"; reason: string };
 
 export type StateMachineSignals = WorkflowPredicateMap;
 
@@ -32,7 +33,9 @@ export function decideNextStep(input: {
     return { kind: "terminate", stateId: state.id, terminal: state.terminal };
   }
 
-  if (!actionExecuted && state.action !== undefined) {
+  const isWait = state.action?.kind === "wait";
+
+  if (!isWait && !actionExecuted && state.action !== undefined) {
     return { action: state.action, kind: "execute_action", stateId: state.id };
   }
 
@@ -52,6 +55,13 @@ export function decideNextStep(input: {
         to: transition.to
       };
     }
+  }
+
+  if (isWait) {
+    return {
+      kind: "stay_waiting",
+      reason: `state ${state.id} wait predicates not yet satisfied`
+    };
   }
 
   return {

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -1178,6 +1178,32 @@ export class RunStore {
       });
   }
 
+  // Wait re-evaluation needs to see merged/closed tracked PRs so a workflow
+  // waiting on `pr_merged: true` can advance after the PR follow-up
+  // dispatcher has marked the tracked row "merged". Returns the most-recent
+  // tracked PR for the (project, issue) pair regardless of `state`.
+  findTrackedPullRequestByIssue(input: {
+    issueNumber: number;
+    projectName: string;
+  }): TrackedPullRequest | undefined {
+    const row = this.database
+      .prepare(
+        [
+          "select id, project_name, issue_number, run_id, pr_number, pr_url,",
+          "branch_name, head_sha_at_dispatch, last_seen_head_sha,",
+          "last_review_dispatch_fingerprint, review_dispatch_count,",
+          "last_followup_run_id, state, last_observed_at, created_at, updated_at",
+          "from tracked_pull_requests",
+          "where project_name = ? and issue_number = ?",
+          "order by id desc limit 1"
+        ].join(" ")
+      )
+      .get(input.projectName, input.issueNumber) as
+      | TrackedPullRequestRow
+      | undefined;
+    return row === undefined ? undefined : mapTrackedPullRequestRow(row);
+  }
+
   listOpenTrackedPullRequests(): TrackedPullRequest[] {
     const rows = this.database
       .prepare(

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -14,7 +14,8 @@ export type RunState =
   | "failed"
   | "succeeded"
   | "cancelled"
-  | "stale";
+  | "stale"
+  | "waiting";
 
 export type FailureClassification = "transient" | "deterministic" | "input_required";
 
@@ -344,6 +345,57 @@ export class RunStore {
       providerName: input.providerName,
       state: "queued"
     });
+  }
+
+  createWaitingRun(input: {
+    currentStateId: string;
+    id: string;
+    issue: IssueSnapshot;
+    parentRunId: string;
+    projectName: string;
+  }): void {
+    this.insertRunRow({
+      id: input.id,
+      isContinuation: true,
+      issue: input.issue,
+      parentRunId: input.parentRunId,
+      projectName: input.projectName,
+      providerCommand: null,
+      providerName: null,
+      state: "waiting"
+    });
+    this.setRunCurrentState(input.id, input.currentStateId);
+  }
+
+  listWaitingRuns(): Array<{
+    currentStateId: string;
+    issueNumber: number;
+    projectName: string;
+    runId: string;
+  }> {
+    const rows = this.database
+      .prepare(
+        [
+          "select id, project_name, issue_number, current_state_id",
+          "from runs",
+          "where state = 'waiting'",
+          "and cancel_requested = 0",
+          "and current_state_id is not null",
+          "order by created_at asc"
+        ].join(" ")
+      )
+      .all() as Array<{
+        id: string;
+        project_name: string;
+        issue_number: number;
+        current_state_id: string;
+      }>;
+    return rows.map((row) => ({
+      currentStateId: row.current_state_id,
+      issueNumber: row.issue_number,
+      projectName: row.project_name,
+      runId: row.id
+    }));
   }
 
   createContinuationRun(input: CreateRunInput & { parentRunId: string }): void {

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -367,6 +367,10 @@ export class RunStore {
     this.setRunCurrentState(input.id, input.currentStateId);
   }
 
+  // Includes cancel-requested rows on purpose: a waiting run cancelled via
+  // cancelViaUi only flips `cancel_requested = 1`, and the cancellation branch
+  // lives inside reEvaluateWaitingRun. Filtering cancel-requested rows out
+  // here would leave the row stuck in `state = "waiting"` forever.
   listWaitingRuns(): Array<{
     currentStateId: string;
     issueNumber: number;
@@ -379,7 +383,6 @@ export class RunStore {
           "select id, project_name, issue_number, current_state_id",
           "from runs",
           "where state = 'waiting'",
-          "and cancel_requested = 0",
           "and current_state_id is not null",
           "order by created_at asc"
         ].join(" ")

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -560,6 +560,25 @@ export class RunStore {
     }));
   }
 
+  // Stale-claim liveness needs waiting rows too: a parked wait still wears
+  // `sym:claimed` (ADR 0046), and between scheduled `wait_park` callbacks it
+  // has no entry in `activeRuns` and no row in `listActiveRunIds`. Cancel-
+  // requested rows stay included for the same reason `listWaitingRuns`
+  // includes them — they are still live until `reEvaluateWaitingRun`
+  // transitions them.
+  listWaitingRunIds(): { runId: string; projectName: string; issueNumber: number }[] {
+    const rows = this.database
+      .prepare(
+        "select id, project_name, issue_number from runs where state = 'waiting'"
+      )
+      .all() as { id: string; project_name: string; issue_number: number }[];
+    return rows.map((row) => ({
+      issueNumber: row.issue_number,
+      projectName: row.project_name,
+      runId: row.id
+    }));
+  }
+
   private insertRunRow(input: {
     id: string;
     isContinuation: boolean;

--- a/src/status.ts
+++ b/src/status.ts
@@ -32,7 +32,8 @@ const ACTIVE_STATES = new Set([
   "queued",
   "preparing_workspace",
   "running",
-  "input_required"
+  "input_required",
+  "waiting"
 ]);
 
 export function buildStatusSnapshot(

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -866,6 +866,19 @@ function parseWorkflowAction(
     }
   }
 
+  if (kind === "wait") {
+    if (provider !== undefined) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} wait action must not define provider`
+      );
+    }
+    if (prompt !== undefined) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} wait action must not define prompt`
+      );
+    }
+  }
+
   return {
     kind,
     ...(method === undefined ? {} : { method }),

--- a/tests/pr-signal-projection.test.ts
+++ b/tests/pr-signal-projection.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import type { RawGitHubPullRequestFollowupState } from "../src/issue-polling.js";
+import { projectPullRequestSignals } from "../src/lifecycle/pr-signal-projection.js";
+
+function makePullRequestState(
+  overrides: Partial<RawGitHubPullRequestFollowupState> = {}
+): RawGitHubPullRequestFollowupState {
+  return {
+    draft: false,
+    headSha: "deadbeef",
+    mergeable: null,
+    merged: false,
+    number: 42,
+    reviewDecision: null,
+    state: "OPEN",
+    statusCheckRollupState: null,
+    unresolvedReviewThreads: [],
+    url: "https://example.test/pr/42",
+    ...overrides
+  };
+}
+
+describe("projectPullRequestSignals", () => {
+  it("emits pr_open: true for an open pull request", () => {
+    const signals = projectPullRequestSignals(makePullRequestState({ state: "OPEN" }));
+    expect(signals.pr_open).toBe(true);
+  });
+
+  it("emits pr_open: false for a closed pull request", () => {
+    const signals = projectPullRequestSignals(makePullRequestState({ state: "CLOSED" }));
+    expect(signals.pr_open).toBe(false);
+  });
+
+  it("emits pr_merged: true when the pull request is merged", () => {
+    const signals = projectPullRequestSignals(
+      makePullRequestState({ state: "MERGED", merged: true })
+    );
+    expect(signals.pr_merged).toBe(true);
+    expect(signals.pr_open).toBe(false);
+  });
+
+  it("does not emit pr_merged when the pull request is not merged", () => {
+    const signals = projectPullRequestSignals(makePullRequestState({ merged: false }));
+    expect(signals.pr_merged).toBeUndefined();
+  });
+
+  it("emits mergeable: true for MERGEABLE state", () => {
+    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: "MERGEABLE" }));
+    expect(signals.mergeable).toBe(true);
+  });
+
+  it("emits mergeable: false for CONFLICTING state", () => {
+    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: "CONFLICTING" }));
+    expect(signals.mergeable).toBe(false);
+  });
+
+  it("omits mergeable when state is UNKNOWN", () => {
+    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: "UNKNOWN" }));
+    expect("mergeable" in signals).toBe(false);
+  });
+
+  it("omits mergeable when state is null", () => {
+    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: null }));
+    expect("mergeable" in signals).toBe(false);
+  });
+
+  it("emits checks: 'success' for SUCCESS rollup", () => {
+    const signals = projectPullRequestSignals(
+      makePullRequestState({ statusCheckRollupState: "SUCCESS" })
+    );
+    expect(signals.checks).toBe("success");
+  });
+
+  it("emits checks: 'failure' for FAILURE and ERROR rollups", () => {
+    for (const rollup of ["FAILURE", "ERROR"] as const) {
+      const signals = projectPullRequestSignals(
+        makePullRequestState({ statusCheckRollupState: rollup })
+      );
+      expect(signals.checks).toBe("failure");
+    }
+  });
+
+  it("emits checks: 'pending' for PENDING and EXPECTED rollups", () => {
+    for (const rollup of ["PENDING", "EXPECTED"] as const) {
+      const signals = projectPullRequestSignals(
+        makePullRequestState({ statusCheckRollupState: rollup })
+      );
+      expect(signals.checks).toBe("pending");
+    }
+  });
+
+  it("omits checks when rollup is null", () => {
+    const signals = projectPullRequestSignals(
+      makePullRequestState({ statusCheckRollupState: null })
+    );
+    expect("checks" in signals).toBe(false);
+  });
+
+  it("emits unresolved_review_threads as the numeric count", () => {
+    const zero = projectPullRequestSignals(
+      makePullRequestState({ unresolvedReviewThreads: [] })
+    );
+    expect(zero.unresolved_review_threads).toBe(0);
+
+    const two = projectPullRequestSignals(
+      makePullRequestState({
+        unresolvedReviewThreads: [
+          { id: "t1", isResolved: false, comments: [] },
+          { id: "t2", isResolved: false, comments: [] }
+        ]
+      })
+    );
+    expect(two.unresolved_review_threads).toBe(2);
+  });
+});

--- a/tests/pull-request-followup.test.ts
+++ b/tests/pull-request-followup.test.ts
@@ -211,6 +211,126 @@ describe("pull request follow-up", () => {
     }
   });
 
+  it("skips the review-followup dispatch when a state_advance is already scheduled for the same issue", async () => {
+    // Regression for the wait→agent race: reconcileWaitingRuns advances a
+    // wait state into an agent state and schedules a state_advance, but the
+    // scheduled item is only in `activeRuns.scheduled` (not `entries`). PR
+    // follow-up runs later in the same tick and must NOT dispatch a parallel
+    // review-followup for the same issue.
+    const root = await makeTempRoot();
+    await writeProject(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const branchName = "sym/symphonika/54-review-followup-race";
+      const workspacePath = path.join(root, "workspace");
+      seedSucceededRun(store, { branchName, runId: "parent-run", workspacePath });
+
+      const providerInputs: ProviderRunInput[] = [];
+      const provider = fakeProvider(providerInputs);
+      const project = projectConfig();
+      const githubIssuesApi: GitHubIssuesApi = {
+        addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+        getIssue: vi.fn().mockResolvedValue(issueFixture()),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(
+          prState({
+            reviewDecision: "CHANGES_REQUESTED",
+            unresolvedReviewThreads: [
+              {
+                comments: [],
+                id: "PRRT_kwDO",
+                isResolved: false,
+                line: 24,
+                path: "src/daemon.ts"
+              }
+            ]
+          })
+        ),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        listPullRequestsForBranch: vi.fn().mockResolvedValue([
+          {
+            draft: false,
+            head: { ref: branchName, sha: "abc123" },
+            html_url: "https://github.com/pmatos/symphonika/pull/82",
+            number: 82,
+            state: "open"
+          }
+        ]),
+        removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+      };
+
+      // Use a controller whose schedule handler actually goes through
+      // ActiveRunRegistry.scheduleDelayed so the scheduled state_advance is
+      // visible to isIssueScheduled. Keep the timeouts long enough that the
+      // fire() never runs during the test.
+      const activeRuns = new ActiveRunRegistry();
+      let nextRun = 0;
+      const controller = new RunController({
+        activeRuns,
+        agentProviders: { codex: provider },
+        configDir: root,
+        createRunId: () => {
+          nextRun += 1;
+          return `race-run-${nextRun}`;
+        },
+        env: { GITHUB_TOKEN: "secret-token" },
+        githubIssuesApi,
+        prepareIssueWorkspace: () =>
+          Promise.resolve({
+            branchName,
+            branchRef: `refs/heads/${branchName}`,
+            cachePath: path.join(root, ".symphonika", "workspaces", ".cache"),
+            issueDirectoryName: "54-review-followup-race",
+            reused: true,
+            workspacePath
+          }),
+        projectsLoader: () =>
+          Promise.resolve(new Map([[project.name, project]])),
+        providersLoader: () => Promise.resolve(providersConfig()),
+        runStore: store,
+        schedule: (item) => {
+          activeRuns.scheduleDelayed({
+            delayMs: 60_000,
+            fire: item.fire,
+            issueNumber: item.issueNumber,
+            kind: item.kind,
+            projectName: item.projectName,
+            runId: item.runId
+          });
+        },
+        stateRoot: path.join(root, ".symphonika")
+      });
+
+      // Simulate the wait→agent advance: pretend the reconciler just
+      // scheduled a state_advance for issue 54.
+      activeRuns.scheduleDelayed({
+        delayMs: 60_000,
+        fire: () => Promise.resolve(),
+        issueNumber: 54,
+        kind: "state_advance",
+        projectName: project.name,
+        runId: "parent-run"
+      });
+
+      const result = await runPullRequestFollowup({
+        configPath: path.join(root, "symphonika.yml"),
+        env: { GITHUB_TOKEN: "secret-token" },
+        githubIssuesApi,
+        projectsLoader: () => Promise.resolve(new Map([[project.name, project]])),
+        runController: controller,
+        runStore: store
+      });
+
+      // PR follow-up either declined explicitly or did not produce a
+      // review_dispatch — what matters is that no provider attempt fired.
+      expect(result.action).not.toBe("review_dispatch");
+      expect(providerInputs).toHaveLength(0);
+
+      activeRuns.cancelAll();
+    } finally {
+      store.close();
+    }
+  });
+
   it("does not merge when status checks are missing under the default policy", () => {
     expect(
       pullRequestReadyToMerge(

--- a/tests/run-store-waiting.test.ts
+++ b/tests/run-store-waiting.test.ts
@@ -75,7 +75,7 @@ describe("RunStore waiting-run helpers", () => {
     }
   });
 
-  it("listWaitingRuns surfaces waiting rows and excludes cancel-requested ones", async () => {
+  it("listWaitingRuns surfaces waiting rows including cancel-requested ones so reconciliation can transition them", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });
     try {
@@ -99,12 +99,15 @@ describe("RunStore waiting-run helpers", () => {
       store.markCancelRequested("wait-B", "operator");
 
       const waiting = store.listWaitingRuns();
-      expect(waiting.map((row: { runId: string }) => row.runId).sort()).toEqual(["wait-A"]);
-      expect(waiting[0]).toMatchObject({
-        currentStateId: "review_check",
-        issueNumber: 10,
+      expect(
+        waiting.map((row: { runId: string }) => row.runId).sort()
+      ).toEqual(["wait-A", "wait-B"]);
+      const waitB = waiting.find((row) => row.runId === "wait-B");
+      expect(waitB).toMatchObject({
+        currentStateId: "merge_gate",
+        issueNumber: 11,
         projectName: "symphonika",
-        runId: "wait-A"
+        runId: "wait-B"
       });
     } finally {
       store.close();

--- a/tests/run-store-waiting.test.ts
+++ b/tests/run-store-waiting.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IssueSnapshot } from "../src/issue-polling.js";
+import { openRunStore } from "../src/run-store.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-run-store-waiting-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+function sampleIssue(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    body: "issue body",
+    created_at: "2026-04-01T00:00:00Z",
+    id: 1001,
+    labels: ["agent-ready"],
+    number: 42,
+    priority: 99,
+    state: "open",
+    title: "Sample issue",
+    updated_at: "2026-04-02T00:00:00Z",
+    url: "https://example.invalid/issue/42",
+    ...overrides
+  };
+}
+
+function seedParent(store: ReturnType<typeof openRunStore>, id: string) {
+  store.createRun({
+    id,
+    issue: sampleIssue(),
+    projectName: "symphonika",
+    providerCommand: "fake-codex",
+    providerName: "codex"
+  });
+  store.updateRunState(id, "succeeded");
+}
+
+describe("RunStore waiting-run helpers", () => {
+  it("createWaitingRun persists a row in 'waiting' state with no provider evidence", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      seedParent(store, "parent-1");
+
+      store.createWaitingRun({
+        currentStateId: "holding",
+        id: "wait-1",
+        issue: sampleIssue(),
+        parentRunId: "parent-1",
+        projectName: "symphonika"
+      });
+
+      const detail = store.getRun("wait-1");
+      expect(detail).toBeDefined();
+      expect(detail?.state).toBe("waiting");
+      expect(detail?.currentStateId).toBe("holding");
+      expect(detail?.continuationParentRunId).toBe("parent-1");
+      expect(detail?.isContinuation).toBe(true);
+      expect(detail?.provider).toBe("");
+      expect(detail?.promptPath).toBe("");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("listWaitingRuns surfaces waiting rows and excludes cancel-requested ones", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      seedParent(store, "parent-A");
+      seedParent(store, "parent-B");
+
+      store.createWaitingRun({
+        currentStateId: "review_check",
+        id: "wait-A",
+        issue: sampleIssue({ number: 10 }),
+        parentRunId: "parent-A",
+        projectName: "symphonika"
+      });
+      store.createWaitingRun({
+        currentStateId: "merge_gate",
+        id: "wait-B",
+        issue: sampleIssue({ number: 11 }),
+        parentRunId: "parent-B",
+        projectName: "symphonika"
+      });
+      store.markCancelRequested("wait-B", "operator");
+
+      const waiting = store.listWaitingRuns();
+      expect(waiting.map((row: { runId: string }) => row.runId).sort()).toEqual(["wait-A"]);
+      expect(waiting[0]).toMatchObject({
+        currentStateId: "review_check",
+        issueNumber: 10,
+        projectName: "symphonika",
+        runId: "wait-A"
+      });
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/tests/stale-claims.test.ts
+++ b/tests/stale-claims.test.ts
@@ -360,6 +360,48 @@ describe("detectStaleClaims", () => {
     });
   });
 
+  it("does not mark when the run-store reports a parked waiting run for the issue", async () => {
+    await withRunStore(async (store) => {
+      const issue = snapshot({ labels: ["agent-ready", "sym:claimed"] });
+      // Parked wait state: agent state succeeded and advanced into a wait
+      // state. The waiting row has no entry in `activeRuns` and no scheduled
+      // work between `wait_park` re-evaluations, but the issue still wears
+      // `sym:claimed` per ADR 0046.
+      store.createRun({
+        id: "parent-agent",
+        issue,
+        projectName: project.name,
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      store.updateRunState("parent-agent", "succeeded");
+      store.createWaitingRun({
+        currentStateId: "holding",
+        id: "wait-row",
+        issue,
+        parentRunId: "parent-agent",
+        projectName: project.name
+      });
+
+      const addLabelsToIssue = vi.fn().mockResolvedValue(undefined);
+      const marks = await detectStaleClaims({
+        activeRuns: new ActiveRunRegistry(),
+        env: { GITHUB_TOKEN: "secret" },
+        githubIssuesApi: {
+          addLabelsToIssue,
+          listOpenIssues: vi.fn().mockResolvedValue([])
+        },
+        logger,
+        pollStatus: pollStatusWithFiltered([issue]),
+        projects: new Map([[project.name, project]]),
+        runStore: store
+      });
+
+      expect(addLabelsToIssue).not.toHaveBeenCalled();
+      expect(marks).toEqual([]);
+    });
+  });
+
   it("does not mark when an in-memory run is registered for the issue", async () => {
     await withRunStore(async (store) => {
       const issue = snapshot({ labels: ["agent-ready", "sym:claimed"] });

--- a/tests/state-machine-dispatch.test.ts
+++ b/tests/state-machine-dispatch.test.ts
@@ -144,6 +144,87 @@ describe("state-machine-dispatch", () => {
       }
     });
 
+    it("skips execute_action for a wait state even on first entry", () => {
+      const waitState: ExpandedWorkflowState = {
+        action: { kind: "wait" },
+        completeWhen: {},
+        id: "holding",
+        transitions: [{ to: "merge", when: { checks: "success" } }]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: false,
+        signals: {},
+        state: waitState
+      });
+
+      expect(decision.kind).not.toBe("execute_action");
+    });
+
+    it("returns stay_waiting for a wait state with no matching transition", () => {
+      const waitState: ExpandedWorkflowState = {
+        action: { kind: "wait" },
+        completeWhen: {},
+        id: "holding",
+        transitions: [{ to: "merge", when: { checks: "success" } }]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: { checks: "pending" },
+        state: waitState
+      });
+
+      expect(decision.kind).toBe("stay_waiting");
+      if (decision.kind === "stay_waiting") {
+        expect(decision.reason).toContain("holding");
+      }
+    });
+
+    it("advances a wait state when a transition's when predicates match", () => {
+      const waitState: ExpandedWorkflowState = {
+        action: { kind: "wait" },
+        completeWhen: {},
+        id: "holding",
+        transitions: [
+          { to: "autofix", when: { unresolved_review_threads: 1 } },
+          { to: "merge", when: { checks: "success", mergeable: true } }
+        ]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: {
+          checks: "success",
+          mergeable: true,
+          unresolved_review_threads: 0
+        },
+        state: waitState
+      });
+
+      expect(decision.kind).toBe("advance");
+      if (decision.kind === "advance") {
+        expect(decision.to).toBe("merge");
+      }
+    });
+
+    it("still returns blocked for a non-wait state with no matching transition", () => {
+      const state: ExpandedWorkflowState = {
+        action: { kind: "agent", provider: "codex" },
+        completeWhen: { provider_success: true },
+        id: "branching",
+        transitions: [{ to: "needs_extra", when: { pr_open: true } }]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: { provider_success: true },
+        state
+      });
+
+      expect(decision.kind).toBe("blocked");
+    });
+
     it("treats a state with no action as ready to evaluate transitions on entry", () => {
       const state: ExpandedWorkflowState = {
         completeWhen: {},

--- a/tests/wait-state.test.ts
+++ b/tests/wait-state.test.ts
@@ -430,6 +430,142 @@ describe("wait state lifecycle", () => {
     }
   });
 
+  it("advances a wait state targeting pr_merged: true after the tracked PR has been merged", async () => {
+    const root = await makeTempRoot();
+    // Workflow uses `pr_merged: true` on the wait transition. Predicate
+    // projection only emits `pr_merged: true` from the live GitHub follow-up
+    // state, so the wait reconciler must still be able to find the tracked
+    // PR row after PR follow-up has marked its tracked state "merged".
+    await writeFile(
+      path.join(root, "symphonika.yml"),
+      [
+        "state:",
+        "  root: ./.symphonika",
+        "polling:",
+        "  interval_ms: 30000",
+        "providers:",
+        "  codex:",
+        `    command: "${DEFAULT_CODEX_COMMAND}"`,
+        "  claude:",
+        '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+        "projects:",
+        "  - name: symphonika",
+        "    disabled: false",
+        "    weight: 1",
+        "    tracker:",
+        "      kind: github",
+        "      owner: pmatos",
+        "      repo: symphonika",
+        '      token: "$GITHUB_TOKEN"',
+        "    issue_filters:",
+        '      states: ["open"]',
+        '      labels_all: ["agent-ready"]',
+        '      labels_none: ["blocked", "needs-human"]',
+        "    priority:",
+        "      labels: {}",
+        "      default: 99",
+        "    workspace:",
+        "      root: ./.symphonika/workspaces/symphonika",
+        "      git:",
+        "        remote: git@github.com:pmatos/symphonika.git",
+        "        base_branch: main",
+        "    agent:",
+        "      provider: codex",
+        "    workflow: ./workflow.yml",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: wait_for_merge",
+        "  initial: awaiting_merge",
+        "  states:",
+        "    awaiting_merge:",
+        "      action:",
+        "        kind: wait",
+        "      transitions:",
+        "        - to: merged",
+        "          when:",
+        "            pr_merged: true",
+        "    merged:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      store.createRun({
+        id: "parent-run",
+        issue,
+        projectName: "symphonika",
+        providerCommand: DEFAULT_CODEX_COMMAND,
+        providerName: "codex"
+      });
+      store.updateRunState("parent-run", "succeeded");
+      store.createWaitingRun({
+        currentStateId: "awaiting_merge",
+        id: "waiting-run",
+        issue,
+        parentRunId: "parent-run",
+        projectName: "symphonika"
+      });
+      store.trackPullRequest({
+        branchName: "sym/symphonika/8-wait-state-acceptance-fixture",
+        headSha: "deadbeef",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+      // PR follow-up has already observed the merge: tracked row's state
+      // becomes "merged" and listOpenTrackedPullRequests would filter it out.
+      const tracked = store
+        .listOpenTrackedPullRequests()
+        .find((pr) => pr.prNumber === 99);
+      if (tracked === undefined) {
+        throw new Error("tracked PR row missing in fixture setup");
+      }
+      store.recordPullRequestObservation({
+        headSha: "deadbeef",
+        id: tracked.id,
+        prUrl: tracked.prUrl,
+        state: "merged"
+      });
+      expect(store.listOpenTrackedPullRequests()).toHaveLength(0);
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(
+          prState({ state: "MERGED", merged: true })
+        ),
+        listOpenIssues: vi.fn().mockResolvedValue([])
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("waiting-run");
+
+      const after = store.getRun("waiting-run");
+      expect(after?.state).toBe("succeeded");
+      expect(after?.terminalStateId).toBe("merged");
+      expect(githubIssuesApi.getPullRequestFollowupState).toHaveBeenCalledTimes(1);
+    } finally {
+      store.close();
+    }
+  });
+
   it("keeps the run waiting when PR predicates do not match", async () => {
     const root = await makeTempRoot();
     await writeWaitStateProject(root);

--- a/tests/wait-state.test.ts
+++ b/tests/wait-state.test.ts
@@ -1,0 +1,846 @@
+import Database from "better-sqlite3";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+import type {
+  GitHubIssuesApi,
+  RawGitHubPullRequestFollowupState
+} from "../src/issue-polling.js";
+import { ActiveRunRegistry } from "../src/lifecycle/active-runs.js";
+import {
+  RunController,
+  type RunControllerProjectConfig,
+  type RunControllerProvidersConfig
+} from "../src/lifecycle/run-controller.js";
+import type {
+  AgentProvider,
+  ProviderEvent,
+  ProviderRunInput
+} from "../src/provider.js";
+import { openRunStore } from "../src/run-store.js";
+import type { PreparedIssueWorkspace } from "../src/workspace.js";
+import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
+
+const tempRoots: string[] = [];
+const DEFAULT_CODEX_COMMAND = `codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server`;
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-wait-state-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+function issueFixture(): {
+  body: string;
+  created_at: string;
+  html_url: string;
+  id: number;
+  labels: string[];
+  number: number;
+  priority: number;
+  state: "open";
+  title: string;
+  updated_at: string;
+  url: string;
+} {
+  return {
+    body: "Wait state acceptance fixture.",
+    created_at: "2026-05-10T10:00:00Z",
+    html_url: "https://github.com/pmatos/symphonika/issues/8",
+    id: 5008,
+    labels: ["agent-ready"],
+    number: 8,
+    priority: 99,
+    state: "open",
+    title: "Wait state acceptance fixture",
+    updated_at: "2026-05-11T11:00:00Z",
+    url: "https://github.com/pmatos/symphonika/issues/8"
+  };
+}
+
+function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
+  const workspacePath = path.join(
+    root,
+    ".symphonika",
+    "workspaces",
+    "symphonika",
+    "issues",
+    "8-wait-state-acceptance-fixture"
+  );
+  return {
+    branchName: "sym/symphonika/8-wait-state-acceptance-fixture",
+    branchRef: "refs/heads/sym/symphonika/8-wait-state-acceptance-fixture",
+    cachePath: path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      ".cache",
+      "repo.git"
+    ),
+    issueDirectoryName: "8-wait-state-acceptance-fixture",
+    reused: false,
+    workspacePath
+  };
+}
+
+function recordingCodexProvider(providerInputs: ProviderRunInput[]): AgentProvider {
+  return {
+    cancel: vi.fn().mockResolvedValue(undefined),
+    name: "codex",
+    runAttempt: vi.fn(async function* (
+      input: ProviderRunInput
+    ): AsyncGenerator<ProviderEvent> {
+      providerInputs.push(input);
+      await Promise.resolve();
+      yield {
+        normalized: { exitCode: 0, type: "process_exit" },
+        raw: { code: 0, kind: "exit" }
+      };
+    }),
+    validate: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+async function writeWaitStateProject(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      `    command: "${DEFAULT_CODEX_COMMAND}"`,
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./workflow.yml",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: agent_then_wait",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: holding",
+      "    holding:",
+      "      action:",
+      "        kind: wait",
+      "      transitions:",
+      "        - to: done",
+      "          when:",
+      "            checks: success",
+      "            mergeable: true",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Plan work on #{{issue.number}}.\n"
+  );
+}
+
+async function waitForWaitingRow(
+  databasePath: string,
+  timeoutMs = 15_000
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const database = new Database(databasePath, { readonly: true });
+      try {
+        const row = database
+          .prepare(
+            [
+              "select id, state, current_state_id, continuation_parent_run_id,",
+              "provider_name, prompt_path",
+              "from runs where state = 'waiting' limit 1"
+            ].join(" ")
+          )
+          .get() as Record<string, unknown> | undefined;
+        if (row !== undefined) {
+          return row;
+        }
+      } finally {
+        database.close();
+      }
+    } catch {
+      // db may not be readable yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("waiting row not observed before timeout");
+}
+
+function prState(
+  overrides: Partial<RawGitHubPullRequestFollowupState> = {}
+): RawGitHubPullRequestFollowupState {
+  return {
+    draft: false,
+    headSha: "deadbeef",
+    mergeable: "MERGEABLE",
+    merged: false,
+    number: 99,
+    reviewDecision: "APPROVED",
+    state: "OPEN",
+    statusCheckRollupState: "SUCCESS",
+    unresolvedReviewThreads: [],
+    url: "https://example.test/pr/99",
+    ...overrides
+  };
+}
+
+function buildController(input: {
+  githubIssuesApi: GitHubIssuesApi;
+  project: RunControllerProjectConfig;
+  root: string;
+  runStore: ReturnType<typeof openRunStore>;
+}): RunController {
+  let nextRun = 0;
+  return new RunController({
+    activeRuns: new ActiveRunRegistry(),
+    agentProviders: {
+      codex: {
+        cancel: vi.fn().mockResolvedValue(undefined),
+        name: "codex",
+        runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+          await Promise.resolve();
+          yield {
+            normalized: { exitCode: 0, type: "process_exit" },
+            raw: { code: 0, kind: "exit" }
+          };
+        }),
+        validate: vi.fn().mockResolvedValue(undefined)
+      }
+    },
+    configDir: input.root,
+    createRunId: () => `wait-rerun-${++nextRun}`,
+    env: { GITHUB_TOKEN: "secret-token" },
+    githubIssuesApi: input.githubIssuesApi,
+    lifecyclePolicy: {
+      continuation: { cap: 0, delayMs: 0 },
+      retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+    },
+    logger: pino({ enabled: false }),
+    prepareIssueWorkspace: () =>
+      Promise.resolve(preparedWorkspaceFixture(input.root)),
+    projectsLoader: () =>
+      Promise.resolve(new Map([[input.project.name, input.project]])),
+    providersLoader: (): Promise<RunControllerProvidersConfig> =>
+      Promise.resolve({
+        claude: { command: "claude" },
+        codex: { command: DEFAULT_CODEX_COMMAND }
+      }),
+    runStore: input.runStore,
+    schedule: () => undefined,
+    stateRoot: path.join(input.root, ".symphonika")
+  });
+}
+
+function projectFixture(workflowPath: string): RunControllerProjectConfig {
+  return {
+    agent: { provider: "codex" },
+    issue_filters: {
+      labels_all: ["agent-ready"],
+      labels_none: ["blocked", "needs-human"],
+      states: ["open"]
+    },
+    name: "symphonika",
+    priority: { default: 99, labels: {} },
+    tracker: {
+      kind: "github",
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "$GITHUB_TOKEN"
+    },
+    workflow: { format: "auto", path: workflowPath },
+    workspace: {
+      git: {
+        base_branch: "main",
+        remote: "git@github.com:pmatos/symphonika.git"
+      },
+      root: "./.symphonika/workspaces/symphonika"
+    }
+  };
+}
+
+describe("wait state lifecycle", () => {
+  it("parks the workflow in a waiting row when an agent state advances into a wait state", async () => {
+    const root = await makeTempRoot();
+    await writeWaitStateProject(root);
+
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    const issue = issueFixture();
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const providerInputs: ProviderRunInput[] = [];
+    const codexProvider = recordingCodexProvider(providerInputs);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => `run-wait-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      const waitingRow = await waitForWaitingRow(
+        path.join(root, ".symphonika", "symphonika.db")
+      );
+
+      expect(waitingRow).toMatchObject({
+        state: "waiting",
+        current_state_id: "holding"
+      });
+      expect(waitingRow.continuation_parent_run_id).toBe("run-wait-1");
+      expect(waitingRow.provider_name).toBeNull();
+      expect(waitingRow.prompt_path).toBeNull();
+
+      // Only the planning state ran a provider attempt. The wait state must
+      // NOT spawn an agent.
+      expect(providerInputs).toHaveLength(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("advances a waiting run to a terminal state when PR predicates match", async () => {
+    const root = await makeTempRoot();
+    await writeWaitStateProject(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      store.createRun({
+        id: "parent-run",
+        issue,
+        projectName: "symphonika",
+        providerCommand: DEFAULT_CODEX_COMMAND,
+        providerName: "codex"
+      });
+      store.updateRunState("parent-run", "succeeded");
+      store.createWaitingRun({
+        currentStateId: "holding",
+        id: "waiting-run",
+        issue,
+        parentRunId: "parent-run",
+        projectName: "symphonika"
+      });
+      store.trackPullRequest({
+        branchName: "sym/symphonika/8-wait-state-acceptance-fixture",
+        headSha: "deadbeef",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(prState()),
+        listOpenIssues: vi.fn().mockResolvedValue([])
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("waiting-run");
+
+      const after = store.getRun("waiting-run");
+      expect(after?.state).toBe("succeeded");
+      expect(after?.terminalStateId).toBe("done");
+      expect(after?.stateTransitionReason).toContain(
+        "holding advanced to done"
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("keeps the run waiting when PR predicates do not match", async () => {
+    const root = await makeTempRoot();
+    await writeWaitStateProject(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      store.createRun({
+        id: "parent-run",
+        issue,
+        projectName: "symphonika",
+        providerCommand: DEFAULT_CODEX_COMMAND,
+        providerName: "codex"
+      });
+      store.updateRunState("parent-run", "succeeded");
+      store.createWaitingRun({
+        currentStateId: "holding",
+        id: "waiting-run",
+        issue,
+        parentRunId: "parent-run",
+        projectName: "symphonika"
+      });
+      store.trackPullRequest({
+        branchName: "sym/symphonika/8-wait-state-acceptance-fixture",
+        headSha: "deadbeef",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi
+          .fn()
+          .mockResolvedValue(prState({ statusCheckRollupState: "PENDING" })),
+        listOpenIssues: vi.fn().mockResolvedValue([])
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("waiting-run");
+
+      const after = store.getRun("waiting-run");
+      expect(after?.state).toBe("waiting");
+      expect(after?.terminalStateId).toBeNull();
+    } finally {
+      store.close();
+    }
+  });
+
+  it("stays parked when no PR is tracked yet", async () => {
+    const root = await makeTempRoot();
+    await writeWaitStateProject(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      store.createRun({
+        id: "parent-run",
+        issue,
+        projectName: "symphonika",
+        providerCommand: DEFAULT_CODEX_COMMAND,
+        providerName: "codex"
+      });
+      store.updateRunState("parent-run", "succeeded");
+      store.createWaitingRun({
+        currentStateId: "holding",
+        id: "waiting-run",
+        issue,
+        parentRunId: "parent-run",
+        projectName: "symphonika"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn(),
+        listOpenIssues: vi.fn().mockResolvedValue([])
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("waiting-run");
+
+      const after = store.getRun("waiting-run");
+      expect(after?.state).toBe("waiting");
+      expect(githubIssuesApi.getPullRequestFollowupState).not.toHaveBeenCalled();
+    } finally {
+      store.close();
+    }
+  });
+
+  it("daemon tick reconciles a waiting run forward when PR predicates become satisfied", async () => {
+    const root = await makeTempRoot();
+    await writeWaitStateProject(root);
+
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    const issue = issueFixture();
+    const githubIssue = {
+      ...issue,
+      labels: issue.labels.map((name) => ({ name }))
+    };
+
+    let prStateValue = prState({ statusCheckRollupState: "PENDING" });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(githubIssue),
+      getPullRequestFollowupState: vi.fn(() => Promise.resolve(prStateValue)),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([githubIssue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const providerInputs: ProviderRunInput[] = [];
+    const codexProvider = recordingCodexProvider(providerInputs);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => `tick-wait-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      const databasePath = path.join(root, ".symphonika", "symphonika.db");
+      const waitingRow = await waitForWaitingRow(databasePath);
+      expect(waitingRow.state).toBe("waiting");
+
+      // Manually seed a tracked PR so the wait reconciler can find it.
+      const tickDatabase = new Database(databasePath);
+      try {
+        const now = new Date().toISOString();
+        tickDatabase
+          .prepare(
+            [
+              "insert into tracked_pull_requests (",
+              "project_name, issue_number, run_id, pr_number, pr_url,",
+              "branch_name, head_sha_at_dispatch, last_seen_head_sha, state,",
+              "last_observed_at, created_at, updated_at",
+              ") values (?,?,?,?,?,?,?,?,?,?,?,?)"
+            ].join(" ")
+          )
+          .run(
+            "symphonika",
+            issue.number,
+            "tick-wait-1",
+            99,
+            "https://example.test/pr/99",
+            preparedWorkspace.branchName,
+            "deadbeef",
+            "deadbeef",
+            "open",
+            now,
+            now,
+            now
+          );
+      } finally {
+        tickDatabase.close();
+      }
+
+      // Predicates become satisfied. The next daemon tick should advance.
+      prStateValue = prState();
+      const pollResponse = await fetch(`${daemon.url}/api/poll-now`, {
+        method: "POST"
+      });
+      expect(pollResponse.ok).toBe(true);
+
+      const deadline = Date.now() + 5000;
+      let advanced = false;
+      while (Date.now() < deadline) {
+        const database = new Database(databasePath, { readonly: true });
+        try {
+          const row = database
+            .prepare(
+              "select state, terminal_state_id from runs where id = ?"
+            )
+            .get(waitingRow.id) as
+            | { state: string; terminal_state_id: string | null }
+            | undefined;
+          if (row?.state === "succeeded" && row.terminal_state_id === "done") {
+            advanced = true;
+            break;
+          }
+        } finally {
+          database.close();
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      expect(advanced).toBe(true);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("routes wait → autofix agent state on unresolved review feedback", async () => {
+    const root = await makeTempRoot();
+    // Custom workflow: planning → review_check (wait) → autofix (agent) on
+    // unresolved reviews; → merged (terminal) on clean.
+    await writeFile(
+      path.join(root, "symphonika.yml"),
+      [
+        "state:",
+        "  root: ./.symphonika",
+        "polling:",
+        "  interval_ms: 30000",
+        "providers:",
+        "  codex:",
+        `    command: "${DEFAULT_CODEX_COMMAND}"`,
+        "  claude:",
+        '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+        "projects:",
+        "  - name: symphonika",
+        "    disabled: false",
+        "    weight: 1",
+        "    tracker:",
+        "      kind: github",
+        "      owner: pmatos",
+        "      repo: symphonika",
+        '      token: "$GITHUB_TOKEN"',
+        "    issue_filters:",
+        '      states: ["open"]',
+        '      labels_all: ["agent-ready"]',
+        '      labels_none: ["blocked", "needs-human"]',
+        "    priority:",
+        "      labels: {}",
+        "      default: 99",
+        "    workspace:",
+        "      root: ./.symphonika/workspaces/symphonika",
+        "      git:",
+        "        remote: git@github.com:pmatos/symphonika.git",
+        "        base_branch: main",
+        "    agent:",
+        "      provider: codex",
+        "    workflow: ./workflow.yml",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: review_branch",
+        "  initial: review_check",
+        "  states:",
+        "    review_check:",
+        "      action:",
+        "        kind: wait",
+        "      transitions:",
+        "        - to: autofix",
+        "          when:",
+        "            unresolved_review_threads: 1",
+        "        - to: merged",
+        "          when:",
+        "            checks: success",
+        "            mergeable: true",
+        "    autofix:",
+        "      action:",
+        "        kind: agent",
+        "        provider: codex",
+        "        prompt: autofix-prompt.md",
+        "      transitions:",
+        "        - to: merged",
+        "    merged:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "autofix-prompt.md"),
+      "Autofix #{{issue.number}}.\n"
+    );
+
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      store.createRun({
+        id: "parent-run",
+        issue,
+        projectName: "symphonika",
+        providerCommand: DEFAULT_CODEX_COMMAND,
+        providerName: "codex"
+      });
+      store.updateRunState("parent-run", "succeeded");
+      store.createWaitingRun({
+        currentStateId: "review_check",
+        id: "waiting-run",
+        issue,
+        parentRunId: "parent-run",
+        projectName: "symphonika"
+      });
+      store.trackPullRequest({
+        branchName: "sym/symphonika/8-wait-state-acceptance-fixture",
+        headSha: "deadbeef",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+
+      const reviewThread = {
+        comments: [],
+        id: "PRRT_kwDO",
+        isResolved: false
+      };
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(
+          prState({
+            mergeable: "MERGEABLE",
+            reviewDecision: "CHANGES_REQUESTED",
+            statusCheckRollupState: "SUCCESS",
+            unresolvedReviewThreads: [reviewThread]
+          })
+        ),
+        listOpenIssues: vi.fn().mockResolvedValue([])
+      };
+
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("waiting-run");
+
+      const after = store.getRun("waiting-run");
+      expect(after?.state).toBe("succeeded");
+      expect(after?.currentStateId).toBe("autofix");
+      expect(after?.stateTransitionReason).toContain(
+        "review_check advanced to autofix"
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("cancels a waiting run when the issue has been closed", async () => {
+    const root = await makeTempRoot();
+    await writeWaitStateProject(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      store.createRun({
+        id: "parent-run",
+        issue,
+        projectName: "symphonika",
+        providerCommand: DEFAULT_CODEX_COMMAND,
+        providerName: "codex"
+      });
+      store.updateRunState("parent-run", "succeeded");
+      store.createWaitingRun({
+        currentStateId: "holding",
+        id: "waiting-run",
+        issue,
+        parentRunId: "parent-run",
+        projectName: "symphonika"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          state: "closed",
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        listOpenIssues: vi.fn().mockResolvedValue([])
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("waiting-run");
+
+      const after = store.getRun("waiting-run");
+      expect(after?.state).toBe("cancelled");
+      expect(after?.cancelReason).toBe("closed_issue");
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -662,6 +662,94 @@ describe("state machine workflow definitions", () => {
     );
   });
 
+  it("accepts a wait action that defines no provider or prompt", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: holding",
+        "  states:",
+        "    holding:",
+        "      action:",
+        "        kind: wait",
+        "      transitions:",
+        "        - to: done",
+        "          when:",
+        "            checks: success",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([]);
+    const holding = result.workflow.states.find((state) => state.id === "holding");
+    expect(holding?.action?.kind).toBe("wait");
+  });
+
+  it("rejects a wait action that declares a provider", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: holding",
+        "  states:",
+        "    holding:",
+        "      action:",
+        "        kind: wait",
+        "        provider: claude",
+        "      transitions:",
+        "        - to: done",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toContain(
+      `workflow state holding at ${workflowPath} wait action must not define provider`
+    );
+  });
+
+  it("rejects a wait action that declares a prompt", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: holding",
+        "  states:",
+        "    holding:",
+        "      action:",
+        "        kind: wait",
+        "        prompt: hello",
+        "      transitions:",
+        "        - to: done",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toContain(
+      `workflow state holding at ${workflowPath} wait action must not define prompt`
+    );
+  });
+
   it("rejects YAML workflow files that are missing the top-level workflow mapping", async () => {
     const root = await makeTempRoot();
     const workflowPath = path.join(root, "workflow.yml");


### PR DESCRIPTION
## Summary

- Adds `action.kind: "wait"` raw FSM states that pause a workflow walk until observable PR predicates change, with no provider launched while parked.
- Daemon tick and `/poll-now` re-evaluate parked wait states by projecting `RawGitHubPullRequestFollowupState` into `WorkflowPredicateMap` and calling `decideNextStep`. First-matching transition wins; no match keeps the run parked.
- Adds a distinct `waiting` lifecycle status (not `blocked`) and a `wait_park` schedule kind. ADR 0047 records the design.

Closes #96. Builds on #109 (issue 95 multi-state raw FSM dispatch).

## Acceptance criteria

- [x] Raw FSM workflows enter `action.kind: wait` without launching a provider.
- [x] Wait-state transitions are re-evaluated on daemon ticks and manual `/poll-now`.
- [x] Predicates support `checks`, `mergeable`, and `unresolved_review_threads` (plus `pr_open`, `pr_merged`).
- [x] Wait→autofix agent state on unresolved review feedback; wait→merge terminal on clean checks + mergeable.
- [x] Tests cover wait-state polling, first-matching transition, and no-provider execution.

## Notable design points (ADR 0047)

- **Synchronous wait-row creation in `applyWorkflowOutcome`**: the in-memory `wait_park` schedule callback can be lost on daemon restart (single-daemon v1, ADR 0012). Persisting the row before scheduling keeps the wait durable; worst case is one tick of latency.
- **`mergeable: UNKNOWN`/`null` omitted from signals**: a transition writing `mergeable: false` will not match on unknown values, so the wait stays parked until GitHub resolves the value.
- **`timeout` predicate deferred**: defined in the schema but not implemented in v1. Tracked for a follow-up issue.

## Test plan

- [x] `tests/pr-signal-projection.test.ts` (13 cases): predicate mapping including `UNKNOWN`/`null`/`CLOSED`/`MERGED`.
- [x] `tests/state-machine-dispatch.test.ts`: wait-aware `decideNextStep` returns `stay_waiting` (not `blocked`) when no transition matches, skips `execute_action` for wait states, still returns `blocked` for non-wait states.
- [x] `tests/workflow.test.ts`: schema rejects `provider`/`prompt` on `kind: "wait"`.
- [x] `tests/run-store-waiting.test.ts`: `createWaitingRun` persists with no provider evidence; `listWaitingRuns` excludes cancel-requested rows.
- [x] `tests/wait-state.test.ts` (7 cases): synchronous park-on-advance, daemon tick advances on satisfied predicates, manual `/poll-now` triggers re-evaluation, no PR tracked stays parked, predicates not matching stays parked, wait→autofix routing, issue-close cancellation.
- [x] `npm test` — 347/347 passing.
- [x] `npm run typecheck` and `npm run lint` clean.