### PR TITLE
Add merge_pr FSM action states for workflow-controlled merges

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -756,6 +756,47 @@ transitions writing `mergeable: false` will not match on unknown values, so the 
 until GitHub resolves the mergeability. The `timeout` predicate is reserved in the schema but
 unimplemented in v1.
 
+### 12.6 Merge States
+
+Raw FSM workflows may declare `action.kind: "merge_pr"` states that merge the workflow instance's
+Symphonika-owned pull request when the configured policy is satisfied. A merge state does not
+launch a provider; it is poll-driven and reconciled on every daemon tick, exactly like a wait
+state. The optional `method` field overrides the merge method from `pull_requests.merge.method`
+for that single state.
+
+Lifecycle:
+
+1. When the FSM advances into a `merge_pr` state, Symphonika persists a new Run row with
+   `state = "waiting"` and `current_state_id` set to the merge state id, identical to a wait
+   parking. The parent Run records `state_transition_reason` for the advance.
+2. On each daemon tick (and on `/poll-now`), `reconcileWaitingRuns` calls
+   `reEvaluateWaitingRun`. For a merge state the handler looks up the tracked pull request
+   associated with the workflow instance's issue and project — Symphonika never merges a PR
+   that is not tied to its own issue branch. If no tracked PR exists yet, the run stays parked
+   and records `state_transition_reason = "merge_pr awaiting Symphonika-tracked pull request"`.
+3. If a tracked PR exists, the handler refreshes its follow-up state from GitHub, projects the
+   same predicate set used by wait states, and checks `pullRequestReadyToMerge` against the
+   configured `pull_requests.merge` policy (mergeable, required status success, required
+   review decision). If the policy is not satisfied, the run stays parked with a deferred
+   reason recorded. If `pull_requests.merge.enabled` is `false`, the merge is also deferred and
+   the policy gate is recorded.
+4. When the policy is satisfied, Symphonika calls `mergePullRequest` with the workflow's
+   `method` override (if any) or the policy default, pinning the merge to the observed head
+   SHA. On success the tracked-PR row is moved to `merged`, the signals projected for
+   `decideNextStep` include `pr_merged: true`, and the workflow advances via its transitions.
+   On a merge API failure the run records the error in `state_transition_reason` and stays
+   parked; the next tick retries from the same row.
+5. Successful merge transitions advancing into a terminal state record the terminal as
+   `succeeded`, exactly like wait-state terminals. Failed, deferred, blocked, or missing-PR
+   outcomes record deterministic `state_transition_reason` text on the merge state's Run row
+   and never delete the workspace, matching §10 (workspaces are never auto-deleted).
+
+The merge state is intentionally scoped to Symphonika-tracked PRs — arbitrary cross-issue or
+external PRs are out of scope. PR follow-up policy (`§12.4`) and merge-state evaluation share
+the same `pullRequestReadyToMerge` helper so the two paths cannot drift on what counts as
+mergeable. Cancellation, issue-close, and label-immunity semantics are inherited from wait
+states (§12.5).
+
 ## 13. CLI
 
 Bootstrap CLI commands:

--- a/docs/adr/0048-fsm-controlled-merge-states.md
+++ b/docs/adr/0048-fsm-controlled-merge-states.md
@@ -1,0 +1,53 @@
+# FSM-controlled merge states reuse the wait-state reconciliation path
+
+Symphonika's raw FSM workflow contract permits `action.kind: "merge_pr"` states so a workflow can
+gate the merge of a Symphonika-owned pull request on workflow-defined predicates rather than the
+opaque policy loop in `runPullRequestFollowup` (§12.4). Merge states are observation-driven, must
+not launch a provider, and must respect the same `pull_requests.merge` policy that operators
+configure for the orchestrator-wide merge loop.
+
+Three design choices follow.
+
+First, a merge state is parked the same way a wait state is. The state-machine decision treats
+`merge_pr` as a "no execute_action on entry" action and lets the FSM evaluate transitions against
+projected predicates. The waiting Run row is created synchronously by `applyWorkflowOutcome`
+inside the parent agent run's terminal phase, so a daemon restart between the agent terminating
+and the first re-evaluation only costs one tick — single-daemon v1 (ADR 0012) keeps scheduler
+callbacks in memory, so the durable state has to live in the run-store row. This is the same
+durability argument that ADR 0047 makes for wait states; merge states reuse the same
+`createWaitingRun` path rather than introducing a parallel "merge_park" lifecycle.
+
+Second, merge attempts go through the existing `reEvaluateWaitingRun` handler rather than a
+separate dispatcher. On every tick the handler refreshes the tracked PR, projects predicates with
+`projectPullRequestSignals` (shared with `runPullRequestFollowup` per ADR 0047), and — only for
+`merge_pr` states — additionally consults the merge policy via `pullRequestReadyToMerge` and
+calls `tryMergePullRequest`. A successful merge augments the projected signals with
+`pr_merged: true` before `decideNextStep` runs, so the workflow author's transitions see the same
+predicate vocabulary regardless of whether the merge happened externally (PR follow-up loop) or
+inside the FSM. Failed, deferred, blocked, or missing-PR outcomes are recorded as a single
+`state_transition_reason` line on the merge state's Run row via a new
+`RunStore.recordWaitingActivity` helper. Recording the outcome on every re-evaluation gives
+operators a per-tick audit trail without creating new Run rows.
+
+Third, the merge-state action is scoped to the workflow instance's tracked PR. The handler looks
+up the tracked PR via `findTrackedPullRequestByIssue(issueNumber, projectName)`, the same lookup
+that wait states use. Symphonika never reaches across issues, projects, or arbitrary GitHub PRs
+to merge — that scoping is what keeps `merge_pr` aligned with ADR 0044's "Symphonika owns only
+its own PRs" stance and what makes the merge state safe to run with the same full-permission
+posture as the rest of the orchestrator. The merge state never calls `git` and never touches the
+workspace, so workspace preservation (§10) is inherited automatically.
+
+The `method` field on the merge_pr action overrides `pull_requests.merge.method` for that state
+only — operators can keep `squash` as the daemon-wide default while a release workflow that
+needs a true merge commit declares `method: merge` on its FSM state. Other policy gates
+(`require_status_success`, `require_review_decision`, `merge.enabled`) stay daemon-wide. That
+asymmetry keeps the workflow file focused on FSM semantics while operators retain veto power
+through service config: setting `pull_requests.merge.enabled: false` defers every FSM-driven
+merge attempt without changes to workflow files.
+
+The merge state intentionally does not invent new predicates. Workflow authors expressing "the
+merge succeeded" use `pr_merged: true`, the same predicate the wait state uses; expressing
+"the merge cannot proceed" uses the existing `mergeable`, `checks`, and
+`unresolved_review_threads` predicates. This keeps the predicate vocabulary small and avoids a
+divergence between the orchestrator-wide PR follow-up loop and the FSM-controlled merge path,
+echoing ADR 0047's reasoning for sharing `projectPullRequestSignals`.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -36,7 +36,10 @@ import {
 import { detectStaleClaims } from "./lifecycle/stale-claims.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
-import { runPullRequestFollowup } from "./pull-request-followup.js";
+import {
+  runPullRequestFollowup,
+  type PullRequestFollowupPolicy
+} from "./pull-request-followup.js";
 import { RuntimeConfigReloader } from "./reload.js";
 import {
   openRunStore,
@@ -129,6 +132,9 @@ export async function startDaemon(
   const providersLoader = (): Promise<RunControllerProvidersConfig> => {
     return Promise.resolve(runtimeConfig.providersConfig());
   };
+  const pullRequestPolicyLoader = (): Promise<PullRequestFollowupPolicy> => {
+    return Promise.resolve(runtimeConfig.pullRequestPolicy());
+  };
   const enqueueScheduledWork = (work: () => Promise<void>): void => {
     scheduledWork = scheduledWork.then(work, work);
     void scheduledWork;
@@ -141,6 +147,7 @@ export async function startDaemon(
     logger,
     projectsLoader,
     providersLoader,
+    pullRequestPolicyLoader,
     runStore,
     schedule: (item: ScheduledWorkInput) => {
       activeRuns.scheduleDelayed({

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -1206,6 +1206,33 @@ export class RunController {
         }
       };
     }
+    // Raw FSM workflows whose entry state is a parked action (wait/merge_pr)
+    // must never launch a provider — they have no prompt and must instead be
+    // parked into the waiting-row reconciliation path immediately. Without
+    // this guard, runAttemptLifecycle would call startAttempt with an empty
+    // raw-FSM prompt, terminate, and then fall through `applyWorkflowOutcome`
+    // (which has no `stay_waiting` branch) leaving the workflow with no
+    // waiting row and no merge attempt scheduled. Returning here keeps the
+    // run row durable (state="waiting", current_state_id set) so a daemon
+    // restart can resume the reconciliation. See SPEC §12.5 / §12.6.
+    if (
+      loadedWorkflow.errors.length === 0 &&
+      loadedWorkflow.expandedWorkflow.source.kind === "raw_fsm" &&
+      currentState !== undefined &&
+      isParkedAction(currentState.action?.kind)
+    ) {
+      this.runStore.updateRunState(input.runId, "waiting");
+      this.schedule({
+        delayMs: this.lifecyclePolicy.continuation.delayMs,
+        fire: () => this.executeWaitPark({ waitingRunId: input.runId }),
+        issueNumber: input.issue.number,
+        kind: "wait_park",
+        projectName: input.project.name,
+        runId: input.runId
+      });
+      return;
+    }
+
     // Raw FSM continuations are state-advance runs: the FSM, not the issue
     // labels, decides whether the agent keeps running. Computed here so both
     // activeRuns.register (in the try block) and scheduleNext (in finally)

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -637,7 +637,20 @@ export class RunController {
             token: repository.token
           });
           if (merged) {
-            signals.pr_merged = true;
+            // Reproject signals against the post-merge state so workflow
+            // transitions written in the natural shape (e.g.
+            // `when: { pr_merged: true, pr_open: false }`) match — without
+            // this, signals would still carry `pr_open: true` from the
+            // pre-merge fetch and a refetch-style transition would silently
+            // stay parked even though the merge succeeded.
+            const mergedSignals = projectPullRequestSignals({
+              ...prState,
+              merged: true,
+              state: "MERGED"
+            });
+            for (const key of Object.keys(mergedSignals)) {
+              signals[key] = mergedSignals[key]!;
+            }
             this.runStore.recordPullRequestObservation({
               headSha: prState.headSha,
               id: tracked.id,

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -472,6 +472,41 @@ export class RunController {
     await this.reEvaluateWaitingRun(payload.waitingRunId);
   }
 
+  // Tells the global PR follow-up loop whether a tracked PR's merge belongs
+  // to a workflow-controlled merge_pr state. When true, the global loop
+  // must skip the auto-merge so the next reEvaluateWaitingRun tick can
+  // apply the workflow's method override and record merge_pr evidence —
+  // otherwise discovery and global merge happen in the same tick before
+  // the merge_pr state's re-evaluation sees the tracked PR. See ADR 0048.
+  async isIssueParkedInMergePrState(input: {
+    issueNumber: number;
+    projectName: string;
+  }): Promise<boolean> {
+    const waiting = this.runStore.findWaitingRunByIssue(input);
+    if (waiting === undefined || waiting.currentStateId === null) {
+      return false;
+    }
+    const projects = await this.projectsLoader();
+    const project = projects.get(input.projectName);
+    if (project === undefined) {
+      return false;
+    }
+    let loaded;
+    try {
+      loaded = await this.loadWorkflow(project.workflow);
+    } catch {
+      return false;
+    }
+    if (loaded.errors.length > 0) {
+      return false;
+    }
+    const state = findWorkflowState(
+      loaded.expandedWorkflow,
+      waiting.currentStateId
+    );
+    return state?.action?.kind === "merge_pr";
+  }
+
   async reEvaluateWaitingRun(runId: string): Promise<void> {
     const row = this.runStore.getRun(runId);
     if (row === undefined || row.state !== "waiting") {

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -16,8 +16,14 @@ import type {
 import {
   evaluateProjectEligibility,
   tryGetIssue,
-  tryGetPullRequestFollowupState
+  tryGetPullRequestFollowupState,
+  tryMergePullRequest
 } from "../issue-polling.js";
+import {
+  DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY,
+  pullRequestReadyToMerge,
+  type PullRequestFollowupPolicy
+} from "../pull-request-followup.js";
 import { projectPullRequestSignals } from "./pr-signal-projection.js";
 import type {
   AgentProvider,
@@ -116,6 +122,7 @@ export type RunControllerOptions = {
   ) => Promise<PreparedIssueWorkspace>;
   projectsLoader: () => Promise<Map<string, RunControllerProjectConfig>>;
   providersLoader: () => Promise<RunControllerProvidersConfig>;
+  pullRequestPolicyLoader?: () => Promise<PullRequestFollowupPolicy>;
   runStore: RunStore;
   schedule: ScheduleHandler;
   stateRoot: string;
@@ -236,6 +243,7 @@ export class RunController {
     Map<string, RunControllerProjectConfig>
   >;
   private readonly providersLoader: () => Promise<RunControllerProvidersConfig>;
+  private readonly pullRequestPolicyLoader: () => Promise<PullRequestFollowupPolicy>;
   private readonly runStore: RunStore;
   private readonly schedule: ScheduleHandler;
   private readonly stateRoot: string;
@@ -255,6 +263,10 @@ export class RunController {
       options.prepareIssueWorkspace ?? defaultPrepareIssueWorkspace;
     this.projectsLoader = options.projectsLoader;
     this.providersLoader = options.providersLoader;
+    this.pullRequestPolicyLoader =
+      options.pullRequestPolicyLoader ??
+      ((): Promise<PullRequestFollowupPolicy> =>
+        Promise.resolve(DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY));
     this.runStore = options.runStore;
     this.schedule = options.schedule;
     this.stateRoot = options.stateRoot;
@@ -518,6 +530,8 @@ export class RunController {
       return;
     }
 
+    const isMergePr = waitState.action?.kind === "merge_pr";
+
     // Use the all-states lookup: a wait state targeting `pr_merged: true` must
     // still see the tracked row after PR follow-up has marked it "merged"; an
     // open-only listing would strand the wait. The dispatcher's own open-only
@@ -527,6 +541,12 @@ export class RunController {
       projectName: row.project
     });
     if (tracked === undefined) {
+      if (isMergePr) {
+        this.runStore.recordWaitingActivity(
+          runId,
+          `merge_pr awaiting Symphonika-tracked pull request for issue #${row.issueNumber}`
+        );
+      }
       this.logger?.debug(
         { runId, issueNumber: row.issueNumber },
         "symphonika wait re-eval skipped: no PR tracked yet"
@@ -553,10 +573,84 @@ export class RunController {
       return;
     }
 
-    const signals = {
+    const signals: WorkflowPredicateMap = {
       provider_success: true,
       ...projectPullRequestSignals(prState)
     };
+
+    if (isMergePr) {
+      const policy = await this.pullRequestPolicyLoader();
+      const method =
+        coerceMergeMethod(waitState.action?.method) ?? policy.merge.method;
+      if (!policy.merge.enabled) {
+        this.runStore.recordWaitingActivity(
+          runId,
+          "merge_pr deferred: pull_requests.merge.enabled is false"
+        );
+        this.logger?.debug(
+          { runId },
+          "symphonika merge_pr re-eval: merge disabled by policy"
+        );
+      } else if (pullRequestReadyToMerge(prState, policy)) {
+        try {
+          const merged = await tryMergePullRequest(this.githubIssuesApi, {
+            expectedHeadSha: prState.headSha,
+            method,
+            owner: repository.owner,
+            pullNumber: tracked.prNumber,
+            repo: repository.repo,
+            token: repository.token
+          });
+          if (merged) {
+            signals.pr_merged = true;
+            this.runStore.recordPullRequestObservation({
+              headSha: prState.headSha,
+              id: tracked.id,
+              prUrl: prState.url,
+              state: "merged"
+            });
+            this.runStore.recordWaitingActivity(
+              runId,
+              `merge_pr merged PR #${tracked.prNumber} via ${method}`
+            );
+            this.logger?.info(
+              { method, prNumber: tracked.prNumber, runId },
+              "symphonika merge_pr merged PR"
+            );
+          } else {
+            this.runStore.recordWaitingActivity(
+              runId,
+              `merge_pr unavailable: GitHub tracker does not expose mergePullRequest`
+            );
+            this.logger?.warn(
+              { runId },
+              "symphonika merge_pr: tracker has no mergePullRequest support"
+            );
+            return;
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.runStore.recordWaitingActivity(
+            runId,
+            `merge_pr attempt failed for PR #${tracked.prNumber}: ${message}`
+          );
+          this.logger?.warn(
+            { err: error, prNumber: tracked.prNumber, runId },
+            "symphonika merge_pr attempt failed"
+          );
+          return;
+        }
+      } else {
+        this.runStore.recordWaitingActivity(
+          runId,
+          `merge_pr deferred: PR #${tracked.prNumber} not yet ready under policy`
+        );
+        this.logger?.debug(
+          { runId },
+          "symphonika merge_pr re-eval: PR not yet ready to merge"
+        );
+      }
+    }
 
     const decision = decideNextStep({
       actionExecuted: true,
@@ -588,7 +682,7 @@ export class RunController {
       });
       this.runStore.updateRunState(runId, "succeeded");
 
-      if (next?.action?.kind === "wait") {
+      if (isParkedAction(next?.action?.kind)) {
         const nextWaitingRunId = this.createRunId();
         this.runStore.createWaitingRun({
           currentStateId: decision.to,
@@ -1462,7 +1556,7 @@ export class RunController {
         nextStateId: decision.to,
         transitionReason: decision.reason
       });
-      if (next?.action?.kind === "wait") {
+      if (isParkedAction(next?.action?.kind)) {
         const waitingRunId = this.createRunId();
         this.runStore.createWaitingRun({
           currentStateId: decision.to,
@@ -2158,4 +2252,17 @@ function signalsFromTerminal(
     return { branch_ahead_of_base: false, provider_success: true };
   }
   return { branch_ahead_of_base: false, provider_success: false };
+}
+
+function isParkedAction(kind: string | undefined): boolean {
+  return kind === "wait" || kind === "merge_pr";
+}
+
+function coerceMergeMethod(
+  method: string | undefined
+): PullRequestFollowupPolicy["merge"]["method"] | undefined {
+  if (method === "merge" || method === "rebase" || method === "squash") {
+    return method;
+  }
+  return undefined;
 }

--- a/src/lifecycle/state-machine-dispatch.ts
+++ b/src/lifecycle/state-machine-dispatch.ts
@@ -33,9 +33,10 @@ export function decideNextStep(input: {
     return { kind: "terminate", stateId: state.id, terminal: state.terminal };
   }
 
-  const isWait = state.action?.kind === "wait";
+  const actionKind = state.action?.kind;
+  const isParked = actionKind === "wait" || actionKind === "merge_pr";
 
-  if (!isWait && !actionExecuted && state.action !== undefined) {
+  if (!isParked && !actionExecuted && state.action !== undefined) {
     return { action: state.action, kind: "execute_action", stateId: state.id };
   }
 
@@ -57,10 +58,14 @@ export function decideNextStep(input: {
     }
   }
 
-  if (isWait) {
+  if (isParked) {
+    const reason =
+      actionKind === "merge_pr"
+        ? `state ${state.id} merge_pr predicates not yet satisfied`
+        : `state ${state.id} wait predicates not yet satisfied`;
     return {
       kind: "stay_waiting",
-      reason: `state ${state.id} wait predicates not yet satisfied`
+      reason
     };
   }
 

--- a/src/pull-request-followup.ts
+++ b/src/pull-request-followup.ts
@@ -351,6 +351,22 @@ async function processTrackedPullRequests(input: {
     if (!pullRequestReadyToMerge(state, input.policy)) {
       continue;
     }
+    // Defer to the workflow when a merge_pr state is parked on this issue —
+    // otherwise the first-discovery tick would merge with the global method
+    // before reEvaluateWaitingRun has a chance to apply the workflow's
+    // method override and record merge_pr evidence. See ADR 0048.
+    if (
+      await input.runController.isIssueParkedInMergePrState({
+        issueNumber: tracked.issueNumber,
+        projectName: tracked.projectName
+      })
+    ) {
+      input.logger?.info(
+        { prNumber: tracked.prNumber, issueNumber: tracked.issueNumber },
+        "symphonika PR follow-up merge deferred: workflow merge_pr state will handle"
+      );
+      continue;
+    }
     const merged = await tryMergePullRequest(input.githubIssuesApi, {
       ...repository,
       expectedHeadSha: state.headSha,

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -17,10 +17,10 @@ import type {
   RunControllerProvidersConfig,
   WorkflowSnapshot
 } from "./lifecycle/run-controller.js";
-import type { PullRequestFollowupPolicy } from "./pull-request-followup.js";
 import {
   DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY,
-  pullRequestFollowupPolicyFromRaw
+  pullRequestFollowupPolicyFromRaw,
+  type PullRequestFollowupPolicy
 } from "./pull-request-followup.js";
 import {
   expandWorkflowDefinition,
@@ -169,6 +169,12 @@ export class RuntimeConfigReloader {
 
   providersConfig(): RunControllerProvidersConfig {
     return this.snapshot?.providers ?? defaultProvidersConfig();
+  }
+
+  pullRequestPolicy(): PullRequestFollowupPolicy {
+    return (
+      this.snapshot?.pullRequestPolicy ?? DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY
+    );
   }
 
   async reload(): Promise<RuntimeConfigSnapshot | undefined> {

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -1186,6 +1186,35 @@ export class RunStore {
       });
   }
 
+  // Used by the global PR follow-up loop to decide whether a tracked PR's
+  // merge belongs to the FSM (when a workflow has parked the run in a
+  // `merge_pr` state) or to the global auto-merge path. Returns the most
+  // recent waiting row for the (project, issue) pair, ignoring cancelled
+  // runs so a long-cancelled wait does not gate the global loop.
+  findWaitingRunByIssue(input: {
+    issueNumber: number;
+    projectName: string;
+  }): { currentStateId: string | null; runId: string } | undefined {
+    const row = this.database
+      .prepare(
+        [
+          "select id, current_state_id",
+          "from runs",
+          "where state = 'waiting'",
+          "and cancel_requested = 0",
+          "and project_name = ? and issue_number = ?",
+          "order by created_at desc limit 1"
+        ].join(" ")
+      )
+      .get(input.projectName, input.issueNumber) as
+      | { current_state_id: string | null; id: string }
+      | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    return { currentStateId: row.current_state_id, runId: row.id };
+  }
+
   // Wait re-evaluation needs to see merged/closed tracked PRs so a workflow
   // waiting on `pr_merged: true` can advance after the PR follow-up
   // dispatcher has marked the tracked row "merged". Returns the most-recent

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -524,6 +524,14 @@ export class RunStore {
       .run(input.stateId, input.transitionReason, timestamp(), runId);
   }
 
+  recordWaitingActivity(runId: string, reason: string): void {
+    this.database
+      .prepare(
+        "update runs set state_transition_reason = ?, updated_at = ? where id = ?"
+      )
+      .run(reason, timestamp(), runId);
+  }
+
   incrementRetryCount(runId: string): number {
     const updated = this.database
       .prepare(

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -185,6 +185,8 @@ const actionKinds = new Set<WorkflowActionKind>([
   "wait"
 ]);
 
+const mergeMethods = new Set<string>(["merge", "rebase", "squash"]);
+
 const completionPredicateKeys = new Set([
   "artifact_exists",
   "branch_ahead_of_base",
@@ -875,6 +877,24 @@ function parseWorkflowAction(
     if (prompt !== undefined) {
       errors.push(
         `workflow state ${stateId} at ${workflowPath} wait action must not define prompt`
+      );
+    }
+  }
+
+  if (kind === "merge_pr") {
+    if (provider !== undefined) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} merge_pr action must not define provider`
+      );
+    }
+    if (prompt !== undefined) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} merge_pr action must not define prompt`
+      );
+    }
+    if (method !== undefined && !mergeMethods.has(method)) {
+      errors.push(
+        `workflow state ${stateId} at ${workflowPath} merge_pr method must be one of ${[...mergeMethods].join(", ")}`
       );
     }
   }

--- a/tests/merge-pr-state.test.ts
+++ b/tests/merge-pr-state.test.ts
@@ -1,0 +1,475 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  GitHubIssuesApi,
+  RawGitHubPullRequestFollowupState
+} from "../src/issue-polling.js";
+import { ActiveRunRegistry } from "../src/lifecycle/active-runs.js";
+import {
+  RunController,
+  type RunControllerProjectConfig,
+  type RunControllerProvidersConfig
+} from "../src/lifecycle/run-controller.js";
+import type {
+  AgentProvider,
+  ProviderEvent
+} from "../src/provider.js";
+import { DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY } from "../src/pull-request-followup.js";
+import { openRunStore } from "../src/run-store.js";
+import type { PreparedIssueWorkspace } from "../src/workspace.js";
+
+const tempRoots: string[] = [];
+const DEFAULT_CODEX_COMMAND = `codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server`;
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-merge-pr-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+function issueFixture(): {
+  body: string;
+  created_at: string;
+  id: number;
+  labels: string[];
+  number: number;
+  priority: number;
+  state: "open";
+  title: string;
+  updated_at: string;
+  url: string;
+} {
+  return {
+    body: "merge_pr acceptance fixture.",
+    created_at: "2026-05-10T10:00:00Z",
+    id: 5097,
+    labels: ["agent-ready"],
+    number: 97,
+    priority: 99,
+    state: "open",
+    title: "merge_pr acceptance fixture",
+    updated_at: "2026-05-11T11:00:00Z",
+    url: "https://github.com/pmatos/symphonika/issues/97"
+  };
+}
+
+function preparedWorkspaceFixture(root: string): PreparedIssueWorkspace {
+  const workspacePath = path.join(
+    root,
+    ".symphonika",
+    "workspaces",
+    "symphonika",
+    "issues",
+    "97-merge-pr-acceptance-fixture"
+  );
+  return {
+    branchName: "sym/symphonika/97-merge-pr-acceptance-fixture",
+    branchRef: "refs/heads/sym/symphonika/97-merge-pr-acceptance-fixture",
+    cachePath: path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      ".cache",
+      "repo.git"
+    ),
+    issueDirectoryName: "97-merge-pr-acceptance-fixture",
+    reused: false,
+    workspacePath
+  };
+}
+
+function prState(
+  overrides: Partial<RawGitHubPullRequestFollowupState> = {}
+): RawGitHubPullRequestFollowupState {
+  return {
+    draft: false,
+    headSha: "abc123",
+    mergeable: "MERGEABLE",
+    merged: false,
+    number: 99,
+    reviewDecision: "APPROVED",
+    state: "OPEN",
+    statusCheckRollupState: "SUCCESS",
+    unresolvedReviewThreads: [],
+    url: "https://example.test/pr/99",
+    ...overrides
+  };
+}
+
+function projectFixture(workflowPath: string): RunControllerProjectConfig {
+  return {
+    agent: { provider: "codex" },
+    issue_filters: {
+      labels_all: ["agent-ready"],
+      labels_none: ["blocked", "needs-human"],
+      states: ["open"]
+    },
+    name: "symphonika",
+    priority: { default: 99, labels: {} },
+    tracker: {
+      kind: "github",
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "$GITHUB_TOKEN"
+    },
+    workflow: { format: "auto", path: workflowPath },
+    workspace: {
+      git: {
+        base_branch: "main",
+        remote: "git@github.com:pmatos/symphonika.git"
+      },
+      root: "./.symphonika/workspaces/symphonika"
+    }
+  };
+}
+
+function noopCodex(): AgentProvider {
+  return {
+    cancel: vi.fn().mockResolvedValue(undefined),
+    name: "codex",
+    runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+      await Promise.resolve();
+      yield {
+        normalized: { exitCode: 0, type: "process_exit" },
+        raw: { code: 0, kind: "exit" }
+      };
+    }),
+    validate: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+function buildController(input: {
+  githubIssuesApi: GitHubIssuesApi;
+  project: RunControllerProjectConfig;
+  pullRequestPolicy?: typeof DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY;
+  root: string;
+  runStore: ReturnType<typeof openRunStore>;
+}): RunController {
+  return new RunController({
+    activeRuns: new ActiveRunRegistry(),
+    agentProviders: { codex: noopCodex() },
+    configDir: input.root,
+    createRunId: () => "merge-pr-rerun",
+    env: { GITHUB_TOKEN: "secret-token" },
+    githubIssuesApi: input.githubIssuesApi,
+    lifecyclePolicy: {
+      continuation: { cap: 0, delayMs: 0 },
+      retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+    },
+    logger: pino({ enabled: false }),
+    prepareIssueWorkspace: () =>
+      Promise.resolve(preparedWorkspaceFixture(input.root)),
+    projectsLoader: () =>
+      Promise.resolve(new Map([[input.project.name, input.project]])),
+    providersLoader: (): Promise<RunControllerProvidersConfig> =>
+      Promise.resolve({
+        claude: { command: "claude" },
+        codex: { command: DEFAULT_CODEX_COMMAND }
+      }),
+    pullRequestPolicyLoader: () =>
+      Promise.resolve(input.pullRequestPolicy ?? DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY),
+    runStore: input.runStore,
+    schedule: () => undefined,
+    stateRoot: path.join(input.root, ".symphonika")
+  });
+}
+
+async function writeMergePrWorkflow(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: merge_when_clear",
+      "  initial: merging",
+      "  states:",
+      "    merging:",
+      "      action:",
+      "        kind: merge_pr",
+      "        method: squash",
+      "      transitions:",
+      "        - to: done",
+      "          when:",
+      "            pr_merged: true",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+}
+
+function seedWaitingMergePrRun(
+  store: ReturnType<typeof openRunStore>,
+  issue: ReturnType<typeof issueFixture>
+): void {
+  store.createRun({
+    id: "parent-run",
+    issue,
+    projectName: "symphonika",
+    providerCommand: DEFAULT_CODEX_COMMAND,
+    providerName: "codex"
+  });
+  store.updateRunState("parent-run", "succeeded");
+  store.createWaitingRun({
+    currentStateId: "merging",
+    id: "merge-pr-run",
+    issue,
+    parentRunId: "parent-run",
+    projectName: "symphonika"
+  });
+}
+
+describe("merge_pr state lifecycle", () => {
+  it("merges the tracked PR and advances the workflow to terminal success", async () => {
+    const root = await makeTempRoot();
+    await writeMergePrWorkflow(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      seedWaitingMergePrRun(store, issue);
+      store.trackPullRequest({
+        branchName: "sym/symphonika/97-merge-pr-acceptance-fixture",
+        headSha: "abc123",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(prState()),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        mergePullRequest: vi.fn().mockResolvedValue(undefined)
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("merge-pr-run");
+
+      expect(githubIssuesApi.mergePullRequest).toHaveBeenCalledWith({
+        expectedHeadSha: "abc123",
+        method: "squash",
+        owner: "pmatos",
+        pullNumber: 99,
+        repo: "symphonika",
+        token: "secret-token"
+      });
+
+      const after = store.getRun("merge-pr-run");
+      expect(after?.state).toBe("succeeded");
+      expect(after?.terminalStateId).toBe("done");
+      expect(after?.stateTransitionReason).toContain("pr_merged");
+
+      // Tracked PR row reflects the merge so PR follow-up does not retry.
+      const tracked = store.findTrackedPullRequestByIssue({
+        issueNumber: issue.number,
+        projectName: "symphonika"
+      });
+      expect(tracked?.state).toBe("merged");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("stays parked when the PR is not yet ready under the configured merge policy", async () => {
+    const root = await makeTempRoot();
+    await writeMergePrWorkflow(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      seedWaitingMergePrRun(store, issue);
+      store.trackPullRequest({
+        branchName: "sym/symphonika/97-merge-pr-acceptance-fixture",
+        headSha: "abc123",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi
+          .fn()
+          .mockResolvedValue(prState({ statusCheckRollupState: "PENDING" })),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        mergePullRequest: vi.fn().mockResolvedValue(undefined)
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("merge-pr-run");
+
+      expect(githubIssuesApi.mergePullRequest).not.toHaveBeenCalled();
+      const after = store.getRun("merge-pr-run");
+      expect(after?.state).toBe("waiting");
+      expect(after?.terminalStateId).toBeNull();
+      expect(after?.stateTransitionReason).toContain("not yet ready");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("records deterministic evidence when no PR is associated yet, without deleting workspace", async () => {
+    const root = await makeTempRoot();
+    await writeMergePrWorkflow(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      seedWaitingMergePrRun(store, issue);
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn(),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        mergePullRequest: vi.fn().mockResolvedValue(undefined)
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("merge-pr-run");
+
+      expect(githubIssuesApi.getPullRequestFollowupState).not.toHaveBeenCalled();
+      expect(githubIssuesApi.mergePullRequest).not.toHaveBeenCalled();
+      const after = store.getRun("merge-pr-run");
+      expect(after?.state).toBe("waiting");
+      expect(after?.stateTransitionReason).toContain(
+        "awaiting Symphonika-tracked pull request"
+      );
+
+      // Workspace evidence preserved: the parent run still holds its workspace path.
+      const parent = store.getRun("parent-run");
+      expect(parent?.state).toBe("succeeded");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("records a failure reason and stays parked when the merge API throws", async () => {
+    const root = await makeTempRoot();
+    await writeMergePrWorkflow(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      seedWaitingMergePrRun(store, issue);
+      store.trackPullRequest({
+        branchName: "sym/symphonika/97-merge-pr-acceptance-fixture",
+        headSha: "abc123",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(prState()),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        mergePullRequest: vi
+          .fn()
+          .mockRejectedValue(new Error("merge_conflict"))
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("merge-pr-run");
+
+      expect(githubIssuesApi.mergePullRequest).toHaveBeenCalledTimes(1);
+      const after = store.getRun("merge-pr-run");
+      expect(after?.state).toBe("waiting");
+      expect(after?.stateTransitionReason).toContain("merge_conflict");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("defers the merge when pull_requests.merge.enabled is false", async () => {
+    const root = await makeTempRoot();
+    await writeMergePrWorkflow(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      seedWaitingMergePrRun(store, issue);
+      store.trackPullRequest({
+        branchName: "sym/symphonika/97-merge-pr-acceptance-fixture",
+        headSha: "abc123",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(prState()),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        mergePullRequest: vi.fn().mockResolvedValue(undefined)
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        pullRequestPolicy: {
+          ...DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY,
+          merge: { ...DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY.merge, enabled: false }
+        },
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("merge-pr-run");
+
+      expect(githubIssuesApi.mergePullRequest).not.toHaveBeenCalled();
+      const after = store.getRun("merge-pr-run");
+      expect(after?.state).toBe("waiting");
+      expect(after?.stateTransitionReason).toContain("merge.enabled is false");
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/tests/merge-pr-state.test.ts
+++ b/tests/merge-pr-state.test.ts
@@ -425,6 +425,71 @@ describe("merge_pr state lifecycle", () => {
     }
   });
 
+  it("advances on transitions written as { pr_merged: true, pr_open: false } after a successful merge", async () => {
+    const root = await makeTempRoot();
+    // Workflow that uses the post-merge shape a refetch would produce — this
+    // exercises the post-merge signal reprojection.
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: merge_then_done",
+        "  initial: merging",
+        "  states:",
+        "    merging:",
+        "      action:",
+        "        kind: merge_pr",
+        "      transitions:",
+        "        - to: done",
+        "          when:",
+        "            pr_merged: true",
+        "            pr_open: false",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      seedWaitingMergePrRun(store, issue);
+      store.trackPullRequest({
+        branchName: "sym/symphonika/97-merge-pr-acceptance-fixture",
+        headSha: "abc123",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(prState()),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        mergePullRequest: vi.fn().mockResolvedValue(undefined)
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("merge-pr-run");
+
+      expect(githubIssuesApi.mergePullRequest).toHaveBeenCalledTimes(1);
+      const after = store.getRun("merge-pr-run");
+      expect(after?.state).toBe("succeeded");
+      expect(after?.terminalStateId).toBe("done");
+    } finally {
+      store.close();
+    }
+  });
+
   it("parks a fresh dispatch whose initial state is merge_pr without launching a provider", async () => {
     const root = await makeTempRoot();
     await writeMergePrWorkflow(root);

--- a/tests/merge-pr-state.test.ts
+++ b/tests/merge-pr-state.test.ts
@@ -425,6 +425,93 @@ describe("merge_pr state lifecycle", () => {
     }
   });
 
+  it("parks a fresh dispatch whose initial state is merge_pr without launching a provider", async () => {
+    const root = await makeTempRoot();
+    await writeMergePrWorkflow(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      const runAttempt = vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      });
+      const provider: AgentProvider = {
+        cancel: vi.fn().mockResolvedValue(undefined),
+        name: "codex",
+        runAttempt,
+        validate: vi.fn().mockResolvedValue(undefined)
+      };
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(prState()),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        mergePullRequest: vi.fn().mockResolvedValue(undefined),
+        removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+      };
+
+      const scheduled: Array<{ runId: string; kind: string }> = [];
+      const project = projectFixture("./workflow.yml");
+      const controller = new RunController({
+        activeRuns: new ActiveRunRegistry(),
+        agentProviders: { codex: provider },
+        configDir: root,
+        createRunId: () => "fresh-merge-pr-run",
+        env: { GITHUB_TOKEN: "secret-token" },
+        githubIssuesApi,
+        lifecyclePolicy: {
+          continuation: { cap: 0, delayMs: 0 },
+          retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+        },
+        logger: pino({ enabled: false }),
+        prepareIssueWorkspace: () =>
+          Promise.resolve(preparedWorkspaceFixture(root)),
+        projectsLoader: () => Promise.resolve(new Map([[project.name, project]])),
+        providersLoader: (): Promise<RunControllerProvidersConfig> =>
+          Promise.resolve({
+            claude: { command: "claude" },
+            codex: { command: DEFAULT_CODEX_COMMAND }
+          }),
+        pullRequestPolicyLoader: () =>
+          Promise.resolve(DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY),
+        runStore: store,
+        schedule: (item) => {
+          scheduled.push({ kind: item.kind, runId: item.runId });
+        },
+        stateRoot: path.join(root, ".symphonika")
+      });
+
+      const result = await controller.dispatchOneFresh({
+        candidateIssues: [{ issue, project: project.name }],
+        errors: [],
+        filteredIssues: [],
+        projects: []
+      });
+
+      expect(result).toEqual({ dispatched: true, runId: "fresh-merge-pr-run" });
+      expect(runAttempt).not.toHaveBeenCalled();
+      expect(provider.validate).not.toHaveBeenCalled();
+      expect(githubIssuesApi.mergePullRequest).not.toHaveBeenCalled();
+
+      const after = store.getRun("fresh-merge-pr-run");
+      expect(after?.state).toBe("waiting");
+      expect(after?.currentStateId).toBe("merging");
+
+      expect(scheduled).toEqual([
+        { kind: "wait_park", runId: "fresh-merge-pr-run" }
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
   it("defers the merge when pull_requests.merge.enabled is false", async () => {
     const root = await makeTempRoot();
     await writeMergePrWorkflow(root);

--- a/tests/pull-request-followup.test.ts
+++ b/tests/pull-request-followup.test.ts
@@ -152,6 +152,73 @@ describe("pull request follow-up", () => {
     }
   });
 
+  it("defers auto-merge when the issue has a waiting merge_pr run so the workflow's method override wins", async () => {
+    const root = await makeTempRoot();
+    await writeMergePrProject(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const branchName = "sym/symphonika/54-merge-pr-precedence";
+      seedSucceededRun(store, {
+        branchName,
+        runId: "parent-run",
+        workspacePath: path.join(root, "workspace")
+      });
+      const project = mergePrProjectConfig();
+      // Existing tracked PR row that the global follow-up loop would otherwise
+      // happily merge on this very tick.
+      store.trackPullRequest({
+        branchName,
+        headSha: "abc123",
+        issueNumber: 54,
+        prNumber: 82,
+        prUrl: "https://example.test/pr/82",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+      // A waiting merge_pr run parked on the same issue must claim the merge.
+      store.createWaitingRun({
+        currentStateId: "merging",
+        id: "merge-pr-run",
+        issue: normalizedIssue(),
+        parentRunId: "parent-run",
+        projectName: "symphonika"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(prState()),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        listPullRequestsForBranch: vi.fn().mockResolvedValue([]),
+        mergePullRequest: vi.fn().mockResolvedValue(undefined)
+      };
+      const controller = runController({
+        githubIssuesApi,
+        project,
+        provider: fakeProvider([]),
+        root,
+        runStore: store,
+        workspacePath: path.join(root, "workspace")
+      });
+
+      const result = await runPullRequestFollowup({
+        configPath: path.join(root, "symphonika.yml"),
+        env: { GITHUB_TOKEN: "secret-token" },
+        githubIssuesApi,
+        projectsLoader: () =>
+          Promise.resolve(new Map([[project.name, project]])),
+        runController: controller,
+        runStore: store
+      });
+
+      expect(result).toEqual({
+        action: "none",
+        reason: "no pull request follow-up action"
+      });
+      expect(githubIssuesApi.mergePullRequest).not.toHaveBeenCalled();
+    } finally {
+      store.close();
+    }
+  });
+
   it("auto-merges a tracked PR when reviews are clear, checks pass, and GitHub says it is mergeable", async () => {
     const root = await makeTempRoot();
     await writeProject(root);
@@ -486,6 +553,50 @@ async function writeProject(root: string): Promise<void> {
       ""
     ].join("\n")
   );
+}
+
+async function writeMergePrProject(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "providers:",
+      "  codex:",
+      `    command: "${DEFAULT_CODEX_COMMAND}"`,
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects: []",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: merge_pr_precedence",
+      "  initial: merging",
+      "  states:",
+      "    merging:",
+      "      action:",
+      "        kind: merge_pr",
+      "        method: merge",
+      "      transitions:",
+      "        - to: done",
+      "          when:",
+      "            pr_merged: true",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+}
+
+function mergePrProjectConfig(): RunControllerProjectConfig {
+  return {
+    ...projectConfig(),
+    workflow: { format: "auto", path: "./workflow.yml" }
+  };
 }
 
 function issueFixture() {

--- a/tests/state-machine-dispatch.test.ts
+++ b/tests/state-machine-dispatch.test.ts
@@ -208,6 +208,64 @@ describe("state-machine-dispatch", () => {
       }
     });
 
+    it("skips execute_action for a merge_pr state even on first entry", () => {
+      const mergeState: ExpandedWorkflowState = {
+        action: { kind: "merge_pr" },
+        completeWhen: {},
+        id: "merging",
+        transitions: [{ to: "done", when: { pr_merged: true } }]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: false,
+        signals: {},
+        state: mergeState
+      });
+
+      expect(decision.kind).not.toBe("execute_action");
+    });
+
+    it("returns stay_waiting for a merge_pr state with no matching transition", () => {
+      const mergeState: ExpandedWorkflowState = {
+        action: { kind: "merge_pr" },
+        completeWhen: {},
+        id: "merging",
+        transitions: [{ to: "done", when: { pr_merged: true } }]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: { pr_open: true, mergeable: true },
+        state: mergeState
+      });
+
+      expect(decision.kind).toBe("stay_waiting");
+      if (decision.kind === "stay_waiting") {
+        expect(decision.reason).toContain("merge_pr");
+        expect(decision.reason).toContain("merging");
+      }
+    });
+
+    it("advances a merge_pr state once pr_merged is signalled", () => {
+      const mergeState: ExpandedWorkflowState = {
+        action: { kind: "merge_pr" },
+        completeWhen: {},
+        id: "merging",
+        transitions: [{ to: "done", when: { pr_merged: true } }]
+      };
+
+      const decision = decideNextStep({
+        actionExecuted: true,
+        signals: { pr_merged: true },
+        state: mergeState
+      });
+
+      expect(decision.kind).toBe("advance");
+      if (decision.kind === "advance") {
+        expect(decision.to).toBe("done");
+      }
+    });
+
     it("still returns blocked for a non-wait state with no matching transition", () => {
       const state: ExpandedWorkflowState = {
         action: { kind: "agent", provider: "codex" },

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -773,6 +773,125 @@ describe("state machine workflow definitions", () => {
       `workflow definition at ${workflowPath} must define a top-level workflow mapping`
     );
   });
+
+  it("accepts a merge_pr action with an optional method override", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: merging",
+        "  states:",
+        "    merging:",
+        "      action:",
+        "        kind: merge_pr",
+        "        method: squash",
+        "      transitions:",
+        "        - to: done",
+        "          when:",
+        "            pr_merged: true",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+    const merging = result.workflow.states.find((state) => state.id === "merging");
+
+    expect(result.errors).toEqual([]);
+    expect(merging?.action?.kind).toBe("merge_pr");
+    expect(merging?.action?.method).toBe("squash");
+  });
+
+  it("rejects a merge_pr action that declares a provider", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: merging",
+        "  states:",
+        "    merging:",
+        "      action:",
+        "        kind: merge_pr",
+        "        provider: codex",
+        "      transitions:",
+        "        - to: done",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toContain(
+      `workflow state merging at ${workflowPath} merge_pr action must not define provider`
+    );
+  });
+
+  it("rejects a merge_pr action that declares a prompt", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: merging",
+        "  states:",
+        "    merging:",
+        "      action:",
+        "        kind: merge_pr",
+        "        prompt: please-merge",
+        "      transitions:",
+        "        - to: done",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toContain(
+      `workflow state merging at ${workflowPath} merge_pr action must not define prompt`
+    );
+  });
+
+  it("rejects a merge_pr action with an unknown method", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: merging",
+        "  states:",
+        "    merging:",
+        "      action:",
+        "        kind: merge_pr",
+        "        method: fast-forward",
+        "      transitions:",
+        "        - to: done",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toContain(
+      `workflow state merging at ${workflowPath} merge_pr method must be one of merge, rebase, squash`
+    );
+  });
 });
 
 describe("workflow format routing", () => {


### PR DESCRIPTION
## Summary

- Adds an `action.kind: merge_pr` state to the raw FSM workflow contract: a parked, observation-driven action that merges the workflow instance's Symphonika-tracked pull request when the configured `pull_requests.merge` policy is satisfied.
- Reuses the wait-state reconciliation path (`reEvaluateWaitingRun`) so merge states pick up the same durability, label-immunity, and cancel-on-issue-close semantics described in ADR 0047, with the workflow's optional `method` field overriding the policy default for a single state.
- Records deterministic `state_transition_reason` evidence for successful merges, policy-deferred / blocked merges, missing-PR rows, and merge API failures — workspaces are never touched.
- Documents the new state machine in SPEC.md §12.6 and ADR 0048.

Fixes #97

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — all 362 tests pass, including 5 new merge_pr lifecycle tests in `tests/merge-pr-state.test.ts` covering successful merge, policy-deferred merge, missing tracked PR, merge API failure, and `merge.enabled: false` deferral
- [x] `npm run build` — production build succeeds