### PR TITLE
Fix CLI help for linked binary

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { InvalidArgumentError, Command } from "commander";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -710,6 +710,22 @@ export async function runCli(argv = process.argv): Promise<void> {
   await buildCli().parseAsync(argv);
 }
 
+function isDirectCliInvocation(moduleUrl: string, argvEntry: string | undefined): boolean {
+  if (argvEntry === undefined) {
+    return false;
+  }
+
+  let entryPath = argvEntry;
+  try {
+    entryPath = realpathSync(argvEntry);
+  } catch {
+    // Fall back to the raw argv path so direct invocation still works when
+    // the entrypoint disappears between process launch and this check.
+  }
+
+  return moduleUrl === pathToFileURL(entryPath).href;
+}
+
 function collectLatestDashboardEvents(
   store: RunStore,
   runs: RunStatus[]
@@ -1389,7 +1405,7 @@ function registerShutdownHandlers(daemon: DaemonHandle): void {
   process.once("SIGTERM", stop);
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+if (isDirectCliInvocation(import.meta.url, process.argv[1])) {
   runCli().catch((error: unknown) => {
     console.error(error);
     process.exitCode = 1;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,6 +1,9 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { buildCli } from "../src/cli.js";
@@ -13,6 +16,8 @@ import type {
 import type { SmokeOptions, SmokeReport } from "../src/smoke.js";
 
 const tempRoots: string[] = [];
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const execFile = promisify(execFileCallback);
 
 async function makeTempRoot(): Promise<string> {
   const root = await mkdtemp(path.join(tmpdir(), "symphonika-cli-test-"));
@@ -29,6 +34,26 @@ afterEach(async () => {
 });
 
 describe("CLI", () => {
+  it("prints top-level help when invoked through an npm-style bin symlink", async () => {
+    const root = await makeTempRoot();
+    const binPath = path.join(root, "symphonika");
+    await symlink(path.join(repoRoot, "src", "cli.ts"), binPath);
+
+    const { stdout } = await execFile(
+      process.execPath,
+      ["--import", "tsx", binPath, "--help"],
+      { cwd: repoRoot }
+    );
+
+    expect(stdout).toContain("Usage: symphonika");
+    expect(stdout).toContain("Commands:");
+    expect(stdout).toContain("doctor");
+    expect(stdout).toContain("clear-stale");
+    expect(stdout).toContain("workflow");
+    expect(stdout).toContain("status");
+    expect(stdout).toContain("show-run");
+  });
+
   it("starts the daemon with the selected config path and port", async () => {
     const starts: StartDaemonOptions[] = [];
     const program = buildCli({


### PR DESCRIPTION
Summary:
- Resolve npm bin symlinks before comparing the CLI entrypoint URL.
- Add regression coverage for npm-style symlinked --help invocation.

Tests:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #126