### PR TITLE
Add terminal status dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ npm run dev -- poll-now --config symphonika.yml
 
 The command discovers `.symphonika/daemon.json`, preflights that the daemon reports the same state root, then posts to the local `/api/poll-now` endpoint. The daemon uses the same reconcile, polling, and dispatch gates as interval ticks, so invalid Projects, operational labels, excluded labels, active runs, and the dispatch mutex still apply.
 
+For a compact terminal dashboard inspired by the upstream Symphony status surface:
+
+```sh
+npm run dev -- status --config symphonika.yml --dashboard
+npm run dev -- status --config symphonika.yml --watch
+```
+
 The `symphony/` directory in the tree is a git submodule of an unrelated upstream project (`openai/symphony`) used as a reference — it is not a launcher for Symphonika.
 
 ## Self-Hosting

--- a/SPEC.md
+++ b/SPEC.md
@@ -804,7 +804,7 @@ Bootstrap CLI commands:
 - `symphonika doctor --config <path>`
 - `symphonika init-project <name> --config <path>`
 - `symphonika daemon --config <path> [--port <port>]`
-- `symphonika status --config <path>`
+- `symphonika status --config <path> [--dashboard] [--watch] [--interval-ms <ms>]`
 - `symphonika poll-now --config <path>`
 - `symphonika runs --config <path>`
 - `symphonika show-run <run-id> --config <path>`
@@ -824,6 +824,10 @@ Bootstrap CLI commands:
 - workspace root
 
 `init-project` creates missing operational labels only after explicit confirmation.
+
+`status --dashboard` renders a compact terminal status dashboard from the run store and daemon
+`/api/status` endpoint. `status --watch` refreshes that read-only dashboard in place; it must not
+dispatch work or mutate GitHub state.
 
 `clear-stale` removes `sym:stale`, `sym:claimed`, and `sym:running` only after explicit confirmation.
 

--- a/docs/adr/0026-bootstrap-cli-surface.md
+++ b/docs/adr/0026-bootstrap-cli-surface.md
@@ -1,3 +1,3 @@
 # Bootstrap CLI surface
 
-Symphonika v1 will include a small operational CLI: `doctor` for validation, `init-project` for confirmed operational-label setup, `daemon` for running the scheduler and local web UI/API, `status` for current state, `runs` for recent attempts, `show-run` for detailed logs and metadata, `cancel` for explicit active-run cancellation, and `clear-stale` for confirmed stale-claim cleanup.
+Symphonika v1 will include a small operational CLI: `doctor` for validation, `init-project` for confirmed operational-label setup, `daemon` for running the scheduler and local web UI/API, `status` for current state, `status --dashboard` / `status --watch` for a compact terminal operator dashboard, `runs` for recent attempts, `show-run` for detailed logs and metadata, `cancel` for explicit active-run cancellation, and `clear-stale` for confirmed stale-claim cleanup.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -363,11 +363,14 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         intervalMs: number;
         watch?: boolean;
       }) => {
-        const printOnce = async (dashboard: boolean): Promise<void> => {
+        const printOnce = async (
+          dashboard: boolean,
+          cachedReport?: DoctorReport
+        ): Promise<void> => {
           const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
           const store = openRunStore({ stateRoot });
           try {
-            const report = await doctor({ configPath: options.config });
+            const report = cachedReport ?? (await doctor({ configPath: options.config }));
             const daemonUrl = resolveDaemonUrl(stateRoot, options.daemonUrl);
             const daemonStatus =
               daemonUrl === undefined
@@ -471,9 +474,10 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         };
 
         if (options.watch === true) {
+          const report = await doctor({ configPath: options.config });
           for (;;) {
             writeOut(program, "\x1b[2J\x1b[H");
-            await printOnce(true);
+            await printOnce(true, report);
             await sleep(options.intervalMs);
           }
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import type {
   OpenRunStoreOptions,
   ProjectState,
   RunState,
+  RunStatus,
   RunStore
 } from "./run-store.js";
 import { openRunStore as openRunStoreReal } from "./run-store.js";
@@ -34,6 +35,11 @@ import {
   parseCapReachedReason
 } from "./lifecycle/terminal-reason.js";
 import { resolveStateRoot } from "./state.js";
+import {
+  renderStatusDashboard,
+  summarizeDashboardEvent,
+  type DashboardEventSummary
+} from "./status-dashboard.js";
 import { VERSION } from "./version.js";
 import { explainWorkflow, loadProjectWorkflow } from "./workflow.js";
 
@@ -346,91 +352,135 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .description("print project validation, issue polling, and run summaries")
     .option("--config <path>", "service config path", "symphonika.yml")
     .option("--daemon-url <url>", "local daemon base URL")
-    .action(async (options: { config: string; daemonUrl?: string }) => {
-      const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
-      const store = openRunStore({ stateRoot });
-      try {
-        const report = await doctor({ configPath: options.config });
-        const daemonUrl = resolveDaemonUrl(stateRoot, options.daemonUrl);
-        const daemonStatus =
-          daemonUrl === undefined
-            ? ({ error: "not configured", kind: "unavailable" } as const)
-            : await fetchDaemonStatus(fetcher, daemonUrl, stateRoot);
-        const all = store.listRuns();
-        const byState = new Map<string, number>();
-        for (const run of all) {
-          byState.set(run.state, (byState.get(run.state) ?? 0) + 1);
-        }
-        writeOut(program, `state root: ${stateRoot}\n`);
-        if (daemonUrl !== undefined) {
-          writeOut(
-            program,
-            `daemon: ${formatDaemonAvailability(daemonStatus, daemonUrl)}\n`
-          );
-          writeOut(program, `config reload: ${formatReloadOutcome(daemonStatus)}\n`);
-        }
-        writeOut(program, "\nProjects:\n");
-        if (report.projects.length === 0) {
-          writeOut(program, "  (no projects validated)\n");
-        }
-        for (const project of report.projects) {
-          writeOut(
-            program,
-            `  ${project.name}: ${project.validForDispatch ? "valid" : "invalid"}\n`
-          );
-          writeOut(program, `    workflow: ${project.workflowPath}\n`);
-          writeOut(
-            program,
-            `    missing operational labels: ${formatList(project.missingOperationalLabels)}\n`
-          );
-          const cursor = projectCursorFromStatus(daemonStatus, project.name);
-          if (cursor !== undefined) {
-            writeOut(program, `    ${formatProjectCursor(cursor)}\n`);
-            writeOut(program, `    ${formatProjectLastPoll(cursor)}\n`);
-            writeOut(program, `    ${formatProjectLastDispatch(cursor)}\n`);
-          }
-        }
-        if (report.errors.length > 0) {
-          writeOut(program, "validation errors:\n");
-          for (const error of report.errors) {
-            writeOut(program, `  - ${error}\n`);
-          }
-        }
-        const issueCounts = issueCountsFromStatus(
-          daemonStatus,
-          report.projects,
-          byState
-        );
-        writeOut(program, "\nIssue counts:\n");
-        writeOut(program, `  candidate: ${issueCounts.candidate}\n`);
-        writeOut(program, `  filtered:  ${issueCounts.filtered}\n`);
-        writeOut(program, `  running:   ${issueCounts.running}\n`);
-        writeOut(program, `  failed:    ${issueCounts.failed}\n`);
-        writeOut(program, `  stale:     ${issueCounts.stale}\n`);
-        writeOut(
-          program,
-          `last poll outcome: ${formatLastPollOutcome(daemonStatus)}\n`
-        );
-        writeOut(program, "\nRun state counts:\n");
-        writeOut(program, `total runs: ${all.length}\n`);
-        for (const [state, count] of [...byState.entries()].sort()) {
-          writeOut(program, `${state}: ${count}\n`);
-        }
-        if (all.length > 0) {
-          writeOut(program, "\nrecent runs:\n");
-          for (const run of all.slice(0, 25)) {
-            const suffix = formatRecentRunSuffix(run, store);
+    .option("--dashboard", "render a compact terminal status dashboard")
+    .option("--watch", "refresh the terminal dashboard until interrupted")
+    .option("--interval-ms <n>", "watch refresh interval in milliseconds", parsePositiveInt, 1000)
+    .action(
+      async (options: {
+        config: string;
+        daemonUrl?: string;
+        dashboard?: boolean;
+        intervalMs: number;
+        watch?: boolean;
+      }) => {
+        const printOnce = async (dashboard: boolean): Promise<void> => {
+          const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
+          const store = openRunStore({ stateRoot });
+          try {
+            const report = await doctor({ configPath: options.config });
+            const daemonUrl = resolveDaemonUrl(stateRoot, options.daemonUrl);
+            const daemonStatus =
+              daemonUrl === undefined
+                ? ({ error: "not configured", kind: "unavailable" } as const)
+                : await fetchDaemonStatus(fetcher, daemonUrl, stateRoot);
+            const all = store.listRuns();
+            const byState = new Map<string, number>();
+            for (const run of all) {
+              byState.set(run.state, (byState.get(run.state) ?? 0) + 1);
+            }
+            const issueCounts = issueCountsFromStatus(
+              daemonStatus,
+              report.projects,
+              byState
+            );
+
+            if (dashboard) {
+              writeOut(
+                program,
+                renderStatusDashboard({
+                  daemon:
+                    daemonUrl === undefined
+                      ? "unavailable (not configured)"
+                      : formatDaemonAvailability(daemonStatus, daemonUrl),
+                  issueCounts,
+                  lastPollOutcome: formatLastPollOutcome(daemonStatus),
+                  latestEvents: collectLatestDashboardEvents(store, all),
+                  projects: report.projects,
+                  reload: formatReloadOutcome(daemonStatus),
+                  runs: all,
+                  stateRoot
+                })
+              );
+              return;
+            }
+
+            writeOut(program, `state root: ${stateRoot}\n`);
+            if (daemonUrl !== undefined) {
+              writeOut(
+                program,
+                `daemon: ${formatDaemonAvailability(daemonStatus, daemonUrl)}\n`
+              );
+              writeOut(program, `config reload: ${formatReloadOutcome(daemonStatus)}\n`);
+            }
+            writeOut(program, "\nProjects:\n");
+            if (report.projects.length === 0) {
+              writeOut(program, "  (no projects validated)\n");
+            }
+            for (const project of report.projects) {
+              writeOut(
+                program,
+                `  ${project.name}: ${project.validForDispatch ? "valid" : "invalid"}\n`
+              );
+              writeOut(program, `    workflow: ${project.workflowPath}\n`);
+              writeOut(
+                program,
+                `    missing operational labels: ${formatList(project.missingOperationalLabels)}\n`
+              );
+              const cursor = projectCursorFromStatus(daemonStatus, project.name);
+              if (cursor !== undefined) {
+                writeOut(program, `    ${formatProjectCursor(cursor)}\n`);
+                writeOut(program, `    ${formatProjectLastPoll(cursor)}\n`);
+                writeOut(program, `    ${formatProjectLastDispatch(cursor)}\n`);
+              }
+            }
+            if (report.errors.length > 0) {
+              writeOut(program, "validation errors:\n");
+              for (const error of report.errors) {
+                writeOut(program, `  - ${error}\n`);
+              }
+            }
+            writeOut(program, "\nIssue counts:\n");
+            writeOut(program, `  candidate: ${issueCounts.candidate}\n`);
+            writeOut(program, `  filtered:  ${issueCounts.filtered}\n`);
+            writeOut(program, `  running:   ${issueCounts.running}\n`);
+            writeOut(program, `  failed:    ${issueCounts.failed}\n`);
+            writeOut(program, `  stale:     ${issueCounts.stale}\n`);
             writeOut(
               program,
-              `  ${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}${suffix}\n`
+              `last poll outcome: ${formatLastPollOutcome(daemonStatus)}\n`
             );
+            writeOut(program, "\nRun state counts:\n");
+            writeOut(program, `total runs: ${all.length}\n`);
+            for (const [state, count] of [...byState.entries()].sort()) {
+              writeOut(program, `${state}: ${count}\n`);
+            }
+            if (all.length > 0) {
+              writeOut(program, "\nrecent runs:\n");
+              for (const run of all.slice(0, 25)) {
+                const suffix = formatRecentRunSuffix(run, store);
+                writeOut(
+                  program,
+                  `  ${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}${suffix}\n`
+                );
+              }
+            }
+            printStaleSection(program, report.projects);
+          } finally {
+            store.close();
+          }
+        };
+
+        if (options.watch === true) {
+          for (;;) {
+            writeOut(program, "\x1b[2J\x1b[H");
+            await printOnce(true);
+            await sleep(options.intervalMs);
           }
         }
-        printStaleSection(program, report.projects);
-      } finally {
-        store.close();
+
+        await printOnce(options.dashboard === true);
       }
-    });
+    );
 
   program
     .command("poll-now")
@@ -653,6 +703,38 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
 
 export async function runCli(argv = process.argv): Promise<void> {
   await buildCli().parseAsync(argv);
+}
+
+function collectLatestDashboardEvents(
+  store: RunStore,
+  runs: RunStatus[]
+): Map<string, DashboardEventSummary> {
+  const latestEvents = new Map<string, DashboardEventSummary>();
+  for (const run of runs) {
+    if (!statusDashboardShowsLatestEvent(run.state)) {
+      continue;
+    }
+    const events = store.listProviderEvents(run.id, { limit: 1, order: "desc" });
+    const summary = summarizeDashboardEvent(events[0]);
+    if (summary !== undefined) {
+      latestEvents.set(run.id, summary);
+    }
+  }
+  return latestEvents;
+}
+
+function statusDashboardShowsLatestEvent(state: RunState): boolean {
+  return (
+    state === "queued" ||
+    state === "preparing_workspace" ||
+    state === "running" ||
+    state === "input_required" ||
+    state === "waiting"
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function fetchDaemonStatus(

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -1042,14 +1042,17 @@ export class RunStore {
       options.limit !== undefined
         ? `limit ${Math.max(0, Math.floor(options.limit))}`
         : "";
-    const order = options.order === "desc" ? "desc" : "asc";
+    const order =
+      options.order === "desc"
+        ? "created_at desc, id desc"
+        : "sequence asc, created_at asc, id asc";
     const rows = this.database
       .prepare(
         [
           "select run_id, attempt_id, sequence, type, raw_json, normalized_json, created_at",
           "from provider_events",
           `where ${conditions.join(" and ")}`,
-          `order by sequence ${order}`,
+          `order by ${order}`,
           limit
         ]
           .filter((part) => part.length > 0)

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -168,6 +168,7 @@ export type ProviderEventRecord = {
 export type ListProviderEventsOptions = {
   afterSequence?: number;
   limit?: number;
+  order?: "asc" | "desc";
 };
 
 export type ListRunsFilter = {
@@ -1041,13 +1042,14 @@ export class RunStore {
       options.limit !== undefined
         ? `limit ${Math.max(0, Math.floor(options.limit))}`
         : "";
+    const order = options.order === "desc" ? "desc" : "asc";
     const rows = this.database
       .prepare(
         [
           "select run_id, attempt_id, sequence, type, raw_json, normalized_json, created_at",
           "from provider_events",
           `where ${conditions.join(" and ")}`,
-          "order by sequence asc",
+          `order by sequence ${order}`,
           limit
         ]
           .filter((part) => part.length > 0)

--- a/src/status-dashboard.ts
+++ b/src/status-dashboard.ts
@@ -1,0 +1,228 @@
+import type { DoctorProjectReport } from "./doctor.js";
+import type { NormalizedProviderEvent } from "./provider.js";
+import type { ProviderEventRecord, RunState, RunStatus } from "./run-store.js";
+
+export type DashboardIssueCounts = {
+  candidate: number;
+  failed: number;
+  filtered: number;
+  running: number;
+  stale: number;
+};
+
+export type DashboardEventSummary = {
+  message: string;
+  sequence: number;
+  type: string;
+};
+
+export type StatusDashboardInput = {
+  daemon: string;
+  issueCounts: DashboardIssueCounts;
+  lastPollOutcome: string;
+  latestEvents: ReadonlyMap<string, DashboardEventSummary>;
+  projects: DoctorProjectReport[];
+  reload: string;
+  runs: RunStatus[];
+  stateRoot: string;
+};
+
+const ACTIVE_RUN_STATES = new Set<RunState>([
+  "queued",
+  "preparing_workspace",
+  "running",
+  "input_required",
+  "waiting"
+]);
+
+const ATTENTION_RUN_STATES = new Set<RunState>([
+  "failed",
+  "input_required",
+  "stale"
+]);
+
+const RECENT_LIMIT = 5;
+
+export function renderStatusDashboard(input: StatusDashboardInput): string {
+  const validProjects = input.projects.filter(
+    (project) => project.validForDispatch
+  ).length;
+  const invalidProjects = input.projects.length - validProjects;
+  const activeRuns = input.runs.filter((run) => ACTIVE_RUN_STATES.has(run.state));
+  const attentionRuns = input.runs.filter((run) =>
+    ATTENTION_RUN_STATES.has(run.state)
+  );
+  const runCounts = countRunsByState(input.runs);
+  const recentRuns = input.runs
+    .filter((run) => !ACTIVE_RUN_STATES.has(run.state))
+    .slice(0, RECENT_LIMIT);
+
+  const lines = [
+    "╭─ SYMPHONIKA STATUS",
+    `│ Daemon: ${input.daemon}`,
+    `│ Config reload: ${input.reload}`,
+    `│ State root: ${input.stateRoot}`,
+    `│ Projects: ${validProjects} valid / ${invalidProjects} invalid`,
+    `│ Issues: candidate ${input.issueCounts.candidate} | filtered ${input.issueCounts.filtered} | running ${input.issueCounts.running} | failed ${input.issueCounts.failed} | stale ${input.issueCounts.stale}`,
+    `│ Runs: active ${activeRuns.length} | succeeded ${runCounts.succeeded ?? 0} | failed ${runCounts.failed ?? 0} | cancelled ${runCounts.cancelled ?? 0} | total ${input.runs.length}`,
+    `│ Last poll: ${input.lastPollOutcome}`,
+    "├─ Active runs",
+    ...formatActiveRuns(activeRuns, input.latestEvents),
+    "├─ Attention",
+    ...formatAttention(input.projects, attentionRuns),
+    "├─ Recent runs",
+    ...formatRecentRuns(recentRuns),
+    "╰─"
+  ];
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function summarizeDashboardEvent(
+  event: ProviderEventRecord | undefined
+): DashboardEventSummary | undefined {
+  if (event === undefined) {
+    return undefined;
+  }
+  return {
+    message: summarizeNormalizedEvent(event.normalized),
+    sequence: event.sequence,
+    type: event.type
+  };
+}
+
+function countRunsByState(runs: RunStatus[]): Partial<Record<RunState, number>> {
+  const counts: Partial<Record<RunState, number>> = {};
+  for (const run of runs) {
+    counts[run.state] = (counts[run.state] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function formatActiveRuns(
+  runs: RunStatus[],
+  latestEvents: ReadonlyMap<string, DashboardEventSummary>
+): string[] {
+  if (runs.length === 0) {
+    return ["│   No active runs"];
+  }
+
+  return [
+    "│   ID           PROJECT      ISSUE   STATE                PROVIDER  EVENT",
+    "│   -------------------------------------------------------------------------------",
+    ...runs.map((run) => {
+      const event = latestEvents.get(run.id);
+      return [
+        "│  ",
+        pad(truncate(run.id, 12), 12),
+        " ",
+        pad(truncate(run.project, 12), 12),
+        " ",
+        pad(`#${run.issueNumber}`, 7),
+        " ",
+        pad(run.state, 20),
+        " ",
+        pad(run.provider || "-", 8),
+        " ",
+        truncate(eventSummary(event), 42)
+      ].join("");
+    })
+  ];
+}
+
+function formatAttention(
+  projects: DoctorProjectReport[],
+  runs: RunStatus[]
+): string[] {
+  const lines: string[] = [];
+  for (const run of runs.slice(0, RECENT_LIMIT)) {
+    lines.push(
+      `│   ${run.state} ${run.project} #${run.issueNumber} ${truncate(run.issueTitle, 52)}${formatReason(run)}`
+    );
+  }
+  for (const project of projects) {
+    for (const issue of project.staleIssues.slice(0, RECENT_LIMIT)) {
+      lines.push(
+        `│   stale claim ${project.name} #${issue.number} ${truncate(issue.title, 52)}`
+      );
+    }
+  }
+  if (lines.length === 0) {
+    return ["│   No failed, input-required, or stale work"];
+  }
+  return lines;
+}
+
+function formatRecentRuns(runs: RunStatus[]): string[] {
+  if (runs.length === 0) {
+    return ["│   No completed runs yet"];
+  }
+  return runs.map(
+    (run) =>
+      `│   ${pad(truncate(run.id, 14), 14)} ${pad(run.project, 12)} #${pad(String(run.issueNumber), 5)} ${pad(run.state, 10)} ${truncate(run.issueTitle, 42)}`
+  );
+}
+
+function formatReason(run: RunStatus): string {
+  const reason = run.terminalReason ?? run.stateTransitionReason;
+  return reason === null ? "" : ` — ${truncate(reason, 40)}`;
+}
+
+function eventSummary(event: DashboardEventSummary | undefined): string {
+  if (event === undefined) {
+    return "(no events)";
+  }
+  return `${event.sequence}. ${event.type}: ${event.message}`;
+}
+
+function summarizeNormalizedEvent(event: NormalizedProviderEvent): string {
+  if (typeof event.message === "string" && event.message.trim().length > 0) {
+    return event.message.trim().replace(/\s+/g, " ");
+  }
+  if (event.type === "tool_call" && typeof event.toolName === "string") {
+    return `tool ${event.toolName}`;
+  }
+  if (event.type === "usage_updated" && isRecord(event.tokenUsage)) {
+    const total =
+      numberField(event.tokenUsage, "total_tokens") ??
+      numberField(event.tokenUsage, "totalTokens") ??
+      numberField(event.tokenUsage, "total");
+    return total === undefined ? "usage updated" : `${total.toLocaleString()} tokens`;
+  }
+  if (event.type === "turn_completed" && typeof event.status === "string") {
+    return event.status;
+  }
+  if (event.type === "process_exit" && typeof event.exitCode === "number") {
+    return `exit ${event.exitCode}`;
+  }
+  if (event.type === "session_started" && typeof event.sessionId === "string") {
+    return `session ${truncate(event.sessionId, 18)}`;
+  }
+  return event.type;
+}
+
+function numberField(
+  value: Record<string, unknown>,
+  key: string
+): number | undefined {
+  const field = value[key];
+  return typeof field === "number" && Number.isFinite(field) ? field : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function pad(value: string, width: number): string {
+  return value.length >= width ? value : value.padEnd(width, " ");
+}
+
+function truncate(value: string, width: number): string {
+  if (value.length <= width) {
+    return value;
+  }
+  if (width <= 1) {
+    return value.slice(0, width);
+  }
+  return `${value.slice(0, width - 1)}…`;
+}

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -200,6 +200,108 @@ describe("CLI run commands", () => {
     );
   });
 
+  it("status --dashboard renders a compact terminal dashboard with active event context", async () => {
+    const stateRoot = await makeTempRoot();
+    const resolvedStateRoot = path.join(stateRoot, ".symphonika");
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "dash-run",
+      issue: sampleIssue({ number: 17, title: "Dashboard issue" }),
+      projectName: "alpha",
+      providerCommand: "codex fake",
+      providerName: "codex"
+    });
+    store.createAttempt({
+      attemptNumber: 1,
+      branchName: "sym/alpha/17-dashboard",
+      branchRef: "refs/heads/sym/alpha/17-dashboard",
+      id: "dash-run-attempt-1",
+      issueSnapshotPath: "/tmp/snap.json",
+      metadataPath: "/tmp/meta.json",
+      normalizedLogPath: "/tmp/normalized.jsonl",
+      promptPath: "/tmp/prompt.md",
+      providerCommand: "codex fake",
+      providerName: "codex",
+      rawLogPath: "/tmp/raw.jsonl",
+      runId: "dash-run",
+      state: "running",
+      workflowGraphPath: "",
+      workspacePath: stateRoot
+    });
+    store.updateRunState("dash-run", "running");
+    store.recordProviderEvent({
+      attemptId: "dash-run-attempt-1",
+      normalized: { message: "hello from dashboard", type: "message" },
+      raw: { message: "hello from dashboard" },
+      runId: "dash-run",
+      sequence: 1
+    });
+    store.close();
+
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: () =>
+        Promise.resolve(
+          Response.json({
+            candidateIssues: [{ issue: { number: 17 }, project: "alpha" }],
+            filteredIssues: [
+              { issue: { labels: ["sym:running"], number: 17 }, project: "alpha" }
+            ],
+            issuePolling: {
+              errors: [],
+              projects: [{ fetchedIssues: 1, name: "alpha", ok: true }]
+            },
+            reload: {
+              errors: [],
+              lastAttemptedAt: "2026-05-13T09:00:00.000Z",
+              lastLoadedAt: "2026-05-13T09:00:00.000Z",
+              ok: true,
+              usingLastKnownGood: false
+            },
+            state: "idle",
+            stateRoot: resolvedStateRoot
+          })
+        ),
+      runDoctor: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          ok: true,
+          projects: [
+            {
+              missingOperationalLabels: [],
+              name: "alpha",
+              staleIssues: [],
+              validForDispatch: true,
+              workflowPath: "/tmp/WORKFLOW.md"
+            }
+          ]
+        } satisfies DoctorReport)
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml"),
+      "--daemon-url",
+      "http://127.0.0.1:3030",
+      "--dashboard"
+    ]);
+
+    expect(output.stdout).toContain("SYMPHONIKA STATUS");
+    expect(output.stdout).toContain("Daemon: idle at http://127.0.0.1:3030");
+    expect(output.stdout).toContain("Projects: 1 valid / 0 invalid");
+    expect(output.stdout).toContain(
+      "Issues: candidate 1 | filtered 1 | running 1 | failed 0 | stale 0"
+    );
+    expect(output.stdout).toContain("Active runs");
+    expect(output.stdout).toContain("dash-run");
+    expect(output.stdout).toContain("#17");
+    expect(output.stdout).toContain("hello from dashboard");
+    expect(output.stdout).toContain("No failed, input-required, or stale work");
+  });
+
   it("status discovers the local daemon endpoint descriptor", async () => {
     const stateRoot = await makeTempRoot();
     const resolvedStateRoot = path.join(stateRoot, ".symphonika");

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -302,6 +302,72 @@ describe("CLI run commands", () => {
     expect(output.stdout).toContain("No failed, input-required, or stale work");
   });
 
+  it("status --watch reuses project validation across refresh ticks", async () => {
+    const stateRoot = await makeTempRoot();
+    const resolvedStateRoot = path.join(stateRoot, ".symphonika");
+    let doctorCalls = 0;
+    let openStoreCalls = 0;
+    let statusRequests = 0;
+    const { program } = captureProgram(stateRoot, {
+      fetch: () => {
+        statusRequests += 1;
+        return Promise.resolve(
+          Response.json({
+            issuePolling: {
+              errors: [],
+              projects: [{ fetchedIssues: 1, name: "alpha", ok: true }]
+            },
+            state: "idle",
+            stateRoot: resolvedStateRoot
+          })
+        );
+      },
+      openRunStore: () => {
+        openStoreCalls += 1;
+        if (openStoreCalls > 2) {
+          throw new Error("stop watch");
+        }
+        return openRunStore({ stateRoot });
+      },
+      runDoctor: () => {
+        doctorCalls += 1;
+        return Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          ok: true,
+          projects: [
+            {
+              missingOperationalLabels: [],
+              name: "alpha",
+              staleIssues: [],
+              validForDispatch: true,
+              workflowPath: "/tmp/WORKFLOW.md"
+            }
+          ]
+        } satisfies DoctorReport);
+      }
+    });
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "symphonika",
+        "status",
+        "--config",
+        path.join(stateRoot, "symphonika.yml"),
+        "--daemon-url",
+        "http://127.0.0.1:3030",
+        "--watch",
+        "--interval-ms",
+        "1"
+      ])
+    ).rejects.toThrow("stop watch");
+
+    expect(statusRequests).toBeGreaterThan(1);
+    expect(openStoreCalls).toBeGreaterThan(2);
+    expect(doctorCalls).toBe(1);
+  });
+
   it("status discovers the local daemon endpoint descriptor", async () => {
     const stateRoot = await makeTempRoot();
     const resolvedStateRoot = path.join(stateRoot, ".symphonika");

--- a/tests/run-store-detail.test.ts
+++ b/tests/run-store-detail.test.ts
@@ -295,6 +295,11 @@ describe("RunStore detail queries", () => {
           .listProviderEvents("r-events", { afterSequence: 3 })
           .map((e) => e.sequence)
       ).toEqual([4, 5]);
+      expect(
+        store
+          .listProviderEvents("r-events", { limit: 1, order: "desc" })
+          .map((e) => e.sequence)
+      ).toEqual([5]);
     } finally {
       store.close();
     }

--- a/tests/run-store-detail.test.ts
+++ b/tests/run-store-detail.test.ts
@@ -272,6 +272,23 @@ describe("RunStore detail queries", () => {
         workflowGraphPath: "",
         workspacePath: "/tmp/work"
       });
+      store.createAttempt({
+        attemptNumber: 2,
+        branchName: "branch",
+        branchRef: "refs/heads/branch",
+        id: "r-events-attempt-2",
+        issueSnapshotPath: "/tmp/snap-2.json",
+        metadataPath: "/tmp/meta-2.json",
+        normalizedLogPath: "/tmp/normalized-2.jsonl",
+        promptPath: "/tmp/prompt-2.md",
+        providerCommand: "x",
+        providerName: "codex",
+        rawLogPath: "/tmp/raw-2.jsonl",
+        runId: "r-events",
+        state: "running",
+        workflowGraphPath: "",
+        workspacePath: "/tmp/work"
+      });
       for (let i = 1; i <= 5; i += 1) {
         store.recordProviderEvent({
           attemptId: "r-events-attempt-1",
@@ -281,15 +298,22 @@ describe("RunStore detail queries", () => {
           sequence: i
         });
       }
+      store.recordProviderEvent({
+        attemptId: "r-events-attempt-2",
+        normalized: { type: "message", message: "retry started" },
+        raw: { kind: "message", body: "retry started" },
+        runId: "r-events",
+        sequence: 1
+      });
 
       expect(store.listProviderEvents("r-events").map((e) => e.sequence)).toEqual([
-        1, 2, 3, 4, 5
+        1, 1, 2, 3, 4, 5
       ]);
       expect(
         store
           .listProviderEvents("r-events", { limit: 2 })
           .map((e) => e.sequence)
-      ).toEqual([1, 2]);
+      ).toEqual([1, 1]);
       expect(
         store
           .listProviderEvents("r-events", { afterSequence: 3 })
@@ -298,8 +322,8 @@ describe("RunStore detail queries", () => {
       expect(
         store
           .listProviderEvents("r-events", { limit: 1, order: "desc" })
-          .map((e) => e.sequence)
-      ).toEqual([5]);
+          .map((e) => [e.attemptId, e.sequence])
+      ).toEqual([["r-events-attempt-2", 1]]);
     } finally {
       store.close();
     }


### PR DESCRIPTION
## Summary

- add `symphonika status --dashboard` and `symphonika status --watch` as a compact terminal operator surface
- summarize daemon health, config reload state, issue/run counts, active run event context, attention items, and recent runs
- document the CLI surface in `SPEC.md`, README, and ADR 0026

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`

Closes #108