### PR TITLE
fix: fail input-required runs terminally

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -410,11 +410,13 @@ On daemon startup:
 
 1. Load `symphonika.yml`.
 2. Open or initialize SQLite.
-3. Validate Projects.
-4. Reconcile stale labels and previous run state.
-5. Start local UI/API if enabled.
-6. Perform an immediate poll.
-7. Schedule interval polling.
+3. Backfill legacy `input_required` Run rows older than 60 seconds to `failed` with
+   `terminal_reason = "provider requested input (legacy)"`.
+4. Validate Projects.
+5. Reconcile stale labels and previous run state.
+6. Start local UI/API if enabled.
+7. Perform an immediate poll.
+8. Schedule interval polling.
 
 Default poll interval: `30000` ms.
 
@@ -613,7 +615,7 @@ credential isolation.
 Runs are autonomous. If a provider requests interactive input:
 
 - record normalized `input_required`
-- fail the attempt
+- fail the attempt and persist the Run as `failed` with terminal reason `provider requested input`
 - add `sym:failed`
 - preserve logs and workspace
 
@@ -634,7 +636,7 @@ Normalized lifecycle states:
 - `queued`
 - `preparing_workspace`
 - `running`
-- `input_required`
+- `input_required` (transient or legacy only; durable provider-input failures are `failed`)
 - `failed`
 - `succeeded`
 - `cancelled`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -733,7 +733,6 @@ function statusDashboardShowsLatestEvent(state: RunState): boolean {
     state === "queued" ||
     state === "preparing_workspace" ||
     state === "running" ||
-    state === "input_required" ||
     state === "waiting"
   );
 }
