### PR TITLE
fix: smooth status dashboard watch redraw

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ import {
 } from "./lifecycle/terminal-reason.js";
 import { resolveStateRoot } from "./state.js";
 import {
+  renderStatusDashboardRedrawFrame,
   renderStatusDashboard,
   summarizeDashboardEvent,
   type DashboardEventSummary
@@ -366,7 +367,8 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
       }) => {
         const printOnce = async (
           dashboard: boolean,
-          cachedReport?: DoctorReport
+          cachedReport?: DoctorReport,
+          redrawState?: { previousLineCount: number }
         ): Promise<void> => {
           const stateRoot = resolveStateRoot({ configPath: options.config }).stateRoot;
           const store = openRunStore({ stateRoot });
@@ -389,22 +391,29 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
             );
 
             if (dashboard) {
-              writeOut(
-                program,
-                renderStatusDashboard({
-                  daemon:
-                    daemonUrl === undefined
-                      ? "unavailable (not configured)"
-                      : formatDaemonAvailability(daemonStatus, daemonUrl),
-                  issueCounts,
-                  lastPollOutcome: formatLastPollOutcome(daemonStatus),
-                  latestEvents: collectLatestDashboardEvents(store, all),
-                  projects: report.projects,
-                  reload: formatReloadOutcome(daemonStatus),
-                  runs: all,
-                  stateRoot
-                })
-              );
+              const dashboardOutput = renderStatusDashboard({
+                daemon:
+                  daemonUrl === undefined
+                    ? "unavailable (not configured)"
+                    : formatDaemonAvailability(daemonStatus, daemonUrl),
+                issueCounts,
+                lastPollOutcome: formatLastPollOutcome(daemonStatus),
+                latestEvents: collectLatestDashboardEvents(store, all),
+                projects: report.projects,
+                reload: formatReloadOutcome(daemonStatus),
+                runs: all,
+                stateRoot
+              });
+              if (redrawState !== undefined) {
+                const frame = renderStatusDashboardRedrawFrame(
+                  dashboardOutput,
+                  redrawState.previousLineCount
+                );
+                redrawState.previousLineCount = frame.lineCount;
+                writeOut(program, frame.output);
+                return;
+              }
+              writeOut(program, dashboardOutput);
               return;
             }
 
@@ -476,9 +485,9 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
 
         if (options.watch === true) {
           const report = await doctor({ configPath: options.config });
+          const redrawState = { previousLineCount: 0 };
           for (;;) {
-            writeOut(program, "\x1b[2J\x1b[H");
-            await printOnce(true, report);
+            await printOnce(true, report, redrawState);
             await sleep(options.intervalMs);
           }
         }

--- a/src/status-dashboard.ts
+++ b/src/status-dashboard.ts
@@ -27,6 +27,11 @@ export type StatusDashboardInput = {
   stateRoot: string;
 };
 
+export type StatusDashboardRedrawFrame = {
+  lineCount: number;
+  output: string;
+};
+
 const ACTIVE_RUN_STATES = new Set<RunState>([
   "queued",
   "preparing_workspace",
@@ -42,6 +47,25 @@ const ATTENTION_RUN_STATES = new Set<RunState>([
 ]);
 
 const RECENT_LIMIT = 5;
+
+export function renderStatusDashboardRedrawFrame(
+  renderedDashboard: string,
+  previousLineCount = 0
+): StatusDashboardRedrawFrame {
+  const lines = linesWithoutFinalNewline(renderedDashboard);
+  const trailingBlankErases = Array.from(
+    { length: Math.max(0, previousLineCount - lines.length) },
+    () => "\x1b[K"
+  );
+  const frameLines = [
+    ...lines.map((line) => `${line}\x1b[K`),
+    ...trailingBlankErases
+  ];
+  return {
+    lineCount: lines.length,
+    output: `\x1b[H${frameLines.join("\n")}\n`
+  };
+}
 
 export function renderStatusDashboard(input: StatusDashboardInput): string {
   const validProjects = input.projects.filter(
@@ -215,6 +239,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function pad(value: string, width: number): string {
   return value.length >= width ? value : value.padEnd(width, " ");
+}
+
+function linesWithoutFinalNewline(value: string): string[] {
+  const trimmed = value.endsWith("\n") ? value.slice(0, -1) : value;
+  return trimmed.length === 0 ? [] : trimmed.split("\n");
 }
 
 function truncate(value: string, width: number): string {

--- a/src/status-dashboard.ts
+++ b/src/status-dashboard.ts
@@ -61,9 +61,10 @@ export function renderStatusDashboardRedrawFrame(
     ...lines.map((line) => `${line}\x1b[K`),
     ...trailingBlankErases
   ];
+  const initialFrameTrailingErase = previousLineCount === 0 ? "\x1b[J" : "";
   return {
     lineCount: lines.length,
-    output: `\x1b[H${frameLines.join("\n")}\n`
+    output: `\x1b[H${frameLines.join("\n")}\n${initialFrameTrailingErase}`
   };
 }
 

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -308,7 +308,7 @@ describe("CLI run commands", () => {
     let doctorCalls = 0;
     let openStoreCalls = 0;
     let statusRequests = 0;
-    const { program } = captureProgram(stateRoot, {
+    const { output, program } = captureProgram(stateRoot, {
       fetch: () => {
         statusRequests += 1;
         return Promise.resolve(
@@ -366,6 +366,9 @@ describe("CLI run commands", () => {
     expect(statusRequests).toBeGreaterThan(1);
     expect(openStoreCalls).toBeGreaterThan(2);
     expect(doctorCalls).toBe(1);
+    expect(output.stdout).not.toContain("\x1b[2J");
+    expect(output.stdout).toContain("\x1b[H");
+    expect(output.stdout).toContain("\x1b[K");
   });
 
   it("status discovers the local daemon endpoint descriptor", async () => {

--- a/tests/status-dashboard-redraw.test.ts
+++ b/tests/status-dashboard-redraw.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { renderStatusDashboardRedrawFrame } from "../src/status-dashboard.js";
+
+describe("status dashboard watch redraw frames", () => {
+  it("renders the initial frame with cursor home and line erases", () => {
+    const frame = renderStatusDashboardRedrawFrame("alpha\nbeta\n");
+
+    expect(frame).toEqual({
+      lineCount: 2,
+      output: "\x1b[Halpha\x1b[K\nbeta\x1b[K\n"
+    });
+    expect(frame.output).not.toContain("\x1b[2J");
+  });
+
+  it("renders a same-height subsequent frame without trailing blank erases", () => {
+    const frame = renderStatusDashboardRedrawFrame("gamma\ndelta\n", 2);
+
+    expect(frame).toEqual({
+      lineCount: 2,
+      output: "\x1b[Hgamma\x1b[K\ndelta\x1b[K\n"
+    });
+    expect(frame.output).not.toContain("\x1b[2J");
+  });
+
+  it("clears leftover rows when a subsequent frame is shorter", () => {
+    const frame = renderStatusDashboardRedrawFrame("epsilon\n", 3);
+
+    expect(frame).toEqual({
+      lineCount: 1,
+      output: "\x1b[Hepsilon\x1b[K\n\x1b[K\n\x1b[K\n"
+    });
+    expect(frame.output).not.toContain("\x1b[2J");
+  });
+});

--- a/tests/status-dashboard-redraw.test.ts
+++ b/tests/status-dashboard-redraw.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from "vitest";
 import { renderStatusDashboardRedrawFrame } from "../src/status-dashboard.js";
 
 describe("status dashboard watch redraw frames", () => {
-  it("renders the initial frame with cursor home and line erases", () => {
+  it("renders the initial frame with cursor home, line erases, and a trailing erase-to-end-of-screen", () => {
     const frame = renderStatusDashboardRedrawFrame("alpha\nbeta\n");
 
     expect(frame).toEqual({
       lineCount: 2,
-      output: "\x1b[Halpha\x1b[K\nbeta\x1b[K\n"
+      output: "\x1b[Halpha\x1b[K\nbeta\x1b[K\n\x1b[J"
     });
     expect(frame.output).not.toContain("\x1b[2J");
   });
@@ -21,6 +21,7 @@ describe("status dashboard watch redraw frames", () => {
       output: "\x1b[Hgamma\x1b[K\ndelta\x1b[K\n"
     });
     expect(frame.output).not.toContain("\x1b[2J");
+    expect(frame.output).not.toContain("\x1b[J");
   });
 
   it("clears leftover rows when a subsequent frame is shorter", () => {
@@ -31,5 +32,6 @@ describe("status dashboard watch redraw frames", () => {
       output: "\x1b[Hepsilon\x1b[K\n\x1b[K\n\x1b[K\n"
     });
     expect(frame.output).not.toContain("\x1b[2J");
+    expect(frame.output).not.toContain("\x1b[J");
   });
 });


### PR DESCRIPTION
Summary:
- redraw status --dashboard --watch with cursor-home frames instead of full-screen clears
- erase to end-of-line for every dashboard line and clear leftover rows after shorter frames
- add redraw-frame coverage plus CLI escape-sequence coverage

Trade-off:
- chose cursor-home only over alternate screen because it fixes the flicker with less terminal state to restore; scrollback behavior remains unchanged, and no SIGINT/SIGTERM restoration path is needed.

Validation:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #121