### PR TITLE
Validate raw FSM prompt files at load time

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -13,7 +13,10 @@ import {
 import { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
-import { loadExpandedWorkflow } from "./workflow.js";
+import {
+  loadExpandedWorkflow,
+  validateExpandedWorkflowReferences
+} from "./workflow.js";
 
 export { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
 
@@ -289,7 +292,10 @@ async function collectWorkflowErrors(
 ): Promise<string[]> {
   try {
     const expanded = await loadExpandedWorkflow(workflowPath, format);
-    return expanded.errors;
+    if (expanded.errors.length > 0) {
+      return expanded.errors;
+    }
+    return validateExpandedWorkflowReferences(expanded.workflow, workflowPath);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return [`workflow contract not found at ${workflowPath}: ${message}`];

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -24,7 +24,8 @@ import {
 } from "./pull-request-followup.js";
 import {
   expandWorkflowDefinition,
-  parseWorkflowContract
+  parseWorkflowContract,
+  validateExpandedWorkflowReferences
 } from "./workflow.js";
 
 export type RuntimeConfigSnapshot = {
@@ -364,6 +365,14 @@ async function readWorkflowSnapshot(
   if (expanded.workflow.source.kind === "raw_fsm") {
     if (expanded.errors.length > 0) {
       errors.push(...expanded.errors);
+      return undefined;
+    }
+    const referenceErrors = await validateExpandedWorkflowReferences(
+      expanded.workflow,
+      workflowPath
+    );
+    if (referenceErrors.length > 0) {
+      errors.push(...referenceErrors);
       return undefined;
     }
     return {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parse } from "yaml";
 import type { WorkflowFormat } from "./config-schemas.js";
@@ -305,6 +305,32 @@ export async function loadExpandedWorkflow(
 ): Promise<ExpandedWorkflowLoadResult> {
   const contents = await readFile(workflowPath, "utf8");
   return expandWorkflowDefinition(contents, workflowPath, format);
+}
+
+export async function validateExpandedWorkflowReferences(
+  workflow: ExpandedWorkflow,
+  workflowPath: string
+): Promise<string[]> {
+  if (workflow.source.kind !== "raw_fsm") {
+    return [];
+  }
+  const workflowDir = path.dirname(workflowPath);
+  const errors: string[] = [];
+  for (const state of workflow.states) {
+    const action = state.action;
+    if (action?.kind !== "agent" || typeof action.prompt !== "string") {
+      continue;
+    }
+    const promptPath = path.resolve(workflowDir, action.prompt);
+    try {
+      await stat(promptPath);
+    } catch (error) {
+      errors.push(
+        `workflow state ${state.id} prompt not found at ${promptPath}: ${errorMessage(error)}`
+      );
+    }
+  }
+  return errors;
 }
 
 export async function loadProjectWorkflow(input: {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parse } from "yaml";
 import type { WorkflowFormat } from "./config-schemas.js";
@@ -323,12 +323,7 @@ export async function validateExpandedWorkflowReferences(
     }
     const promptPath = path.resolve(workflowDir, action.prompt);
     try {
-      const stats = await stat(promptPath);
-      if (!stats.isFile()) {
-        errors.push(
-          `workflow state ${state.id} prompt not found at ${promptPath}: path is not a regular file`
-        );
-      }
+      await readFile(promptPath, "utf8");
     } catch (error) {
       errors.push(
         `workflow state ${state.id} prompt not found at ${promptPath}: ${errorMessage(error)}`

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -323,7 +323,12 @@ export async function validateExpandedWorkflowReferences(
     }
     const promptPath = path.resolve(workflowDir, action.prompt);
     try {
-      await stat(promptPath);
+      const stats = await stat(promptPath);
+      if (!stats.isFile()) {
+        errors.push(
+          `workflow state ${state.id} prompt not found at ${promptPath}: path is not a regular file`
+        );
+      }
     } catch (error) {
       errors.push(
         `workflow state ${state.id} prompt not found at ${promptPath}: ${errorMessage(error)}`

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -299,6 +299,40 @@ describe("doctor", () => {
     expect(output.stderr).toContain("unknown variable");
     expect(output.stderr).toContain("{{ticket.title}}");
   });
+
+  it("rejects raw FSM workflows whose agent prompt files are missing on disk", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath, { workflowPath: "./workflow.yml" });
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: missing_prompt",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: agent",
+        "        provider: codex",
+        "        prompt: prompts/plan.md",
+        "      complete_when:",
+        "        artifact_exists: PLAN.md",
+        "      transitions:",
+        "        - to: done",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stderr).toContain("prompt not found");
+    expect(output.stderr).toContain("planning");
+  });
 });
 
 async function runDoctorCommand(

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -104,9 +104,53 @@ describe("RuntimeConfigReloader workflow validation", () => {
     expect(reloader.projectsByName().has("symphonika")).toBe(false);
   });
 
+  it("rejects raw FSM workflows whose agent prompt files do not exist on disk", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "workflow.yml");
+    await writeFile(
+      path.join(root, "workflow.yml"),
+      [
+        "workflow:",
+        "  name: missing_prompt",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: agent",
+        "        provider: codex",
+        "        prompt: prompts/missing.md",
+        "      complete_when:",
+        "        artifact_exists: PLAN.md",
+        "      transitions:",
+        "        - to: done",
+        "    done:",
+        "      terminal: success",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+
+    const reloader = new RuntimeConfigReloader({
+      configPath: path.join(root, "symphonika.yml")
+    });
+    await reloader.reload();
+    const status = reloader.getStatus();
+
+    expect(status.ok).toBe(false);
+    expect(
+      status.errors.some((message) => message.includes("prompt not found"))
+    ).toBe(true);
+    expect(
+      status.errors.some((message) => message.includes("planning"))
+    ).toBe(true);
+    expect(reloader.projectsByName().has("symphonika")).toBe(false);
+  });
+
   it("accepts a valid raw FSM workflow at reload time", async () => {
     const root = await makeTempRoot();
     await writeProjectConfig(root, "workflow.yml");
+    await mkdir(path.join(root, "prompts"), { recursive: true });
+    await writeFile(path.join(root, "prompts/plan.md"), "Plan the work.\n", "utf8");
     await writeFile(
       path.join(root, "workflow.yml"),
       [
@@ -181,6 +225,9 @@ describe("RuntimeConfigReloader workflow validation", () => {
     await writeProjectConfig(root, "workflow.yml");
     const templateDir = path.join(root, ".symphonika", "workflow-templates");
     await mkdir(templateDir, { recursive: true });
+    await mkdir(path.join(root, "prompts"), { recursive: true });
+    await writeFile(path.join(root, "prompts/plan.md"), "Plan.\n", "utf8");
+    await writeFile(path.join(root, "prompts/revised-plan.md"), "Revised plan.\n", "utf8");
     const workflowPath = path.join(root, "workflow.yml");
     const templatePath = path.join(templateDir, "plan-tdd-pr.yml");
     await writeFile(

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -8,8 +8,10 @@ import {
   loadExpandedWorkflow,
   loadWorkflowContract,
   persistRunEvidence,
-  renderAutonomousPrompt
+  renderAutonomousPrompt,
+  validateExpandedWorkflowReferences
 } from "../src/workflow.js";
+import type { ExpandedWorkflow } from "../src/workflow.js";
 
 const tempRoots: string[] = [];
 const DEFAULT_CODEX_COMMAND = `codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server`;
@@ -1688,6 +1690,124 @@ describe("workflow format routing", () => {
         )
       )
     ).toBe(true);
+  });
+});
+
+describe("validateExpandedWorkflowReferences", () => {
+  it("returns no errors when every raw FSM agent prompt resolves to an existing file", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    const promptRelPath = "prompts/plan.md";
+    await mkdir(path.join(root, "prompts"), { recursive: true });
+    await writeFile(path.join(root, promptRelPath), "Plan the work.\n");
+
+    const workflow: ExpandedWorkflow = {
+      contentHash: "sha256:placeholder",
+      initial: "planning",
+      name: "valid",
+      source: { kind: "raw_fsm", path: workflowPath },
+      states: [
+        {
+          action: { kind: "agent", provider: "codex", prompt: promptRelPath },
+          completeWhen: {},
+          id: "planning",
+          transitions: [{ to: "done", when: {} }]
+        },
+        { completeWhen: {}, id: "done", terminal: "success", transitions: [] }
+      ],
+      templateFiles: []
+    };
+
+    const errors = await validateExpandedWorkflowReferences(workflow, workflowPath);
+    expect(errors).toEqual([]);
+  });
+
+  it("reports a missing raw FSM agent prompt with the state id and resolved path", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    const promptRelPath = "prompts/missing.md";
+
+    const workflow: ExpandedWorkflow = {
+      contentHash: "sha256:placeholder",
+      initial: "planning",
+      name: "missing_prompt",
+      source: { kind: "raw_fsm", path: workflowPath },
+      states: [
+        {
+          action: { kind: "agent", provider: "codex", prompt: promptRelPath },
+          completeWhen: {},
+          id: "planning",
+          transitions: [{ to: "done", when: {} }]
+        },
+        { completeWhen: {}, id: "done", terminal: "success", transitions: [] }
+      ],
+      templateFiles: []
+    };
+
+    const errors = await validateExpandedWorkflowReferences(workflow, workflowPath);
+    expect(errors).toHaveLength(1);
+    const expectedPath = path.resolve(root, promptRelPath);
+    expect(errors[0]).toContain("planning");
+    expect(errors[0]).toContain("prompt not found");
+    expect(errors[0]).toContain(expectedPath);
+  });
+
+  it("aggregates one error per missing prompt across multiple agent states", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+
+    const workflow: ExpandedWorkflow = {
+      contentHash: "sha256:placeholder",
+      initial: "plan",
+      name: "two_missing",
+      source: { kind: "raw_fsm", path: workflowPath },
+      states: [
+        {
+          action: { kind: "agent", provider: "codex", prompt: "prompts/plan.md" },
+          completeWhen: {},
+          id: "plan",
+          transitions: [{ to: "build", when: {} }]
+        },
+        {
+          action: { kind: "agent", provider: "codex", prompt: "prompts/build.md" },
+          completeWhen: {},
+          id: "build",
+          transitions: [{ to: "done", when: {} }]
+        },
+        { completeWhen: {}, id: "done", terminal: "success", transitions: [] }
+      ],
+      templateFiles: []
+    };
+
+    const errors = await validateExpandedWorkflowReferences(workflow, workflowPath);
+    expect(errors).toHaveLength(2);
+    expect(errors.some((message) => message.includes("plan"))).toBe(true);
+    expect(errors.some((message) => message.includes("build"))).toBe(true);
+  });
+
+  it("skips validation for markdown-sourced workflows", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "WORKFLOW.md");
+
+    const workflow: ExpandedWorkflow = {
+      contentHash: "sha256:placeholder",
+      initial: "run_agent",
+      name: "markdown_workflow",
+      source: { kind: "markdown", path: workflowPath },
+      states: [
+        {
+          action: { kind: "agent", provider: "codex", prompt: "prompts/never.md" },
+          completeWhen: {},
+          id: "run_agent",
+          transitions: [{ to: "done", when: {} }]
+        },
+        { completeWhen: {}, id: "done", terminal: "success", transitions: [] }
+      ],
+      templateFiles: []
+    };
+
+    const errors = await validateExpandedWorkflowReferences(workflow, workflowPath);
+    expect(errors).toEqual([]);
   });
 });
 

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1785,6 +1785,37 @@ describe("validateExpandedWorkflowReferences", () => {
     expect(errors.some((message) => message.includes("build"))).toBe(true);
   });
 
+  it("reports an error when a raw FSM agent prompt path resolves to a directory", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    const promptRelPath = "prompts/dir-not-file";
+    await mkdir(path.join(root, promptRelPath), { recursive: true });
+
+    const workflow: ExpandedWorkflow = {
+      contentHash: "sha256:placeholder",
+      initial: "planning",
+      name: "directory_target",
+      source: { kind: "raw_fsm", path: workflowPath },
+      states: [
+        {
+          action: { kind: "agent", provider: "codex", prompt: promptRelPath },
+          completeWhen: {},
+          id: "planning",
+          transitions: [{ to: "done", when: {} }]
+        },
+        { completeWhen: {}, id: "done", terminal: "success", transitions: [] }
+      ],
+      templateFiles: []
+    };
+
+    const errors = await validateExpandedWorkflowReferences(workflow, workflowPath);
+    expect(errors).toHaveLength(1);
+    const expectedPath = path.resolve(root, promptRelPath);
+    expect(errors[0]).toContain("planning");
+    expect(errors[0]).toContain("prompt not found");
+    expect(errors[0]).toContain(expectedPath);
+  });
+
   it("skips validation for markdown-sourced workflows", async () => {
     const root = await makeTempRoot();
     const workflowPath = path.join(root, "WORKFLOW.md");


### PR DESCRIPTION
## Summary
- New `validateExpandedWorkflowReferences(workflow, workflowPath)` in `src/workflow.ts` stats every raw FSM agent state's `action.prompt` (resolved against the workflow directory) and returns one error per missing/unreadable file.
- `doctor.collectWorkflowErrors` and `reload.readWorkflowSnapshot` now invoke the validator after the schema check passes, so misconfigured prompt paths surface up front instead of being discovered inside `runAttemptLifecycle` after an issue has already been claimed.
- The runtime `readFile`-and-throw in `run-controller.ts` is left untouched as defense-in-depth — covers the validate→dispatch race and the `WorkflowSnapshot` reuse short-circuit.

Closes #107.

## Test plan
- [x] `npx vitest run tests/workflow.test.ts` — 4 new unit tests (happy path, missing prompt, multi-state aggregation, markdown-skip gate).
- [x] `npx vitest run tests/doctor.test.ts` — new integration test asserts `doctor` exits 1 with `"prompt not found"` on a raw FSM workflow whose prompt is missing.
- [x] `npx vitest run tests/reload.test.ts` — new integration test asserts `RuntimeConfigReloader` reports `status.ok=false`, surfaces the error, and does not register the project. (Two pre-existing reload tests had to land a real `prompts/plan.md` fixture to keep passing — they had been referencing a non-existent file.)
- [x] `npm test` — 387 tests pass. The only failing file (`tests/property-invariants.test.ts`) is a pre-existing missing `fast-check` install, unrelated to this change.
- [x] `npx eslint` + `npx tsc --noEmit` clean on every touched file.