@@ -1014,7 +1013,7 @@ function issueCountsFromStatus(
       candidate: arrayLength(daemonStatus.status.candidateIssues),
       failed: Math.max(
         countIssuesWithLabel(filteredIssues, "sym:failed"),
-        (byState.get("failed") ?? 0) + (byState.get("input_required") ?? 0)
+        byState.get("failed") ?? 0
       ),
       filtered: arrayLength(filteredIssues),
       running: Math.max(
@@ -1032,7 +1031,7 @@ function issueCountsFromStatus(
 
   return {
     candidate: 0,
-    failed: (byState.get("failed") ?? 0) + (byState.get("input_required") ?? 0),
+    failed: byState.get("failed") ?? 0,
     filtered: 0,
     running: byState.get("running") ?? 0,
     stale: Math.max(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -42,6 +42,7 @@ import {
 } from "./pull-request-followup.js";
 import { RuntimeConfigReloader } from "./reload.js";
 import {
+  INPUT_REQUIRED_LEGACY_BACKFILL_GRACE_MS,
   openRunStore,
   type RunState,
   type SyncProjectStateInput
@@ -62,6 +63,7 @@ export type StartDaemonOptions = {
   env?: NodeJS.ProcessEnv;
   githubIssuesApi?: GitHubIssuesApi;
   host?: string;
+  legacyInputRequiredRecheckDelayMs?: number;
   lifecyclePolicy?: LifecyclePolicy;
   logger?: Logger;
   port?: number;
@@ -103,6 +105,33 @@ export async function startDaemon(
       { migrated: failedLegacyInputRequired },
       "symphonika startup: failed legacy input_required runs"
     );
+  }
+  // Rows updated within the grace window at startup are skipped by the
+  // initial sweep, so schedule one more pass after the window elapses to
+  // catch rows that an outgoing daemon wrote moments before restart.
+  const legacyRecheckDelayMs =
+    options.legacyInputRequiredRecheckDelayMs ??
+    INPUT_REQUIRED_LEGACY_BACKFILL_GRACE_MS * 2;
+  let legacyRecheckTimer: ReturnType<typeof setTimeout> | undefined;
+  if (legacyRecheckDelayMs > 0) {
+    legacyRecheckTimer = setTimeout(() => {
+      legacyRecheckTimer = undefined;
+      try {
+        const migrated = runStore.failLegacyInputRequiredRuns();
+        if (migrated.length > 0) {
+          logger.info(
+            { migrated },
+            "symphonika legacy input_required recheck: failed remaining runs"
+          );
+        }
+      } catch (error) {
+        logger.error(
+          { err: error },
+          "symphonika legacy input_required recheck failed"
+        );
+      }
+    }, legacyRecheckDelayMs);
+    legacyRecheckTimer.unref?.();
   }
   const sweptOnStartup = runStore.markLeakedRunsAsStale();
   if (sweptOnStartup.length > 0) {
@@ -554,6 +583,10 @@ export async function startDaemon(
     stop: async () => {
       if (pollTimer !== undefined) {
         clearInterval(pollTimer);
+      }
+      if (legacyRecheckTimer !== undefined) {
+        clearTimeout(legacyRecheckTimer);
+        legacyRecheckTimer = undefined;
       }
       activeRuns.cancelAll();
       await scheduledWork;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -97,6 +97,13 @@ export async function startDaemon(
   const runStore = openRunStore({
     stateRoot: state.stateRoot
   });
+  const failedLegacyInputRequired = runStore.failLegacyInputRequiredRuns();
+  if (failedLegacyInputRequired.length > 0) {
+    logger.info(
+      { migrated: failedLegacyInputRequired },
+      "symphonika startup: failed legacy input_required runs"
+    );
+  }
   const sweptOnStartup = runStore.markLeakedRunsAsStale();
   if (sweptOnStartup.length > 0) {
     logger.info(

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -2235,7 +2235,7 @@ function mapOutcomeToRunState(outcome: ClassifiedTerminal): RunState {
     case "cancelled":
       return "cancelled";
     case "input_required":
-      return "input_required";
+      return "failed";
     case "failed":
     default:
       return "failed";

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -324,6 +324,9 @@ type ProjectStateRow = {
 
 export const PULL_REQUEST_DISCOVERY_LIMIT = 25;
 export const MAX_PULL_REQUEST_DISCOVERY_ATTEMPTS = 10;
+export const INPUT_REQUIRED_LEGACY_BACKFILL_GRACE_MS = 60_000;
+export const INPUT_REQUIRED_LEGACY_TERMINAL_REASON =
+  "provider requested input (legacy)";
 
 export class RunStore {
   private readonly database: SqliteDatabase;
@@ -1346,6 +1349,53 @@ export class RunStore {
       this.updateRunState(entry.runId, "stale");
     }
     return swept;
+  }
+
+  failLegacyInputRequiredRuns(
+    options: { graceMs?: number; now?: Date } = {}
+  ): { runId: string; projectName: string; issueNumber: number }[] {
+    const graceMs = options.graceMs ?? INPUT_REQUIRED_LEGACY_BACKFILL_GRACE_MS;
+    const now = options.now ?? new Date();
+    const cutoff = new Date(now.getTime() - graceMs).toISOString();
+    const rows = this.database
+      .prepare(
+        [
+          "select id, project_name, issue_number",
+          "from runs",
+          "where state = 'input_required'",
+          "and updated_at < ?",
+          "order by updated_at asc, id asc"
+        ].join(" ")
+      )
+      .all(cutoff) as { id: string; project_name: string; issue_number: number }[];
+    const migrated = rows.map((row) => ({
+      issueNumber: row.issue_number,
+      projectName: row.project_name,
+      runId: row.id
+    }));
+    const update = this.database.prepare(
+      [
+        "update runs set",
+        "state = 'failed',",
+        "terminal_reason = ?,",
+        "failure_classification = 'input_required',",
+        "updated_at = ?",
+        "where id = ?"
+      ].join(" ")
+    );
+    const apply = this.database.transaction(() => {
+      for (const entry of migrated) {
+        const updatedAt = timestamp();
+        update.run(
+          INPUT_REQUIRED_LEGACY_TERMINAL_REASON,
+          updatedAt,
+          entry.runId
+        );
+        this.recordRunTransition(entry.runId, "failed", updatedAt);
+      }
+    });
+    apply();
+    return migrated;
   }
 
   private migrate(): void {

--- a/src/status-dashboard.ts
+++ b/src/status-dashboard.ts
@@ -31,14 +31,19 @@ const ACTIVE_RUN_STATES = new Set<RunState>([
   "queued",
   "preparing_workspace",
   "running",
-  "input_required",
   "waiting"
 ]);
 
 const ATTENTION_RUN_STATES = new Set<RunState>([
   "failed",
-  "input_required",
   "stale"
+]);
+
+const RECENT_RUN_STATES = new Set<RunState>([
+  "cancelled",
+  "failed",
+  "stale",
+  "succeeded"
 ]);
 
 const RECENT_LIMIT = 5;
@@ -54,7 +59,7 @@ export function renderStatusDashboard(input: StatusDashboardInput): string {
   );
   const runCounts = countRunsByState(input.runs);
   const recentRuns = input.runs
-    .filter((run) => !ACTIVE_RUN_STATES.has(run.state))
+    .filter((run) => RECENT_RUN_STATES.has(run.state))
     .slice(0, RECENT_LIMIT);
 
   const lines = [

--- a/src/status.ts
+++ b/src/status.ts
@@ -32,7 +32,6 @@ const ACTIVE_STATES = new Set([
   "queued",
   "preparing_workspace",
   "running",
-  "input_required",
   "waiting"
 ]);
 

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -302,6 +302,99 @@ describe("CLI run commands", () => {
     expect(output.stdout).toContain("No failed, input-required, or stale work");
   });
 
+  it("status --dashboard does not report input_required rows as active", async () => {
+    const stateRoot = await makeTempRoot();
+    const resolvedStateRoot = path.join(stateRoot, ".symphonika");
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "needs-input",
+      issue: sampleIssue({ number: 18, title: "Needs input" }),
+      projectName: "alpha",
+      providerCommand: "codex fake",
+      providerName: "codex"
+    });
+    store.createAttempt({
+      attemptNumber: 1,
+      branchName: "sym/alpha/18-needs-input",
+      branchRef: "refs/heads/sym/alpha/18-needs-input",
+      id: "needs-input-attempt-1",
+      issueSnapshotPath: "/tmp/snap.json",
+      metadataPath: "/tmp/meta.json",
+      normalizedLogPath: "/tmp/normalized.jsonl",
+      promptPath: "/tmp/prompt.md",
+      providerCommand: "codex fake",
+      providerName: "codex",
+      rawLogPath: "/tmp/raw.jsonl",
+      runId: "needs-input",
+      state: "input_required",
+      workflowGraphPath: "",
+      workspacePath: stateRoot
+    });
+    store.updateRunState("needs-input", "input_required");
+    store.recordProviderEvent({
+      attemptId: "needs-input-attempt-1",
+      normalized: { message: "approval prompt", type: "input_required" },
+      raw: { message: "approval prompt" },
+      runId: "needs-input",
+      sequence: 1
+    });
+    store.close();
+
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: () =>
+        Promise.resolve(
+          Response.json({
+            candidateIssues: [],
+            filteredIssues: [],
+            issuePolling: {
+              errors: [],
+              projects: [{ fetchedIssues: 0, name: "alpha", ok: true }]
+            },
+            reload: {
+              errors: [],
+              lastAttemptedAt: null,
+              lastLoadedAt: null,
+              ok: true,
+              usingLastKnownGood: false
+            },
+            state: "idle",
+            stateRoot: resolvedStateRoot
+          })
+        ),
+      runDoctor: () =>
+        Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          ok: true,
+          projects: [
+            {
+              missingOperationalLabels: [],
+              name: "alpha",
+              staleIssues: [],
+              validForDispatch: true,
+              workflowPath: "/tmp/WORKFLOW.md"
+            }
+          ]
+        } satisfies DoctorReport)
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml"),
+      "--daemon-url",
+      "http://127.0.0.1:3030",
+      "--dashboard"
+    ]);
+
+    expect(output.stdout).toContain("Runs: active 0");
+    expect(output.stdout).toContain("No active runs");
+    expect(output.stdout).not.toContain("needs-input");
+    expect(output.stdout).not.toContain("approval prompt");
+  });
+
   it("status --watch reuses project validation across refresh ticks", async () => {
     const stateRoot = await makeTempRoot();
     const resolvedStateRoot = path.join(stateRoot, ".symphonika");

--- a/tests/codex-provider.test.ts
+++ b/tests/codex-provider.test.ts
@@ -571,14 +571,23 @@ describe("Codex provider validate", () => {
     await writeFakeCodexValidator(fakePath, ["symphonika"], {
       hangFeaturesList: true
     });
-    process.env.SYMPHONIKA_CODEX_PROBE_TIMEOUT_MS = "200";
+    const previousTimeout = process.env.SYMPHONIKA_CODEX_PROBE_TIMEOUT_MS;
+    process.env.SYMPHONIKA_CODEX_PROBE_TIMEOUT_MS = "1000";
     const provider = createCodexProvider();
 
-    await expect(
-      provider.validate(
-        `${process.execPath} ${fakePath} -p symphonika app-server`
-      )
-    ).rejects.toThrow(/profile probe for 'symphonika' timed out/i);
+    try {
+      await expect(
+        provider.validate(
+          `${process.execPath} ${fakePath} -p symphonika app-server`
+        )
+      ).rejects.toThrow(/profile probe for 'symphonika' timed out/i);
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.SYMPHONIKA_CODEX_PROBE_TIMEOUT_MS;
+      } else {
+        process.env.SYMPHONIKA_CODEX_PROBE_TIMEOUT_MS = previousTimeout;
+      }
+    }
   });
 });
 

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -752,6 +752,7 @@ describe("daemon dispatch", () => {
 
     const daemon = await startDaemon({
       cwd: root,
+      legacyInputRequiredRecheckDelayMs: 0,
       logger: pino({ enabled: false }),
       port: 0
     });
@@ -781,6 +782,93 @@ describe("daemon dispatch", () => {
       } finally {
         after.close();
       }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("rechecks input_required rows after the grace window so freshly-written legacy rows do not require a second restart", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "fresh-input-required",
+      issue: issueSnapshotFixture({ number: 47, title: "Fresh input recheck" }),
+      projectName: "symphonika",
+      providerCommand: "codex fake",
+      providerName: "codex"
+    });
+    store.updateRunState("fresh-input-required", "input_required");
+    store.close();
+
+    // Age the row to 30s ago: inside the 60s grace window, so the
+    // startup sweep skips it. Then start the daemon with a 300ms recheck
+    // delay and, before that timer fires, age the row past the grace
+    // window. The recheck must observe the new updated_at and reap it.
+    const seeding = new Database(databasePath(stateRoot));
+    try {
+      seeding
+        .prepare("update runs set updated_at = ? where id = ?")
+        .run(
+          new Date(Date.now() - 30_000).toISOString(),
+          "fresh-input-required"
+        );
+    } finally {
+      seeding.close();
+    }
+
+    const daemon = await startDaemon({
+      cwd: root,
+      legacyInputRequiredRecheckDelayMs: 300,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      const initial = new Database(databasePath(stateRoot), { readonly: true });
+      try {
+        const stateAfterStartup = initial
+          .prepare("select state from runs where id = ?")
+          .get("fresh-input-required") as { state: string } | undefined;
+        expect(stateAfterStartup?.state).toBe("input_required");
+      } finally {
+        initial.close();
+      }
+
+      const aging = new Database(databasePath(stateRoot));
+      try {
+        aging
+          .prepare("update runs set updated_at = ? where id = ?")
+          .run(
+            new Date(Date.now() - 120_000).toISOString(),
+            "fresh-input-required"
+          );
+      } finally {
+        aging.close();
+      }
+
+      await vi.waitFor(
+        () => {
+          const after = new Database(databasePath(stateRoot), {
+            readonly: true
+          });
+          try {
+            const row = after
+              .prepare(
+                "select state, terminal_reason, failure_classification from runs where id = ?"
+              )
+              .get("fresh-input-required");
+            expect(row).toEqual({
+              failure_classification: "input_required",
+              state: "failed",
+              terminal_reason: "provider requested input (legacy)"
+            });
+          } finally {
+            after.close();
+          }
+        },
+        { interval: 25, timeout: 3_000 }
+      );
     } finally {
       await daemon.stop();
     }

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -18,7 +18,7 @@ import type {
   ProviderRunInput
 } from "../src/provider.js";
 import { RuntimeConfigReloader } from "../src/reload.js";
-import { openRunStore } from "../src/run-store.js";
+import { databasePath, openRunStore } from "../src/run-store.js";
 import { loadExpandedWorkflow } from "../src/workflow.js";
 import type {
   PreparedIssueWorkspace,
@@ -591,6 +591,195 @@ describe("daemon dispatch", () => {
         ]);
       } finally {
         database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("records provider input_required as a failed terminal run", async () => {
+    const root = await makeTempRoot();
+    await writeValidProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi.fn().mockResolvedValue([
+        issueFixture({
+          labels: ["agent-ready"],
+          number: 8,
+          title: "Dispatch an end-to-end run through a test provider"
+        })
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: {
+            type: "input_required"
+          },
+          raw: {
+            kind: "input_required"
+          }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    const prepareIssueWorkspace = vi.fn(
+      (input: PrepareIssueWorkspaceInput): Promise<PreparedIssueWorkspace> => {
+        void input;
+        return Promise.resolve(preparedWorkspace);
+      }
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: {
+        codex: codexProvider
+      },
+      createRunId: () => "run-issue-8-input-required",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 0 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "failed");
+      const run = firstRun(status);
+      expect(run).toMatchObject({
+        id: "run-issue-8-input-required",
+        issueNumber: 8,
+        state: "failed"
+      });
+
+      expect(githubIssuesApi.removeLabelsFromIssue).toHaveBeenCalledWith({
+        issueNumber: 8,
+        labels: ["sym:running"],
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret-token"
+      });
+      expect(githubIssuesApi.addLabelsToIssue).toHaveBeenCalledWith({
+        issueNumber: 8,
+        labels: ["sym:failed"],
+        owner: "pmatos",
+        repo: "symphonika",
+        token: "secret-token"
+      });
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const storedRun = database
+          .prepare(
+            [
+              "select state, terminal_reason, failure_classification",
+              "from runs where id = ?"
+            ].join(" ")
+          )
+          .get("run-issue-8-input-required");
+        expect(storedRun).toMatchObject({
+          failure_classification: "input_required",
+          state: "failed",
+          terminal_reason: "provider requested input"
+        });
+        const transitions = database
+          .prepare("select state from run_state_transitions order by sequence")
+          .all()
+          .map((row) => stringColumn(row, "state"));
+        expect(transitions).toEqual([
+          "queued",
+          "preparing_workspace",
+          "running",
+          "failed"
+        ]);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("backfills old input_required rows on daemon startup and leaves recent rows untouched", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "legacy-input-required",
+      issue: issueSnapshotFixture({ number: 45, title: "Legacy input" }),
+      projectName: "symphonika",
+      providerCommand: "codex fake",
+      providerName: "codex"
+    });
+    store.updateRunState("legacy-input-required", "input_required");
+    store.createRun({
+      id: "fresh-input-required",
+      issue: issueSnapshotFixture({ number: 46, title: "Fresh input" }),
+      projectName: "symphonika",
+      providerCommand: "codex fake",
+      providerName: "codex"
+    });
+    store.updateRunState("fresh-input-required", "input_required");
+    store.close();
+
+    const database = new Database(databasePath(stateRoot));
+    try {
+      database
+        .prepare("update runs set updated_at = ? where id = ?")
+        .run(
+          new Date(Date.now() - 120_000).toISOString(),
+          "legacy-input-required"
+        );
+      database
+        .prepare("update runs set updated_at = ? where id = ?")
+        .run(new Date().toISOString(), "fresh-input-required");
+    } finally {
+      database.close();
+    }
+
+    const daemon = await startDaemon({
+      cwd: root,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      const after = new Database(databasePath(stateRoot), { readonly: true });
+      try {
+        const rows = after
+          .prepare(
+            "select id, state, terminal_reason, failure_classification from runs order by id"
+          )
+          .all();
+        expect(rows).toEqual([
+          {
+            failure_classification: null,
+            id: "fresh-input-required",
+            state: "input_required",
+            terminal_reason: null
+          },
+          {
+            failure_classification: "input_required",
+            id: "legacy-input-required",
+            state: "failed",
+            terminal_reason: "provider requested input (legacy)"
+          }
+        ]);
+      } finally {
+        after.close();
       }
     } finally {
       await daemon.stop();
@@ -1580,6 +1769,35 @@ function issueFixture(overrides: {
     state: "open",
     title: overrides.title,
     updated_at: "2026-04-21T11:00:00Z"
+  };
+}
+
+function issueSnapshotFixture(overrides: {
+  number: number;
+  title: string;
+}): {
+  body: string;
+  created_at: string;
+  id: number;
+  labels: string[];
+  number: number;
+  priority: number;
+  state: "open";
+  title: string;
+  updated_at: string;
+  url: string;
+} {
+  return {
+    body: `${overrides.title} body.`,
+    created_at: "2026-04-20T10:00:00Z",
+    id: 6000 + overrides.number,
+    labels: ["agent-ready"],
+    number: overrides.number,
+    priority: 99,
+    state: "open",
+    title: overrides.title,
+    updated_at: "2026-04-21T11:00:00Z",
+    url: `https://github.com/pmatos/symphonika/issues/${overrides.number}`
   };
 }
 


### PR DESCRIPTION
## Summary
- persist provider input_required outcomes as failed runs with terminal_reason=provider requested input
- hide transient input_required rows from the terminal dashboard active/attention/recent surfaces
- backfill legacy input_required rows older than 60 seconds on daemon startup

## Tests
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #122