### PR TITLE
Strip GITHUB_TOKEN from vitest env so test daemons cannot mutate live issues

### DIFF
--- a/tests/setup-env.ts
+++ b/tests/setup-env.ts
@@ -1,0 +1,11 @@
+// Strip GitHub credentials from the test environment so that any test which
+// resolves token: "$GITHUB_TOKEN" in a config fixture cannot accidentally
+// authenticate against the live GitHub API. Without this, a daemon spun up by
+// a test (with the helper YAML pointed at the real owner/repo) would inherit
+// the real token from the parent process and mutate live issues. The failure
+// mode is silent — the test still passes — and the side effect is writing
+// sym:stale to a real issue, which cancels a running daemon's run.
+delete process.env.GITHUB_TOKEN;
+delete process.env.GH_TOKEN;
+delete process.env.GH_ENTERPRISE_TOKEN;
+delete process.env.GITHUB_ENTERPRISE_TOKEN;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
+    setupFiles: ["./tests/setup-env.ts"],
     testTimeout: 35_000
   }
 });


### PR DESCRIPTION
## Summary

Every recent run dispatched by the local daemon — #119, #121, #122, #123, #126, #127, #132, #135, etc. — terminated with `cancelReason=eligibility_loss` after `sym:stale` appeared on the live issue while the daemon's agent was still working. Investigation showed:

1. The daemon's `OctokitGitHubIssuesApi.addLabelsToIssue` is the only sym:stale writer in the codebase. With stack-trace logging on every call, it was confirmed to never write sym:stale during a run.
2. The agent itself only calls `gh issue view` (read-only). A `gh` shim that logged every invocation captured zero label mutations.
3. The agent's `npm test` invocation runs `tests/daemon-dispatch.test.ts`, which calls `startDaemon` against a `writeValidProject` YAML whose tracker reads `token: "$GITHUB_TOKEN"`. The codex shell snapshot (`~/.codex/shell_snapshots/*.sh`) exports the real PAT into the vitest process, so the test daemon resolves the token to the live PAT, polls real `pmatos/symphonika`, sees `sym:claimed`/`sym:running` on the active issue, finds no matching live run in its own (empty) in-memory state, and writes `sym:stale` to the live issue. The production daemon's next reconcile sees the new label, fails the `labels_none: [sym:stale]` filter, and cancels the run via the eligibility_loss path.

This fix wires a `setupFiles` entry that wipes `GITHUB_TOKEN` (and the other Octokit-honoured env vars) before any test module loads. `resolveToken` returns `undefined`, every token-gated path short-circuits before making an HTTP call, and the silent live-mutation is blocked.

Tests that legitimately need a token already pass an explicit `env: { GITHUB_TOKEN: "secret-token" }` to `startDaemon` and keep working — verified by running the full suite (`424 passed`, the lone failure is the unrelated missing `fast-check` dep in `property-invariants.test.ts`).

## Why not also rename the YAML owner/repo to a fake?

That was the original belt-and-suspenders plan, but applying it broke ~12 tests that hard-code `pmatos/symphonika` in their assertions (display strings, expected report fields, etc.). With the env scrub in place no real HTTP call leaves the process anyway, so the rename is no longer load-bearing. Happy to add it as a follow-up if you'd still like the second layer.

## Test plan
- [x] `npm test` passes (424/424 substantive tests; `fast-check` import failure is pre-existing)
- [ ] Manually reproduce on a fresh agent run for an open `agent-ready` issue and confirm no `sym:stale` appears mid-flight