### PR TITLE
Expand repo-local workflow templates

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -316,6 +316,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
       );
       writeOut(program, `source: ${report.workflowPath ?? report.workflow.source.path}\n`);
       writeOut(program, `states: ${report.workflow.states.length}\n`);
+      writeOut(program, explainWorkflow(report.workflow));
     });
 
   workflowCommand

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -1680,7 +1680,7 @@ export class RunController {
     if (!("expandedWorkflow" in workflow)) {
       const workflowPath = path.resolve(this.configDir, workflow.path);
       const contents = await readFile(workflowPath, "utf8");
-      const expanded = expandWorkflowDefinition(
+      const expanded = await expandWorkflowDefinition(
         contents,
         workflowPath,
         workflow.format

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -355,7 +355,7 @@ async function readWorkflowSnapshot(
     return undefined;
   }
 
-  const expanded = expandWorkflowDefinition(contents, workflowPath, format);
+  const expanded = await expandWorkflowDefinition(contents, workflowPath, format);
   // Raw FSM YAML files can open with `---` (the YAML document marker); the
   // markdown contract parser would mistake that for unterminated front matter,
   // so skip it. The expanded workflow's contentHash is sufficient for snapshot

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -811,6 +811,10 @@ async function expandRawStateMachineWorkflow(
     );
   }
   for (const state of states) {
+    state.transitions = state.transitions.map((transition) => ({
+      ...transition,
+      to: templateEntryTargets.get(transition.to) ?? transition.to
+    }));
     for (const transition of state.transitions) {
       if (!stateIds.has(transition.to) && !unresolvedTemplateExitTargets.has(transition.to)) {
         errors.push(

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -763,6 +763,7 @@ async function expandRawStateMachineWorkflow(
   }
 
   const rawStateIds = new Set(states.map((state) => state.id));
+  const stateIds = new Set(rawStateIds);
   for (const use of uses) {
     if (rawStateIds.has(use.id)) {
       errors.push(
@@ -786,14 +787,22 @@ async function expandRawStateMachineWorkflow(
       workflowPath,
       errors
     );
-    states.push(...expansion.states);
+    for (const state of expansion.states) {
+      if (stateIds.has(state.id)) {
+        errors.push(
+          `workflow template instance ${loaded.use.id} at ${workflowPath} expands state ${state.id} that conflicts with an existing workflow state`
+        );
+        continue;
+      }
+      stateIds.add(state.id);
+      states.push(state);
+    }
     for (const target of expansion.unresolvedExitTargets) {
       unresolvedTemplateExitTargets.add(target);
     }
   }
 
   const templateFiles = uniqueStrings(loadedUses.map((loaded) => loaded.template.path));
-  const stateIds = new Set(states.map((state) => state.id));
   const expandedInitial =
     initial === undefined ? undefined : templateEntryTargets.get(initial) ?? initial;
   if (expandedInitial !== undefined && !stateIds.has(expandedInitial)) {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -122,6 +122,47 @@ export type ExpandedWorkflow = {
   templateFiles: string[];
 };
 
+type WorkflowTemplateInputType =
+  | "boolean"
+  | "label"
+  | "number"
+  | "path"
+  | "provider"
+  | "string";
+
+type WorkflowTemplateScalar = boolean | number | string;
+
+type WorkflowTemplateInput = {
+  type: WorkflowTemplateInputType;
+  defaultValue?: WorkflowTemplateScalar;
+};
+
+type WorkflowTemplateUse = {
+  exitMappings: Record<string, string>;
+  id: string;
+  template: string;
+  withValues: Record<string, unknown>;
+};
+
+type ParsedWorkflowTemplate = {
+  contents: string;
+  entry: string;
+  exits: Record<string, string>;
+  inputs: Record<string, WorkflowTemplateInput>;
+  path: string;
+  states: Record<string, unknown>;
+};
+
+type LoadedWorkflowTemplateUse = {
+  template: ParsedWorkflowTemplate;
+  use: WorkflowTemplateUse;
+};
+
+type WorkflowTemplateUseExpansion = {
+  states: ExpandedWorkflowState[];
+  unresolvedExitTargets: Set<string>;
+};
+
 export type ExpandedWorkflowLoadResult = {
   errors: string[];
   workflow: ExpandedWorkflow;
@@ -465,11 +506,11 @@ export function validateWorkflowTemplate(
   return errors;
 }
 
-export function expandWorkflowDefinition(
+export async function expandWorkflowDefinition(
   contents: string,
   workflowPath: string,
   format: WorkflowFormat = "auto"
-): ExpandedWorkflowLoadResult {
+): Promise<ExpandedWorkflowLoadResult> {
   const resolved = resolveWorkflowFormat(format, workflowPath);
   if (resolved.kind === "error") {
     return {
@@ -490,7 +531,7 @@ export function expandWorkflowDefinition(
     return expandRawStateMachineWorkflow(
       explicit,
       workflowPath,
-      contentHash(contents),
+      contents,
       errors
     );
   }
@@ -691,12 +732,12 @@ function parseExplicitWorkflowDefinition(
   return parsed.workflow;
 }
 
-function expandRawStateMachineWorkflow(
+async function expandRawStateMachineWorkflow(
   rawWorkflow: Record<string, unknown>,
   workflowPath: string,
-  workflowContentHash: string,
+  workflowContents: string,
   errors: string[]
-): ExpandedWorkflowLoadResult {
+): Promise<ExpandedWorkflowLoadResult> {
   const name = stringProperty(rawWorkflow, "name");
   if (name === undefined) {
     errors.push(`workflow definition at ${workflowPath} must define workflow.name`);
@@ -708,7 +749,9 @@ function expandRawStateMachineWorkflow(
   }
 
   const rawStates = recordProperty(rawWorkflow, "states");
-  if (rawStates === undefined) {
+  const rawUse = rawWorkflow.use;
+  const uses = parseWorkflowTemplateUses(rawUse, workflowPath, errors);
+  if (rawStates === undefined && uses.length === 0) {
     errors.push(`workflow definition at ${workflowPath} must define workflow.states`);
   }
 
@@ -719,15 +762,48 @@ function expandRawStateMachineWorkflow(
     }
   }
 
+  const rawStateIds = new Set(states.map((state) => state.id));
+  for (const use of uses) {
+    if (rawStateIds.has(use.id)) {
+      errors.push(
+        `workflow template instance ${use.id} at ${workflowPath} conflicts with a workflow state`
+      );
+    }
+  }
+
+  const loadedUses = await loadWorkflowTemplateUses(uses, workflowPath, errors);
+  const templateEntryTargets = new Map(
+    loadedUses.map((loaded) => [
+      loaded.use.id,
+      `${loaded.use.id}.${loaded.template.entry}`
+    ])
+  );
+  const unresolvedTemplateExitTargets = new Set<string>();
+  for (const loaded of loadedUses) {
+    const expansion = expandWorkflowTemplateUse(
+      loaded,
+      templateEntryTargets,
+      workflowPath,
+      errors
+    );
+    states.push(...expansion.states);
+    for (const target of expansion.unresolvedExitTargets) {
+      unresolvedTemplateExitTargets.add(target);
+    }
+  }
+
+  const templateFiles = uniqueStrings(loadedUses.map((loaded) => loaded.template.path));
   const stateIds = new Set(states.map((state) => state.id));
-  if (initial !== undefined && !stateIds.has(initial)) {
+  const expandedInitial =
+    initial === undefined ? undefined : templateEntryTargets.get(initial) ?? initial;
+  if (expandedInitial !== undefined && !stateIds.has(expandedInitial)) {
     errors.push(
       `workflow definition at ${workflowPath} initial state ${initial} is not declared`
     );
   }
   for (const state of states) {
     for (const transition of state.transitions) {
-      if (!stateIds.has(transition.to)) {
+      if (!stateIds.has(transition.to) && !unresolvedTemplateExitTargets.has(transition.to)) {
         errors.push(
           `workflow state ${state.id} at ${workflowPath} transitions to unknown state ${transition.to}`
         );
@@ -738,17 +814,351 @@ function expandRawStateMachineWorkflow(
   return {
     errors,
     workflow: {
-      contentHash: workflowContentHash,
-      initial: initial ?? "",
+      contentHash: contentHash(
+        [
+          workflowContents,
+          ...loadedUses.map(
+            (loaded) => `${loaded.template.path}\n${loaded.template.contents}`
+          )
+        ].join("\n\0\n")
+      ),
+      initial: expandedInitial ?? "",
       name: name ?? path.basename(workflowPath, path.extname(workflowPath)),
       source: {
         kind: "raw_fsm",
         path: workflowPath
       },
       states,
-      templateFiles: []
+      templateFiles
     }
   };
+}
+
+function parseWorkflowTemplateUses(
+  rawUse: unknown,
+  workflowPath: string,
+  errors: string[]
+): WorkflowTemplateUse[] {
+  if (rawUse === undefined) {
+    return [];
+  }
+  if (!isRecord(rawUse)) {
+    errors.push(`workflow definition at ${workflowPath} workflow.use must be a mapping`);
+    return [];
+  }
+
+  const uses: WorkflowTemplateUse[] = [];
+  for (const [instanceId, rawInstance] of Object.entries(rawUse)) {
+    if (!isPathSafeIdentifier(instanceId)) {
+      errors.push(
+        `workflow template instance ${instanceId} at ${workflowPath} must use a path-safe identifier`
+      );
+    }
+    if (!isRecord(rawInstance)) {
+      errors.push(
+        `workflow template instance ${instanceId} at ${workflowPath} must be a mapping`
+      );
+      continue;
+    }
+    const template = stringProperty(rawInstance, "template");
+    if (template === undefined) {
+      errors.push(
+        `workflow template instance ${instanceId} at ${workflowPath} must define template`
+      );
+      continue;
+    }
+    if (template.startsWith("builtin:")) {
+      errors.push(
+        `workflow template instance ${instanceId} at ${workflowPath} uses unsupported built-in template ${template}`
+      );
+      continue;
+    }
+    if (path.isAbsolute(template)) {
+      errors.push(
+        `workflow template instance ${instanceId} at ${workflowPath} template must be a repo-local relative path`
+      );
+      continue;
+    }
+    uses.push({
+      exitMappings: parseStringMap(
+        rawInstance.exits,
+        `workflow template instance ${instanceId} at ${workflowPath} exits`,
+        errors
+      ),
+      id: instanceId,
+      template,
+      withValues: parseUnknownMap(
+        rawInstance.with,
+        `workflow template instance ${instanceId} at ${workflowPath} with`,
+        errors
+      )
+    });
+  }
+  return uses;
+}
+
+async function loadWorkflowTemplateUses(
+  uses: WorkflowTemplateUse[],
+  workflowPath: string,
+  errors: string[]
+): Promise<LoadedWorkflowTemplateUse[]> {
+  const loaded: LoadedWorkflowTemplateUse[] = [];
+  for (const use of uses) {
+    const template = await loadWorkflowTemplate(use, workflowPath, errors);
+    if (template !== undefined) {
+      loaded.push({ template, use });
+    }
+  }
+  return loaded;
+}
+
+async function loadWorkflowTemplate(
+  use: WorkflowTemplateUse,
+  workflowPath: string,
+  errors: string[]
+): Promise<ParsedWorkflowTemplate | undefined> {
+  const workflowDir = path.dirname(workflowPath);
+  const templatePath = path.resolve(workflowDir, use.template);
+  if (!isPathInside(templatePath, workflowDir)) {
+    errors.push(
+      `workflow template instance ${use.id} at ${workflowPath} template ${use.template} must stay inside ${workflowDir}`
+    );
+    return undefined;
+  }
+
+  let contents: string;
+  try {
+    contents = await readFile(templatePath, "utf8");
+  } catch (error) {
+    errors.push(
+      `workflow template instance ${use.id} at ${workflowPath} could not read ${templatePath}: ${errorMessage(error)}`
+    );
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parse(contents) ?? {};
+  } catch (error) {
+    errors.push(
+      `workflow template at ${templatePath} could not be parsed: ${errorMessage(error)}`
+    );
+    return undefined;
+  }
+  if (!isRecord(parsed)) {
+    errors.push(`workflow template at ${templatePath} must be a mapping`);
+    return undefined;
+  }
+
+  const entry = stringProperty(parsed, "entry");
+  if (entry === undefined) {
+    errors.push(`workflow template at ${templatePath} must define entry`);
+  }
+  const states = recordProperty(parsed, "states");
+  if (states === undefined) {
+    errors.push(`workflow template at ${templatePath} must define states`);
+  }
+  const exits = parseStringMap(
+    parsed.exits,
+    `workflow template at ${templatePath} exits`,
+    errors
+  );
+
+  return {
+    contents,
+    entry: entry ?? "",
+    exits,
+    inputs: parseWorkflowTemplateInputs(parsed.inputs, templatePath, errors),
+    path: templatePath,
+    states: states ?? {}
+  };
+}
+
+function parseWorkflowTemplateInputs(
+  rawInputs: unknown,
+  templatePath: string,
+  errors: string[]
+): Record<string, WorkflowTemplateInput> {
+  if (rawInputs === undefined) {
+    return {};
+  }
+  if (!isRecord(rawInputs)) {
+    errors.push(`workflow template at ${templatePath} inputs must be a mapping`);
+    return {};
+  }
+  const inputs: Record<string, WorkflowTemplateInput> = {};
+  for (const [name, rawInput] of Object.entries(rawInputs)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      errors.push(`workflow template input ${name} at ${templatePath} must be an identifier`);
+      continue;
+    }
+    if (!isRecord(rawInput)) {
+      errors.push(`workflow template input ${name} at ${templatePath} must be a mapping`);
+      continue;
+    }
+    const type = stringProperty(rawInput, "type");
+    if (!isWorkflowTemplateInputType(type)) {
+      errors.push(
+        `workflow template input ${name} at ${templatePath} type must be one of boolean, label, number, path, provider, string`
+      );
+      continue;
+    }
+    const defaultValue = Object.hasOwn(rawInput, "default")
+      ? validateWorkflowTemplateInputValue(
+          name,
+          type,
+          rawInput.default,
+          templatePath,
+          errors
+        )
+      : undefined;
+    inputs[name] = {
+      type,
+      ...(defaultValue === undefined ? {} : { defaultValue })
+    };
+  }
+  return inputs;
+}
+
+function expandWorkflowTemplateUse(
+  loaded: LoadedWorkflowTemplateUse,
+  templateEntryTargets: Map<string, string>,
+  workflowPath: string,
+  errors: string[]
+): WorkflowTemplateUseExpansion {
+  const { template, use } = loaded;
+  const inputValues = resolveWorkflowTemplateInputs(template, use, errors);
+  const templateExitStates = templateExitStateMap(template, errors);
+  const expandedStates: ExpandedWorkflowState[] = [];
+  const unresolvedExitTargets = new Set<string>();
+  for (const exitName of Object.keys(use.exitMappings)) {
+    if (!Object.hasOwn(template.exits, exitName)) {
+      errors.push(
+        `workflow template instance ${use.id} at ${workflowPath} maps undeclared exit ${exitName} from ${template.path}`
+      );
+    }
+  }
+  if (!Object.hasOwn(template.states, template.entry)) {
+    errors.push(`workflow template at ${template.path} entry state ${template.entry} is not declared`);
+  }
+
+  for (const [stateId, rawState] of Object.entries(template.states)) {
+    const exitName = templateExitStates.get(stateId);
+    if (
+      exitName !== undefined &&
+      (Object.hasOwn(use.exitMappings, exitName) ||
+        !isTemplateTerminalState(template, stateId))
+    ) {
+      continue;
+    }
+    const expandedStateId = `${use.id}.${stateId}`;
+    const interpolated = interpolateWorkflowTemplateValue(
+      rawState,
+      inputValues,
+      template.path,
+      errors
+    );
+    const state = parseWorkflowState(expandedStateId, interpolated, template.path, errors);
+    state.transitions = state.transitions.map((transition) => ({
+      ...transition,
+      to: rewriteTemplateTransitionTarget(
+        stateId,
+        transition.to,
+        loaded,
+        templateExitStates,
+        templateEntryTargets,
+        unresolvedExitTargets,
+        workflowPath,
+        errors
+      )
+    }));
+    expandedStates.push(state);
+  }
+  return { states: expandedStates, unresolvedExitTargets };
+}
+
+function templateExitStateMap(
+  template: ParsedWorkflowTemplate,
+  errors: string[]
+): Map<string, string> {
+  const exitStates = new Map<string, string>();
+  for (const [exitName, targetState] of Object.entries(template.exits)) {
+    if (!Object.hasOwn(template.states, targetState)) {
+      errors.push(
+        `workflow template at ${template.path} exit ${exitName} targets unknown state ${targetState}`
+      );
+      continue;
+    }
+    const rawState = template.states[targetState];
+    if (!isRecord(rawState)) {
+      errors.push(`workflow template state ${targetState} at ${template.path} must be a mapping`);
+      continue;
+    }
+    const terminal = stringProperty(rawState, "terminal");
+    if (terminal !== undefined && terminalStates.has(terminal)) {
+      exitStates.set(targetState, exitName);
+      continue;
+    }
+    const declaredExit = stringProperty(rawState, "exit");
+    if (declaredExit !== exitName) {
+      errors.push(
+        `workflow template at ${template.path} exit ${exitName} must target a state declaring exit: ${exitName}`
+      );
+      continue;
+    }
+    exitStates.set(targetState, exitName);
+  }
+  return exitStates;
+}
+
+function rewriteTemplateTransitionTarget(
+  fromStateId: string,
+  target: string,
+  loaded: LoadedWorkflowTemplateUse,
+  templateExitStates: Map<string, string>,
+  templateEntryTargets: Map<string, string>,
+  unresolvedExitTargets: Set<string>,
+  workflowPath: string,
+  errors: string[]
+): string {
+  const { template, use } = loaded;
+  if (!Object.hasOwn(template.states, target)) {
+    errors.push(
+      `workflow template state ${fromStateId} at ${template.path} transitions to ${target} outside declared exits`
+    );
+    return target;
+  }
+
+  const exitName = templateExitStates.get(target);
+  if (exitName === undefined) {
+    return `${use.id}.${target}`;
+  }
+
+  const mappedTarget = use.exitMappings[exitName];
+  if (mappedTarget === undefined) {
+    if (isTemplateTerminalState(template, target)) {
+      return `${use.id}.${target}`;
+    }
+    const unresolvedTarget = `${use.id}.${target}`;
+    unresolvedExitTargets.add(unresolvedTarget);
+    errors.push(
+      `workflow template instance ${use.id} at ${workflowPath} must map exit ${exitName}`
+    );
+    return unresolvedTarget;
+  }
+  return templateEntryTargets.get(mappedTarget) ?? mappedTarget;
+}
+
+function isTemplateTerminalState(
+  template: ParsedWorkflowTemplate,
+  stateId: string
+): boolean {
+  const state = template.states[stateId];
+  if (!isRecord(state)) {
+    return false;
+  }
+  const terminal = stringProperty(state, "terminal");
+  return terminal !== undefined && terminalStates.has(terminal);
 }
 
 function parseWorkflowState(
@@ -757,7 +1167,7 @@ function parseWorkflowState(
   workflowPath: string,
   errors: string[]
 ): ExpandedWorkflowState {
-  if (!/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(stateId)) {
+  if (!isPathSafeIdentifier(stateId)) {
     errors.push(
       `workflow state ${stateId} at ${workflowPath} must use a path-safe identifier`
     );
@@ -1065,6 +1475,208 @@ function recordProperty(
 ): Record<string, unknown> | undefined {
   const value = record[key];
   return isRecord(value) ? value : undefined;
+}
+
+function parseStringMap(
+  rawValue: unknown,
+  fieldLabel: string,
+  errors: string[]
+): Record<string, string> {
+  if (rawValue === undefined) {
+    return {};
+  }
+  if (!isRecord(rawValue)) {
+    errors.push(`${fieldLabel} must be a mapping`);
+    return {};
+  }
+  const values: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rawValue)) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      errors.push(`${fieldLabel}.${key} must be a non-empty string`);
+      continue;
+    }
+    values[key] = value.trim();
+  }
+  return values;
+}
+
+function parseUnknownMap(
+  rawValue: unknown,
+  fieldLabel: string,
+  errors: string[]
+): Record<string, unknown> {
+  if (rawValue === undefined) {
+    return {};
+  }
+  if (!isRecord(rawValue)) {
+    errors.push(`${fieldLabel} must be a mapping`);
+    return {};
+  }
+  return rawValue;
+}
+
+function resolveWorkflowTemplateInputs(
+  template: ParsedWorkflowTemplate,
+  use: WorkflowTemplateUse,
+  errors: string[]
+): Record<string, WorkflowTemplateScalar> {
+  const values: Record<string, WorkflowTemplateScalar> = {};
+
+  for (const key of Object.keys(use.withValues)) {
+    if (!Object.hasOwn(template.inputs, key)) {
+      errors.push(
+        `workflow template instance ${use.id} at ${template.path} supplies undeclared input ${key}`
+      );
+    }
+  }
+
+  for (const [name, input] of Object.entries(template.inputs)) {
+    const rawValue = Object.hasOwn(use.withValues, name)
+      ? use.withValues[name]
+      : input.defaultValue;
+    if (rawValue === undefined) {
+      errors.push(
+        `workflow template instance ${use.id} at ${template.path} must provide input ${name}`
+      );
+      continue;
+    }
+    const value = validateWorkflowTemplateInputValue(
+      name,
+      input.type,
+      rawValue,
+      template.path,
+      errors
+    );
+    if (value !== undefined) {
+      values[name] = value;
+    }
+  }
+
+  return values;
+}
+
+function validateWorkflowTemplateInputValue(
+  inputName: string,
+  inputType: WorkflowTemplateInputType,
+  value: unknown,
+  templatePath: string,
+  errors: string[]
+): WorkflowTemplateScalar | undefined {
+  if (inputType === "boolean") {
+    if (typeof value === "boolean") {
+      return value;
+    }
+  } else if (inputType === "number") {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  } else if (inputType === "provider") {
+    if (value === "codex" || value === "claude") {
+      return value;
+    }
+  } else if (typeof value === "string" && value.trim().length > 0) {
+    if (inputType !== "path" || !value.includes("\0")) {
+      return value.trim();
+    }
+  }
+
+  errors.push(
+    `workflow template input ${inputName} at ${templatePath} must be a ${inputType} scalar`
+  );
+  return undefined;
+}
+
+function interpolateWorkflowTemplateValue(
+  value: unknown,
+  inputValues: Record<string, WorkflowTemplateScalar>,
+  templatePath: string,
+  errors: string[]
+): unknown {
+  if (typeof value === "string") {
+    return interpolateWorkflowTemplateString(value, inputValues, templatePath, errors);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      interpolateWorkflowTemplateValue(item, inputValues, templatePath, errors)
+    );
+  }
+  if (isRecord(value)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      result[key] = interpolateWorkflowTemplateValue(
+        nested,
+        inputValues,
+        templatePath,
+        errors
+      );
+    }
+    return result;
+  }
+  return value;
+}
+
+function interpolateWorkflowTemplateString(
+  value: string,
+  inputValues: Record<string, WorkflowTemplateScalar>,
+  templatePath: string,
+  errors: string[]
+): WorkflowTemplateScalar {
+  const exact = /^{{\s*([^{}]+?)\s*}}$/.exec(value);
+  if (exact !== null) {
+    const expression = exact[1]?.trim() ?? "";
+    const input = workflowTemplateInputValue(expression, inputValues, templatePath, errors);
+    return input ?? value;
+  }
+
+  return value.replace(tagPattern, (_tag, expression) => {
+    const input = workflowTemplateInputValue(
+      String(expression).trim(),
+      inputValues,
+      templatePath,
+      errors
+    );
+    return input === undefined ? "" : String(input);
+  });
+}
+
+function workflowTemplateInputValue(
+  expression: string,
+  inputValues: Record<string, WorkflowTemplateScalar>,
+  templatePath: string,
+  errors: string[]
+): WorkflowTemplateScalar | undefined {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(expression)) {
+    errors.push(`workflow template at ${templatePath} has unsupported tag {{${expression}}}`);
+    return undefined;
+  }
+  if (!Object.hasOwn(inputValues, expression)) {
+    errors.push(
+      `workflow template at ${templatePath} references unknown input {{${expression}}}`
+    );
+    return undefined;
+  }
+  return inputValues[expression];
+}
+
+function isWorkflowTemplateInputType(
+  value: string | undefined
+): value is WorkflowTemplateInputType {
+  return (
+    value === "boolean" ||
+    value === "label" ||
+    value === "number" ||
+    value === "path" ||
+    value === "provider" ||
+    value === "string"
+  );
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function isPathSafeIdentifier(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_.-]*$/.test(value);
 }
 
 export async function persistRunEvidence(

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -811,10 +811,12 @@ async function expandRawStateMachineWorkflow(
     );
   }
   for (const state of states) {
-    state.transitions = state.transitions.map((transition) => ({
-      ...transition,
-      to: templateEntryTargets.get(transition.to) ?? transition.to
-    }));
+    if (rawStateIds.has(state.id)) {
+      state.transitions = state.transitions.map((transition) => ({
+        ...transition,
+        to: templateEntryTargets.get(transition.to) ?? transition.to
+      }));
+    }
     for (const transition of state.transitions) {
       if (!stateIds.has(transition.to) && !unresolvedTemplateExitTargets.has(transition.to)) {
         errors.push(

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1107,6 +1107,13 @@ function templateExitStateMap(
       errors.push(`workflow template state ${targetState} at ${template.path} must be a mapping`);
       continue;
     }
+    const existingExitName = exitStates.get(targetState);
+    if (existingExitName !== undefined) {
+      errors.push(
+        `workflow template at ${template.path} exits ${existingExitName} and ${exitName} both target state ${targetState}`
+      );
+      continue;
+    }
     const terminal = stringProperty(rawState, "terminal");
     if (terminal !== undefined && terminalStates.has(terminal)) {
       exitStates.set(targetState, exitName);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -489,6 +489,9 @@ describe("CLI", () => {
   it("explains the expanded workflow graph for a selected project", async () => {
     const root = await makeTempRoot();
     const configPath = path.join(root, "symphonika.yml");
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
     await writeFile(
       configPath,
       [
@@ -499,12 +502,13 @@ describe("CLI", () => {
       ].join("\n")
     );
     await writeFile(
-      path.join(root, "workflow.yml"),
+      templatePath,
       [
-        "workflow:",
-        "  name: issue_to_merge",
-        "  initial: planning",
-        "  states:",
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: pr_open",
+        "states:",
         "    planning:",
         "      action:",
         "        kind: agent",
@@ -513,7 +517,24 @@ describe("CLI", () => {
         "      complete_when:",
         "        artifact_exists: PLAN.md",
         "      transitions:",
-        "        - to: done",
+        "        - to: pr_open",
+        "    pr_open:",
+        "      exit: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      exits:",
+        "        success: done",
+        "  states:",
         "    done:",
         "      terminal: success",
         ""
@@ -545,7 +566,8 @@ describe("CLI", () => {
     expect(output.stderr).toBe("");
     expect(output.stdout).toContain("workflow: issue_to_merge");
     expect(output.stdout).toContain(`source: ${path.join(root, "workflow.yml")}`);
-    expect(output.stdout).toContain("state: planning");
+    expect(output.stdout).toContain(`template files: ${templatePath}`);
+    expect(output.stdout).toContain("state: build_pr.planning");
     expect(output.stdout).toContain(
       "action: agent provider=codex prompt=prompts/plan.md"
     );
@@ -787,6 +809,88 @@ describe("CLI", () => {
     );
     expect(output.stdout).toContain(`source: ${path.join(root, "WORKFLOW.md")}`);
     expect(output.stdout).toContain("states: 2");
+  });
+
+  it("validates a template-backed workflow and prints the expanded graph", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
+    await writeFile(
+      configPath,
+      [
+        "projects:",
+        "  - name: symphonika",
+        "    workflow: ./workflow.yml",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      templatePath,
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: pr_open",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: pr_open",
+        "  pr_open:",
+        "    exit: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      exits:",
+        "        success: done",
+        "  states:",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({ registerSignalHandlers: false });
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "workflow",
+      "validate",
+      "--config",
+      configPath,
+      "--project",
+      "symphonika"
+    ]);
+
+    expect(output.stderr).toBe("");
+    expect(output.stdout).toContain("workflow validate ok: symphonika -> issue_to_merge");
+    expect(output.stdout).toContain(`template files: ${templatePath}`);
+    expect(output.stdout).toContain("state: build_pr.planning");
+    expect(output.stdout).not.toContain("state: pr_open");
   });
 
   it("explains the compatibility graph for a Markdown WORKFLOW.md", async () => {

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -175,4 +175,107 @@ describe("RuntimeConfigReloader workflow validation", () => {
       "done"
     ]);
   });
+
+  it("stores template-expanded raw FSM snapshots and refreshes when a template changes", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "workflow.yml");
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      exits:",
+        "        success: done",
+        "  states:",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await writeFile(
+      templatePath,
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: pr_open",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: pr_open",
+        "  pr_open:",
+        "    exit: success",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+
+    const reloader = new RuntimeConfigReloader({
+      configPath: path.join(root, "symphonika.yml")
+    });
+    await reloader.reload();
+    const firstWorkflow = reloader.projectsByName().get("symphonika")?.workflow;
+    if (firstWorkflow === undefined || !("expandedWorkflow" in firstWorkflow)) {
+      throw new Error("expected workflow snapshot to be an object");
+    }
+    const firstHash = firstWorkflow.expandedWorkflow.contentHash;
+
+    expect(firstWorkflow.expandedWorkflow.templateFiles).toEqual([templatePath]);
+    expect(firstWorkflow.expandedWorkflow.states.map((state) => state.id)).toEqual([
+      "done",
+      "build_pr.planning"
+    ]);
+
+    await writeFile(
+      templatePath,
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: pr_open",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/revised-plan.md",
+        "    transitions:",
+        "      - to: pr_open",
+        "  pr_open:",
+        "    exit: success",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await reloader.reload();
+    const secondWorkflow = reloader.projectsByName().get("symphonika")?.workflow;
+    if (secondWorkflow === undefined || !("expandedWorkflow" in secondWorkflow)) {
+      throw new Error("expected workflow snapshot to be an object");
+    }
+
+    expect(secondWorkflow.expandedWorkflow.contentHash).not.toBe(firstHash);
+    expect(secondWorkflow.expandedWorkflow.states).toContainEqual({
+      action: {
+        kind: "agent",
+        prompt: "prompts/revised-plan.md",
+        provider: "codex"
+      },
+      completeWhen: {},
+      id: "build_pr.planning",
+      transitions: [{ to: "done", when: {} }]
+    });
+  });
 });

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -674,6 +674,69 @@ describe("state machine workflow definitions", () => {
     });
   });
 
+  it("does not rewrite expanded template transitions as instance targets", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      path.join(templateDir, "build.yml"),
+      [
+        "name: build",
+        "entry: planning",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: pr",
+        "  pr:",
+        "    terminal: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      path.join(templateDir, "followup.yml"),
+      [
+        "name: followup",
+        "entry: start",
+        "states:",
+        "  start:",
+        "    terminal: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build",
+        "  use:",
+        "    build:",
+        "      template: .symphonika/workflow-templates/build.yml",
+        "    build.pr:",
+        "      template: .symphonika/workflow-templates/followup.yml",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow.states.map((state) => state.id)).toEqual([
+      "build.planning",
+      "build.pr",
+      "build.pr.start"
+    ]);
+    expect(result.workflow.states[0]).toMatchObject({
+      id: "build.planning",
+      transitions: [{ to: "build.pr", when: {} }]
+    });
+  });
+
   it("rejects workflow instance mappings for undeclared template exits", async () => {
     const root = await makeTempRoot();
     const templateDir = path.join(root, ".symphonika", "workflow-templates");

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -623,6 +623,57 @@ describe("state machine workflow definitions", () => {
     ]);
   });
 
+  it("resolves raw workflow transitions that target template instances", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      path.join(templateDir, "plan-tdd-pr.yml"),
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: done",
+        "  done:",
+        "    terminal: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: triage",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "  states:",
+        "    triage:",
+        "      action:",
+        "        kind: wait",
+        "      transitions:",
+        "        - to: build_pr",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow.states[0]).toMatchObject({
+      id: "triage",
+      transitions: [{ to: "build_pr.planning", when: {} }]
+    });
+  });
+
   it("rejects workflow instance mappings for undeclared template exits", async () => {
     const root = await makeTempRoot();
     const templateDir = path.join(root, ".symphonika", "workflow-templates");

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -428,6 +428,459 @@ describe("state machine workflow definitions", () => {
         }
       ]
     });
+  });
+
+  it("expands repo-local workflow templates into a prefixed raw FSM graph", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
+    await writeFile(
+      templatePath,
+      [
+        "name: plan_tdd_pr",
+        "inputs:",
+        "  planner:",
+        "    type: provider",
+        "    default: codex",
+        "  plan_prompt:",
+        "    type: path",
+        "    default: prompts/plan.md",
+        "entry: planning",
+        "exits:",
+        "  success: pr_open",
+        "  blocked: blocked",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: \"{{ planner }}\"",
+        "      prompt: \"{{ plan_prompt }}\"",
+        "    complete_when:",
+        "      artifact_exists: PLAN.md",
+        "    transitions:",
+        "      - to: pr_open",
+        "  pr_open:",
+        "    exit: success",
+        "  blocked:",
+        "    exit: blocked",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      with:",
+        "        planner: claude",
+        "        plan_prompt: prompts/custom-plan.md",
+        "      exits:",
+        "        success: done",
+        "        blocked: needs_operator",
+        "  states:",
+        "    done:",
+        "      terminal: success",
+        "    needs_operator:",
+        "      terminal: blocked",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+    const explanation = explainWorkflow(result.workflow);
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow.initial).toBe("build_pr.planning");
+    expect(result.workflow.templateFiles).toEqual([templatePath]);
+    expect(result.workflow.states.map((state) => state.id)).toEqual([
+      "done",
+      "needs_operator",
+      "build_pr.planning"
+    ]);
+    expect(result.workflow.states).toContainEqual({
+      action: {
+        kind: "agent",
+        prompt: "prompts/custom-plan.md",
+        provider: "claude"
+      },
+      completeWhen: {
+        artifact_exists: "PLAN.md"
+      },
+      id: "build_pr.planning",
+      transitions: [{ to: "done", when: {} }]
+    });
+    expect(explanation).toContain(`template files: ${templatePath}`);
+    expect(explanation).toContain("state: build_pr.planning");
+    expect(explanation).not.toContain("state: pr_open");
+  });
+
+  it("rejects template exits that are not mapped by the workflow instance", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      path.join(templateDir, "plan-tdd-pr.yml"),
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: pr_open",
+        "  blocked: blocked",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: blocked",
+        "  pr_open:",
+        "    exit: success",
+        "  blocked:",
+        "    exit: blocked",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      exits:",
+        "        success: done",
+        "  states:",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([
+      `workflow template instance build_pr at ${workflowPath} must map exit blocked`
+    ]);
+  });
+
+  it("rejects workflow instance mappings for undeclared template exits", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
+    await writeFile(
+      templatePath,
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: pr_open",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: pr_open",
+        "  pr_open:",
+        "    exit: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      exits:",
+        "        success: done",
+        "        exhausted: needs_operator",
+        "  states:",
+        "    done:",
+        "      terminal: success",
+        "    needs_operator:",
+        "      terminal: blocked",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([
+      `workflow template instance build_pr at ${workflowPath} maps undeclared exit exhausted from ${templatePath}`
+    ]);
+  });
+
+  it("rejects undeclared and non-scalar template inputs", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
+    await writeFile(
+      templatePath,
+      [
+        "name: plan_tdd_pr",
+        "inputs:",
+        "  planner:",
+        "    type: provider",
+        "  branch_label:",
+        "    type: label",
+        "  retries:",
+        "    type: number",
+        "    default: 1",
+        "entry: planning",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      with:",
+        "        planner: gemini",
+        "        branch_label:",
+        "          - agent-ready",
+        "        extra: true",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([
+      `workflow template instance build_pr at ${templatePath} supplies undeclared input extra`,
+      `workflow template input planner at ${templatePath} must be a provider scalar`,
+      `workflow template input branch_label at ${templatePath} must be a label scalar`
+    ]);
+  });
+
+  it("rejects template interpolation that references undeclared inputs", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
+    await writeFile(
+      templatePath,
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: \"{{ missing_prompt }}\"",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([
+      `workflow template at ${templatePath} references unknown input {{missing_prompt}}`
+    ]);
+  });
+
+  it("rejects template-internal transitions that bypass declared exits", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
+    await writeFile(
+      templatePath,
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: pr_open",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: done",
+        "  pr_open:",
+        "    exit: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      exits:",
+        "        success: done",
+        "  states:",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([
+      `workflow template state planning at ${templatePath} transitions to done outside declared exits`
+    ]);
+  });
+
+  it("allows unmapped template exits that target a terminal state inside the template", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      path.join(templateDir, "plan-tdd-pr.yml"),
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: done",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: done",
+        "  done:",
+        "    terminal: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow.initial).toBe("build_pr.planning");
+    expect(result.workflow.states.map((state) => state.id)).toEqual([
+      "build_pr.planning",
+      "build_pr.done"
+    ]);
+    expect(result.workflow.states[0]?.transitions).toEqual([
+      { to: "build_pr.done", when: {} }
+    ]);
+    expect(result.workflow.states[1]).toMatchObject({
+      id: "build_pr.done",
+      terminal: "success"
+    });
+  });
+
+  it("uses explicit workflow mappings for terminal template exits when provided", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      path.join(templateDir, "plan-tdd-pr.yml"),
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: done",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: done",
+        "  done:",
+        "    terminal: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      exits:",
+        "        success: reviewed",
+        "  states:",
+        "    reviewed:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow.states.map((state) => state.id)).toEqual([
+      "reviewed",
+      "build_pr.planning"
+    ]);
+    expect(result.workflow.states[1]?.transitions).toEqual([
+      { to: "reviewed", when: {} }
+    ]);
   });
 
   it("loads and explains an explicit raw FSM workflow", async () => {

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -984,6 +984,61 @@ describe("state machine workflow definitions", () => {
     ]);
   });
 
+  it("rejects duplicate template exits that target the same terminal state", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
+    await writeFile(
+      templatePath,
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "exits:",
+        "  success: done",
+        "  blocked: done",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: done",
+        "  done:",
+        "    terminal: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "      exits:",
+        "        success: reviewed",
+        "        blocked: needs_operator",
+        "  states:",
+        "    reviewed:",
+        "      terminal: success",
+        "    needs_operator:",
+        "      terminal: blocked",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([
+      `workflow template at ${templatePath} exits success and blocked both target state done`
+    ]);
+  });
+
   it("loads and explains an explicit raw FSM workflow", async () => {
     const root = await makeTempRoot();
     const workflowPath = path.join(root, "workflow.yml");

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -573,6 +573,56 @@ describe("state machine workflow definitions", () => {
     ]);
   });
 
+  it("rejects template-expanded state IDs that collide with workflow states", async () => {
+    const root = await makeTempRoot();
+    const templateDir = path.join(root, ".symphonika", "workflow-templates");
+    await mkdir(templateDir, { recursive: true });
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      path.join(templateDir, "plan-tdd-pr.yml"),
+      [
+        "name: plan_tdd_pr",
+        "entry: planning",
+        "states:",
+        "  planning:",
+        "    action:",
+        "      kind: agent",
+        "      provider: codex",
+        "      prompt: prompts/plan.md",
+        "    transitions:",
+        "      - to: done",
+        "  done:",
+        "    terminal: success",
+        ""
+      ].join("\n")
+    );
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: issue_to_merge",
+        "  initial: build_pr",
+        "  use:",
+        "    build_pr:",
+        "      template: .symphonika/workflow-templates/plan-tdd-pr.yml",
+        "  states:",
+        "    build_pr.planning:",
+        "      terminal: blocked",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([
+      `workflow template instance build_pr at ${workflowPath} expands state build_pr.planning that conflicts with an existing workflow state`
+    ]);
+    expect(result.workflow.states.map((state) => state.id)).toEqual([
+      "build_pr.planning",
+      "build_pr.done"
+    ]);
+  });
+
   it("rejects workflow instance mappings for undeclared template exits", async () => {
     const root = await makeTempRoot();
     const templateDir = path.join(root, ".symphonika", "workflow-templates");


### PR DESCRIPTION
## Summary
- add repo-local workflow template expansion for raw FSM workflows
- validate typed scalar inputs, strict interpolation, prefixed internal state names, and declared exits
- show template files and fully expanded graphs through validate/explain and reload snapshots

## Validation
- npm test -- tests/workflow.test.ts tests/cli.test.ts tests/reload.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test
- git diff --check
- npm run dev -- workflow validate --config symphonika.yml --project symphonika

Closes #98