### PR TITLE
Add workspace hook config validation

### DIFF
--- a/docs/adr/0050-workspace-hook-lifecycle.md
+++ b/docs/adr/0050-workspace-hook-lifecycle.md
@@ -1,0 +1,25 @@
+# Workspace hooks are Project-owned service config
+
+Status: Accepted
+
+Symphonika will model repository bootstrap and teardown hooks as optional Project-owned workspace
+configuration under each Project's `workspace.hooks` map in `symphonika.yml`. Hooks are not a
+service-wide setting: different Projects may need different install, bootstrap, test, or cleanup
+commands, and keeping them beside `workspace.root` and `workspace.git` preserves that ownership
+boundary.
+
+The lifecycle vocabulary is fixed to four points inspired by upstream Symphony:
+
+- `after_create`: after a new issue workspace is created
+- `before_run`: before a coding agent provider is launched from the workspace cwd
+- `after_run`: after the provider run completes
+- `before_remove`: before an operator-requested workspace removal
+
+For v1, issue #119 implements config schema and validation only. `workspace.hooks` may declare
+entries with a required non-empty `command` string and an optional integer `timeout_ms` of at least
+1000 milliseconds, but Symphonika does not execute those commands yet.
+
+Runtime execution, ordering between lifecycle points and other workspace steps, timeout handling,
+stdout/stderr evidence capture, retries, and failure-to-terminal-reason mapping are deferred to a
+follow-up child of #82. Until that follow-up lands, accepting hook configuration is a contract and
+operator-facing validation surface, not a runtime behavior change.

--- a/src/config-schemas.ts
+++ b/src/config-schemas.ts
@@ -1,10 +1,70 @@
 import { z } from "zod";
 
-const workflowPathSchema = z
+export const pathStringSchema = z
   .string()
   .trim()
   .min(1)
   .refine((value) => !value.includes("\0"), "path must not contain NUL bytes");
+
+const workflowPathSchema = pathStringSchema;
+
+export const WORKSPACE_HOOK_LIFECYCLES = [
+  "after_create",
+  "before_run",
+  "after_run",
+  "before_remove"
+] as const;
+
+const allowedWorkspaceHookLifecycles = new Set<string>(WORKSPACE_HOOK_LIFECYCLES);
+const workspaceHookLifecycleList = WORKSPACE_HOOK_LIFECYCLES.join(", ");
+
+export const workspaceHookSchema = z
+  .object({
+    command: z.string().trim().min(1, "command must be a non-empty string"),
+    timeout_ms: z.number().int().min(1000).optional()
+  })
+  .strict();
+
+export type WorkspaceHook = z.infer<typeof workspaceHookSchema>;
+
+export const workspaceHooksSchema = z
+  .object({
+    after_create: workspaceHookSchema.optional(),
+    before_run: workspaceHookSchema.optional(),
+    after_run: workspaceHookSchema.optional(),
+    before_remove: workspaceHookSchema.optional()
+  })
+  .passthrough()
+  .superRefine((value, context) => {
+    for (const key of Object.keys(value)) {
+      if (allowedWorkspaceHookLifecycles.has(key)) {
+        continue;
+      }
+
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `unknown workspace hook lifecycle "${key}"; allowed lifecycles: ${workspaceHookLifecycleList}`,
+        path: [key]
+      });
+    }
+  });
+
+export type WorkspaceHooks = z.infer<typeof workspaceHooksSchema>;
+
+export const projectWorkspaceSchema = z
+  .object({
+    root: pathStringSchema,
+    git: z
+      .object({
+        remote: z.string().trim().min(1),
+        base_branch: z.string().trim().min(1)
+      })
+      .passthrough(),
+    hooks: workspaceHooksSchema.optional()
+  })
+  .passthrough();
+
+export type ProjectWorkspace = z.infer<typeof projectWorkspaceSchema>;
 
 export const workflowFormatSchema = z.enum(["markdown", "raw_fsm", "auto"]);
 export type WorkflowFormat = z.infer<typeof workflowFormatSchema>;

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -2,7 +2,10 @@ import { readFile } from "node:fs/promises";
 import { parse } from "yaml";
 import { z } from "zod";
 
