### PR TITLE
Honor raw FSM failure/blocked terminal labels in run state

### DIFF
--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -220,6 +220,7 @@ type WorkflowOutcomeResult = {
   advancedToTerminal: boolean;
   blocked: boolean;
   parkAsWait?: boolean;
+  terminalLabel?: "success" | "failure" | "blocked";
   waitingRunId?: string;
 };
 
@@ -1395,15 +1396,6 @@ export class RunController {
               }
             })
       });
-      const outcomeState = mapOutcomeToRunState(terminal);
-      if (attemptCreated) {
-        this.runStore.updateAttemptState(attemptId, outcomeState);
-      }
-      this.runStore.recordTerminalReason(
-        input.runId,
-        terminal.reason,
-        terminal.classification
-      );
       let workflowOutcome: WorkflowOutcomeResult = {
         advancedToState: null,
         advancedToTerminal: false,
@@ -1419,6 +1411,19 @@ export class RunController {
           workflow: loadedWorkflow.expandedWorkflow
         });
       }
+      const effectiveOutcome = fuseWorkflowTerminal(
+        terminal,
+        workflowOutcome.terminalLabel
+      );
+      const outcomeState = mapOutcomeToRunState(effectiveOutcome);
+      if (attemptCreated) {
+        this.runStore.updateAttemptState(attemptId, outcomeState);
+      }
+      this.runStore.recordTerminalReason(
+        input.runId,
+        effectiveOutcome.reason,
+        effectiveOutcome.classification
+      );
       const sourceKind = loadedWorkflow.expandedWorkflow.source.kind;
       const isRawFsm = sourceKind === "raw_fsm";
       const suppressContinuation =
@@ -1429,8 +1434,8 @@ export class RunController {
       this.runStore.updateRunState(input.runId, outcomeState);
 
       const willRetry =
-        terminal.kind === "failed" &&
-        terminal.classification === "transient" &&
+        effectiveOutcome.kind === "failed" &&
+        effectiveOutcome.classification === "transient" &&
         this.runStore.runRetryCount(input.runId) < this.lifecyclePolicy.retry.cap;
 
       this.logger?.info(
@@ -1438,22 +1443,23 @@ export class RunController {
           attemptNumber: input.attemptNumber,
           cancelReason,
           cancelRequested,
-          classification: terminal.classification,
+          classification: effectiveOutcome.classification,
           isContinuation: input.isContinuation,
           issueNumber: input.issue.number,
-          kind: terminal.kind,
+          kind: effectiveOutcome.kind,
           project: input.project.name,
           runId: input.runId,
           state: outcomeState,
-          terminalReason: terminal.reason,
-          willRetry
+          terminalReason: effectiveOutcome.reason,
+          willRetry,
+          workflowTerminalLabel: workflowOutcome.terminalLabel
         },
         "symphonika run terminated"
       );
 
       const labelInput: ApplyLabelsInput = {
         issueNumber: input.issue.number,
-        outcome: terminal,
+        outcome: effectiveOutcome,
         repository: input.repository,
         willRetry
       };
@@ -1470,7 +1476,7 @@ export class RunController {
             ? {}
             : { extraInstructions: input.extraInstructions }),
           issue: input.issue,
-          outcome: terminal,
+          outcome: effectiveOutcome,
           project: input.project,
           repository: input.repository,
           respectsIssueLabels,
@@ -1625,7 +1631,13 @@ export class RunController {
           terminalStateId: next.id,
           transitionReason: decision.reason
         });
-        return { advancedToState: null, advancedToTerminal: true, blocked: false };
+        const terminalLabel = narrowTerminalLabel(next.terminal);
+        return {
+          advancedToState: null,
+          advancedToTerminal: true,
+          blocked: false,
+          ...(terminalLabel === undefined ? {} : { terminalLabel })
+        };
       }
       this.runStore.recordWorkflowStateAdvance(input.runId, {
         nextStateId: decision.to,
@@ -1668,7 +1680,13 @@ export class RunController {
         terminalStateId: decision.stateId,
         transitionReason: `entered terminal state ${decision.terminal}`
       });
-      return { advancedToState: null, advancedToTerminal: true, blocked: false };
+      const terminalLabel = narrowTerminalLabel(decision.terminal);
+      return {
+        advancedToState: null,
+        advancedToTerminal: true,
+        blocked: false,
+        ...(terminalLabel === undefined ? {} : { terminalLabel })
+      };
     }
 
     return { advancedToState: null, advancedToTerminal: false, blocked: false };
@@ -2222,6 +2240,40 @@ function mapOutcomeToRunState(outcome: ClassifiedTerminal): RunState {
     default:
       return "failed";
   }
+}
+
+function narrowTerminalLabel(
+  value: string | undefined
+): "success" | "failure" | "blocked" | undefined {
+  if (value === "success" || value === "failure" || value === "blocked") {
+    return value;
+  }
+  return undefined;
+}
+
+// When a raw FSM walks to a `failure` or `blocked` terminal node, the workflow
+// author has declared the run is a deterministic failure regardless of the
+// provider's exit code. Synthesize that classification so downstream code
+// (state write, terminal_reason, sym:failed label, scheduleNext) all observe
+// the workflow's verdict. Cancellation and input_required always win — they
+// reflect operator/system intent that an FSM terminal label cannot override.
+// This intentionally pre-empts the transient-retry policy for workflow-driven
+// failures.
+function fuseWorkflowTerminal(
+  terminal: ClassifiedTerminal,
+  terminalLabel: "success" | "failure" | "blocked" | undefined
+): ClassifiedTerminal {
+  if (terminal.kind === "cancelled" || terminal.kind === "input_required") {
+    return terminal;
+  }
+  if (terminalLabel !== "failure" && terminalLabel !== "blocked") {
+    return terminal;
+  }
+  return {
+    classification: "deterministic",
+    kind: "failed",
+    reason: `workflow_terminal_${terminalLabel}`
+  };
 }
 
 function isLabelWritingGitHubIssuesApi(

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1367,6 +1367,192 @@ describe("daemon dispatch", () => {
       await daemon.stop();
     }
   });
+
+  it("walks a raw FSM workflow to a terminal failure node and records the run as failed", async () => {
+    const root = await makeTempRoot();
+    await writeFailureTerminalRawFsmProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 8,
+            title: "Dispatch an end-to-end run through a test provider"
+          })
+        ])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => "run-raw-fsm-terminal-failure",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 0 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "failed");
+      // Wait beyond continuation delay to confirm no follow-up run is dispatched.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const run = firstRun(status);
+      expect(run).toMatchObject({
+        id: "run-raw-fsm-terminal-failure",
+        issueNumber: 8,
+        state: "failed"
+      });
+
+      const finalStatus = (await fetch(`${daemon.url}/api/status`).then((r) =>
+        r.json()
+      )) as { runs: StatusRun[] };
+      expect(finalStatus.runs).toHaveLength(1);
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const storedRun = database
+          .prepare(
+            [
+              "select state, current_state_id, terminal_state_id,",
+              "terminal_reason, failure_classification from runs",
+              "where id = ?"
+            ].join(" ")
+          )
+          .get("run-raw-fsm-terminal-failure");
+        expect(storedRun).toMatchObject({
+          state: "failed",
+          current_state_id: null,
+          terminal_state_id: "done",
+          terminal_reason: "workflow_terminal_failure",
+          failure_classification: "deterministic"
+        });
+      } finally {
+        database.close();
+      }
+
+      // The workflow drove the failure (not a transient provider crash) so
+      // the issue must end up with sym:failed applied.
+      const failedLabelCalls = githubIssuesApi.addLabelsToIssue.mock.calls.filter(
+        (call) => {
+          const arg = call[0] as { labels?: string[] } | undefined;
+          return arg?.labels?.includes("sym:failed") ?? false;
+        }
+      );
+      expect(failedLabelCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  // Distinct from the "no transition matching observed signals" test above,
+  // which exercises decideNextStep returning `kind: "blocked"` without ever
+  // entering a terminal node — that case still records state="succeeded"
+  // because the workflow merely stalled. This test exercises the explicit
+  // `terminal: blocked` node path, which is a workflow-author-declared failure.
+  it("walks a raw FSM workflow to a terminal blocked node and records the run as failed", async () => {
+    const root = await makeTempRoot();
+    await writeBlockedTerminalRawFsmProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 8,
+            title: "Dispatch an end-to-end run through a test provider"
+          })
+        ])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => "run-raw-fsm-terminal-blocked",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 0 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "failed");
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const run = firstRun(status);
+      expect(run).toMatchObject({
+        id: "run-raw-fsm-terminal-blocked",
+        issueNumber: 8,
+        state: "failed"
+      });
+
+      const finalStatus = (await fetch(`${daemon.url}/api/status`).then((r) =>
+        r.json()
+      )) as { runs: StatusRun[] };
+      expect(finalStatus.runs).toHaveLength(1);
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const storedRun = database
+          .prepare(
+            [
+              "select state, current_state_id, terminal_state_id,",
+              "terminal_reason, failure_classification from runs",
+              "where id = ?"
+            ].join(" ")
+          )
+          .get("run-raw-fsm-terminal-blocked");
+        expect(storedRun).toMatchObject({
+          state: "failed",
+          current_state_id: null,
+          terminal_state_id: "done",
+          terminal_reason: "workflow_terminal_blocked",
+          failure_classification: "deterministic"
+        });
+      } finally {
+        database.close();
+      }
+
+      const failedLabelCalls = githubIssuesApi.addLabelsToIssue.mock.calls.filter(
+        (call) => {
+          const arg = call[0] as { labels?: string[] } | undefined;
+          return arg?.labels?.includes("sym:failed") ?? false;
+        }
+      );
+      expect(failedLabelCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
 });
 
 function issueFixture(overrides: {
@@ -1507,6 +1693,66 @@ async function writeRawFsmProject(root: string): Promise<void> {
       "        - to: done",
       "    done:",
       "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "prompt.md"),
+    "Work on #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+async function writeFailureTerminalRawFsmProject(root: string): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: failure_terminal",
+      "  initial: run_agent",
+      "  states:",
+      "    run_agent:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: failure",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "prompt.md"),
+    "Work on #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+async function writeBlockedTerminalRawFsmProject(root: string): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: blocked_terminal",
+      "  initial: run_agent",
+      "  states:",
+      "    run_agent:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: blocked",
       ""
     ].join("\n")
   );


### PR DESCRIPTION
## Summary
- Fix #106: when a raw FSM workflow walks to a terminal node labeled `failure` or `blocked`, the run is now recorded as `failed` (with deterministic `terminal_reason=workflow_terminal_failure|_blocked`, `sym:failed` applied, no continuation scheduled), regardless of the provider's exit code. Previously the run state was derived purely from `classifyFailure` so a provider exit 0 walking to `terminal: failure` was incorrectly recorded `succeeded`.
- `applyWorkflowOutcome` propagates the terminal node's label via `WorkflowOutcomeResult.terminalLabel`; `runAttemptLifecycle` runs the FSM walk before mapping run state and threads a fused `effectiveOutcome` through `recordTerminalReason`, `applyTerminalLabels`, and `scheduleNext`. Cancellation and `input_required` always win over the FSM label so operator/system intent is preserved.
- Out of scope (deliberate, flagged for a follow-up): `executeWaitPark` has the same bug pattern for wait-state walks into non-success terminal labels — SPEC §11.7 still says wait-state terminals end "succeeded"; not touched here.

## Test plan
- [x] New: `tests/daemon-dispatch.test.ts` — walks a raw FSM workflow to a terminal failure node and records the run as failed
- [x] New: `tests/daemon-dispatch.test.ts` — walks a raw FSM workflow to a terminal blocked node and records the run as failed
- [x] Existing regression coverage: `terminal: success` end-to-end (line 876) and `decision.kind === "blocked"` (no terminal node, line 1202) and stuck-at-agent failure (line 1282) still pass
- [x] `npm test` — 387/387 pass
- [x] `npm run build`, `npm run lint`, `npm run typecheck` — clean