-import { workflowReferenceSchema } from "./config-schemas.js";
+import {
+  projectWorkspaceSchema,
+  workflowReferenceSchema
+} from "./config-schemas.js";
 import type {
   GitHubIssueLabelInput,
   GitHubIssuesApi,
@@ -88,17 +91,7 @@ const dispatchProjectSchema = z
         default: z.number().int().nonnegative()
       })
       .passthrough(),
-    workspace: z
-      .object({
-        root: z.string().trim().min(1),
-        git: z
-          .object({
-            remote: z.string().trim().min(1),
-            base_branch: z.string().trim().min(1)
-          })
-          .passthrough()
-      })
-      .passthrough(),
+    workspace: projectWorkspaceSchema,
     agent: z
       .object({
         provider: providerNameSchema

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,7 +5,11 @@ import { parse } from "yaml";
 import { z } from "zod";
 
 import type { WorkflowFormat } from "./config-schemas.js";
-import { workflowReferenceSchema } from "./config-schemas.js";
+import {
+  pathStringSchema,
+  projectWorkspaceSchema,
+  workflowReferenceSchema
+} from "./config-schemas.js";
 import {
   DEFAULT_GITHUB_ISSUES_API,
   type GitHubIssuesApi
@@ -151,12 +155,6 @@ const SILENT_OCTOKIT_LOG = {
 };
 
 const providerNameSchema = z.enum(["codex", "claude"]);
-const pathStringSchema = z
-  .string()
-  .trim()
-  .min(1)
-  .refine((value) => !value.includes("\0"), "path must not contain NUL bytes");
-
 const providerCommandSchema = z
   .object({
     command: z.string().trim().min(1)
@@ -189,17 +187,7 @@ const projectSchema = z
         default: z.number().int().nonnegative()
       })
       .passthrough(),
-    workspace: z
-      .object({
-        root: pathStringSchema,
-        git: z
-          .object({
-            remote: z.string().trim().min(1),
-            base_branch: z.string().trim().min(1)
-          })
-          .passthrough()
-      })
-      .passthrough(),
+    workspace: projectWorkspaceSchema,
     agent: z
       .object({
         provider: providerNameSchema

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -6,7 +6,10 @@ import { parse } from "yaml";
 import { z } from "zod";
 
 import type { WorkflowFormat } from "./config-schemas.js";
-import { workflowReferenceSchema } from "./config-schemas.js";
+import {
+  projectWorkspaceSchema,
+  workflowReferenceSchema
+} from "./config-schemas.js";
 import type {
   PollingProjectConfig,
   PollingServiceConfig
@@ -95,17 +98,7 @@ const pollingProjectSchema = z
 const runtimeProjectDetailSchema = z
   .object({
     name: z.string().trim().min(1),
-    workspace: z
-      .object({
-        root: z.string().trim().min(1),
-        git: z
-          .object({
-            remote: z.string().trim().min(1),
-            base_branch: z.string().trim().min(1)
-          })
-          .passthrough()
-      })
-      .passthrough(),
+    workspace: projectWorkspaceSchema,
     workflow: workflowReferenceSchema
   })
   .passthrough();

--- a/symphonika.example.yml
+++ b/symphonika.example.yml
@@ -35,6 +35,16 @@ projects:
       git:
         remote: git@github.com:pmatos/symphonika.git
         base_branch: main
+      # hooks:
+      #   after_create:
+      #     command: "npm ci"
+      #     timeout_ms: 600000
+      #   before_run:
+      #     command: "./scripts/bootstrap.sh"
+      #   after_run:
+      #     command: "npm test"
+      #   before_remove:
+      #     command: "./scripts/archive-evidence.sh"
     agent:
       provider: codex
     workflow: ./WORKFLOW.md

--- a/tests/config-schemas.test.ts
+++ b/tests/config-schemas.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { workflowReferenceSchema } from "../src/config-schemas.js";
+import {
+  projectWorkspaceSchema,
+  workflowReferenceSchema
+} from "../src/config-schemas.js";
 
 describe("workflowReferenceSchema", () => {
   it("normalizes a bare string into { path, format: 'auto' }", () => {
@@ -58,6 +61,139 @@ describe("workflowReferenceSchema", () => {
   it("rejects an object form with a missing path", () => {
     expect(() =>
       workflowReferenceSchema.parse({ format: "markdown" })
+    ).toThrow();
+  });
+});
+
+describe("projectWorkspaceSchema", () => {
+  it("accepts existing workspace config without hooks unchanged", () => {
+    const result = projectWorkspaceSchema.parse({
+      git: {
+        base_branch: "main",
+        remote: "git@github.com:pmatos/symphonika.git"
+      },
+      root: "./.symphonika/workspaces/symphonika"
+    });
+
+    expect(result).toEqual({
+      git: {
+        base_branch: "main",
+        remote: "git@github.com:pmatos/symphonika.git"
+      },
+      root: "./.symphonika/workspaces/symphonika"
+    });
+  });
+
+  it("accepts an empty workspace hooks map", () => {
+    const result = projectWorkspaceSchema.parse({
+      git: {
+        base_branch: "main",
+        remote: "git@github.com:pmatos/symphonika.git"
+      },
+      hooks: {},
+      root: "./.symphonika/workspaces/symphonika"
+    });
+
+    expect(result.hooks).toEqual({});
+  });
+
+  it("accepts one configured workspace hook", () => {
+    const result = projectWorkspaceSchema.parse({
+      git: {
+        base_branch: "main",
+        remote: "git@github.com:pmatos/symphonika.git"
+      },
+      hooks: {
+        after_create: {
+          command: "npm ci",
+          timeout_ms: 600_000
+        }
+      },
+      root: "./.symphonika/workspaces/symphonika"
+    });
+
+    expect(result.hooks?.after_create).toEqual({
+      command: "npm ci",
+      timeout_ms: 600_000
+    });
+  });
+
+  it("accepts all configured workspace hook lifecycle keys", () => {
+    const result = projectWorkspaceSchema.parse({
+      git: {
+        base_branch: "main",
+        remote: "git@github.com:pmatos/symphonika.git"
+      },
+      hooks: {
+        after_create: { command: "npm ci" },
+        after_run: { command: "npm test" },
+        before_remove: { command: "./scripts/archive-evidence.sh" },
+        before_run: { command: "./scripts/bootstrap.sh" }
+      },
+      root: "./.symphonika/workspaces/symphonika"
+    });
+
+    expect(Object.keys(result.hooks ?? {}).sort()).toEqual([
+      "after_create",
+      "after_run",
+      "before_remove",
+      "before_run"
+    ]);
+  });
+
+  it("rejects unknown workspace hook lifecycle keys with the allowed set", () => {
+    const result = projectWorkspaceSchema.safeParse({
+      git: {
+        base_branch: "main",
+        remote: "git@github.com:pmatos/symphonika.git"
+      },
+      hooks: {
+        after_merge: { command: "npm ci" }
+      },
+      root: "./.symphonika/workspaces/symphonika"
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected workspace hooks validation to fail");
+    }
+    expect(result.error.issues[0]).toMatchObject({
+      message:
+        'unknown workspace hook lifecycle "after_merge"; allowed lifecycles: after_create, before_run, after_run, before_remove',
+      path: ["hooks", "after_merge"]
+    });
+  });
+
+  it("rejects empty workspace hook commands after trimming", () => {
+    expect(() =>
+      projectWorkspaceSchema.parse({
+        git: {
+          base_branch: "main",
+          remote: "git@github.com:pmatos/symphonika.git"
+        },
+        hooks: {
+          before_run: { command: "   " }
+        },
+        root: "./.symphonika/workspaces/symphonika"
+      })
+    ).toThrow(/command must be a non-empty string/);
+  });
+
+  it.each([
+    ["non-integer", 1000.5],
+    ["sub-minimum", 999]
+  ])("rejects %s workspace hook timeout_ms values", (_label, timeoutMs) => {
+    expect(() =>
+      projectWorkspaceSchema.parse({
+        git: {
+          base_branch: "main",
+          remote: "git@github.com:pmatos/symphonika.git"
+        },
+        hooks: {
+          before_run: { command: "./scripts/bootstrap.sh", timeout_ms: timeoutMs }
+        },
+        root: "./.symphonika/workspaces/symphonika"
+      })
     ).toThrow();
   });
 });

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -99,6 +99,32 @@ describe("doctor", () => {
     expect(output.stderr).toContain("codex");
   });
 
+  it("reports unknown workspace hook lifecycle keys", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath, {
+      workspaceHookLines: [
+        "      hooks:",
+        "        after_merge:",
+        '          command: "npm ci"'
+      ]
+    });
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}} for {{project.name}}.\n"
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stderr).toContain("projects.0.workspace.hooks.after_merge");
+    expect(output.stderr).toContain("allowed lifecycles");
+    expect(output.stderr).toContain(
+      "after_create, before_run, after_run, before_remove"
+    );
+  });
+
   it("reports missing workflow contract paths", async () => {
     const root = await makeTempRoot();
     const configPath = path.join(root, "symphonika.yml");
@@ -399,6 +425,7 @@ async function writeValidConfig(
     codexCommand?: string;
     token?: string;
     trackerKind?: string;
+    workspaceHookLines?: string[];
     workflowPath?: string;
   } = {}
 ): Promise<void> {
@@ -441,6 +468,7 @@ async function writeValidConfig(
       "      git:",
       "        remote: git@github.com:pmatos/symphonika.git",
       "        base_branch: main",
+      ...(overrides.workspaceHookLines ?? []),
       "    agent:",
       `      provider: ${overrides.agentProvider ?? "codex"}`,
       `    workflow: ${overrides.workflowPath ?? "./WORKFLOW.md"}`,

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -22,7 +22,8 @@ afterEach(async () => {
 
 async function writeProjectConfig(
   root: string,
-  workflowFileName: string
+  workflowFileName: string,
+  options: { workspaceHookLines?: string[] } = {}
 ): Promise<void> {
   await mkdir(root, { recursive: true });
   await writeFile(
@@ -58,6 +59,7 @@ async function writeProjectConfig(
       "      git:",
       "        remote: git@github.com:pmatos/symphonika.git",
       "        base_branch: main",
+      ...(options.workspaceHookLines ?? []),
       "    agent:",
       "      provider: codex",
       `    workflow: ./${workflowFileName}`,
@@ -67,6 +69,30 @@ async function writeProjectConfig(
 }
 
 describe("RuntimeConfigReloader workflow validation", () => {
+  it("rejects unknown workspace hook lifecycle keys during config reload", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md", {
+      workspaceHookLines: [
+        "      hooks:",
+        "        after_merge:",
+        '          command: "npm ci"'
+      ]
+    });
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+
+    const reloader = new RuntimeConfigReloader({
+      configPath: path.join(root, "symphonika.yml")
+    });
+    await reloader.reload();
+    const status = reloader.getStatus();
+
+    expect(status.ok).toBe(false);
+    expect(status.errors).toContain(
+      'projects.0.workspace.hooks.after_merge: unknown workspace hook lifecycle "after_merge"; allowed lifecycles: after_create, before_run, after_run, before_remove'
+    );
+    expect(reloader.projectsByName().has("symphonika")).toBe(false);
+  });
+
   it("rejects raw FSM workflows whose transitions point at undeclared states", async () => {
     const root = await makeTempRoot();
     await writeProjectConfig(root, "workflow.yml");


### PR DESCRIPTION
Summary:
- add accepted ADR 0050 for Project-owned workspace hook lifecycle config
- validate optional workspace.hooks entries and surface errors through doctor/reload/dispatch config loading
- document the commented hook shape in symphonika.example.yml

Validation:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #119