### PR TITLE
feat: add PR review wait-state signals

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -750,7 +750,8 @@ Lifecycle:
 2. On each daemon tick (and on `/poll-now`), the reconciliation phase calls
    `reconcileWaitingRuns`, which iterates the rows in `state = "waiting"`, refreshes the issue,
    looks up the tracked pull request, fetches its follow-up state, projects predicates
-   (`pr_open`, `pr_merged`, `mergeable`, `checks`, `unresolved_review_threads`) and emits a static
+   (`pr_open`, `pr_merged`, `mergeable`, `checks`, `review_decision`,
+   `has_unresolved_reviews`, `unresolved_review_threads`) and emits a static
    `provider_success: true`, then evaluates the wait state's transitions in file order.
 3. The first matching transition wins. If the destination is an agent state, Symphonika schedules
    a `state_advance` that runs the agent through `runFreshLifecycle`. If the destination is another
@@ -770,6 +771,12 @@ Mergeability `UNKNOWN`/`null` is intentionally projected as the predicate key om
 transitions writing `mergeable: false` will not match on unknown values, so the wait stays parked
 until GitHub resolves the mergeability. The `timeout` predicate is reserved in the schema but
 unimplemented in v1.
+
+Review decisions are projected as `review_decision: approved|changes_requested|review_required|none`.
+The `none` value covers GitHub `null`. Unresolved review feedback is projected both as
+`unresolved_review_threads: <number>` for exact-count workflows and
+`has_unresolved_reviews: <boolean>` for strict-equality workflows that only need to detect whether
+any unresolved threads exist.
 
 ### 12.6 Merge States
 

--- a/docs/adr/0047-poll-driven-wait-states.md
+++ b/docs/adr/0047-poll-driven-wait-states.md
@@ -2,9 +2,9 @@
 
 Symphonika's raw FSM workflow contract allows `action.kind: "wait"` states whose purpose is to pause
 a workflow walk until observable pull-request conditions change (status-check rollup, mergeability,
-unresolved review threads). Unlike `action.kind: "agent"` states, a wait state must not launch a
-provider — it only re-evaluates predicates against externally-observed GitHub state and either
-advances to the next workflow state or stays parked.
+review decision, unresolved review threads). Unlike `action.kind: "agent"` states, a wait state
+must not launch a provider — it only re-evaluates predicates against externally-observed GitHub
+state and either advances to the next workflow state or stays parked.
 
 Two design choices follow from that contract.
 
@@ -61,6 +61,11 @@ Projection of `mergeable` deliberately omits the predicate key when GitHub repor
 UNKNOWN — the wait state stays parked until GitHub resolves the value. This is the correct
 behavior: matching unknown against either branch would race the GitHub mergeability computation
 that runs right after a push.
+
+Review decisions are projected as `review_decision: approved|changes_requested|review_required|none`.
+Unresolved review feedback is projected as both the exact `unresolved_review_threads` count and the
+derived `has_unresolved_reviews` boolean, so strict-equality transitions can match "any unresolved
+review exists" without comparator syntax.
 
 The PR follow-up logic in `src/pull-request-followup.ts` shares `projectPullRequestSignals` with
 the wait handler so the two paths cannot drift in how they interpret a given GitHub state.

--- a/docs/adr/0048-fsm-controlled-merge-states.md
+++ b/docs/adr/0048-fsm-controlled-merge-states.md
@@ -45,9 +45,10 @@ asymmetry keeps the workflow file focused on FSM semantics while operators retai
 through service config: setting `pull_requests.merge.enabled: false` defers every FSM-driven
 merge attempt without changes to workflow files.
 
-The merge state intentionally does not invent new predicates. Workflow authors expressing "the
-merge succeeded" use `pr_merged: true`, the same predicate the wait state uses; expressing
-"the merge cannot proceed" uses the existing `mergeable`, `checks`, and
+The merge state intentionally reuses the wait-state predicate vocabulary instead of inventing
+merge-only predicates. Workflow authors expressing "the merge succeeded" use `pr_merged: true`,
+the same predicate the wait state uses; expressing "the merge cannot proceed" uses the existing
+`mergeable`, `checks`, `review_decision`, `has_unresolved_reviews`, and
 `unresolved_review_threads` predicates. This keeps the predicate vocabulary small and avoids a
 divergence between the orchestrator-wide PR follow-up loop and the FSM-controlled merge path,
 echoing ADR 0047's reasoning for sharing `projectPullRequestSignals`.

--- a/docs/specs/2026-05-07-state-machine-workflows-design.md
+++ b/docs/specs/2026-05-07-state-machine-workflows-design.md
@@ -97,7 +97,7 @@ workflow:
       transitions:
         - to: autofixing
           when:
-            unresolved_review_threads: ">0"
+            has_unresolved_reviews: true
         - to: merging
           when:
             checks: success
@@ -160,6 +160,8 @@ Initial completion predicates:
 - `pr_merged`
 - `checks`
 - `mergeable`
+- `review_decision`
+- `has_unresolved_reviews`
 - `unresolved_review_threads`
 - `timeout`
 

--- a/src/lifecycle/pr-signal-projection.ts
+++ b/src/lifecycle/pr-signal-projection.ts
@@ -30,9 +30,26 @@ export function projectPullRequestSignals(
     signals.checks = checks;
   }
 
+  signals.review_decision = mapReviewDecision(state.reviewDecision);
   signals.unresolved_review_threads = state.unresolvedReviewThreads.length;
+  signals.has_unresolved_reviews = state.unresolvedReviewThreads.length > 0;
 
   return signals;
+}
+
+function mapReviewDecision(
+  reviewDecision: RawGitHubPullRequestFollowupState["reviewDecision"]
+): "approved" | "changes_requested" | "none" | "review_required" {
+  switch (reviewDecision) {
+    case "APPROVED":
+      return "approved";
+    case "CHANGES_REQUESTED":
+      return "changes_requested";
+    case "REVIEW_REQUIRED":
+      return "review_required";
+    default:
+      return "none";
+  }
 }
 
 function mapStatusCheckRollup(

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -234,10 +234,12 @@ const completionPredicateKeys = new Set([
   "branch_ahead_of_base",
   "branch_pushed",
   "checks",
+  "has_unresolved_reviews",
   "mergeable",
   "pr_merged",
   "pr_open",
   "provider_success",
+  "review_decision",
   "timeout",
   "unresolved_review_threads"
 ]);

--- a/tests/pr-signal-projection.test.ts
+++ b/tests/pr-signal-projection.test.ts
@@ -97,6 +97,22 @@ describe("projectPullRequestSignals", () => {
     expect("checks" in signals).toBe(false);
   });
 
+  it("emits normalized review_decision states", () => {
+    const cases = [
+      ["APPROVED", "approved"],
+      ["CHANGES_REQUESTED", "changes_requested"],
+      ["REVIEW_REQUIRED", "review_required"],
+      [null, "none"]
+    ] as const;
+
+    for (const [reviewDecision, expected] of cases) {
+      const signals = projectPullRequestSignals(
+        makePullRequestState({ reviewDecision })
+      );
+      expect(signals.review_decision).toBe(expected);
+    }
+  });
+
   it("emits unresolved_review_threads as the numeric count", () => {
     const zero = projectPullRequestSignals(
       makePullRequestState({ unresolvedReviewThreads: [] })
@@ -112,5 +128,19 @@ describe("projectPullRequestSignals", () => {
       })
     );
     expect(two.unresolved_review_threads).toBe(2);
+  });
+
+  it("emits has_unresolved_reviews from the unresolved review thread count", () => {
+    const zero = projectPullRequestSignals(
+      makePullRequestState({ unresolvedReviewThreads: [] })
+    );
+    expect(zero.has_unresolved_reviews).toBe(false);
+
+    const one = projectPullRequestSignals(
+      makePullRequestState({
+        unresolvedReviewThreads: [{ id: "t1", isResolved: false, comments: [] }]
+      })
+    );
+    expect(one.has_unresolved_reviews).toBe(true);
   });
 });

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1307,6 +1307,51 @@ describe("state machine workflow definitions", () => {
     );
   });
 
+  it("accepts pull request review-state predicates in raw FSM transitions", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: review_wait",
+        "  initial: wait_for_review",
+        "  states:",
+        "    wait_for_review:",
+        "      action:",
+        "        kind: wait",
+        "      transitions:",
+        "        - to: autofix",
+        "          when:",
+        "            has_unresolved_reviews: true",
+        "        - to: ready",
+        "          when:",
+        "            review_decision: approved",
+        "    autofix:",
+        "      action:",
+        "        kind: agent",
+        "        provider: codex",
+        "        prompt: prompts/autofix.md",
+        "      transitions:",
+        "        - to: wait_for_review",
+        "    ready:",
+        "      terminal: success",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath);
+
+    expect(result.errors).toEqual([]);
+    const waitState = result.workflow.states.find(
+      (state) => state.id === "wait_for_review"
+    );
+    expect(waitState?.transitions).toEqual([
+      { to: "autofix", when: { has_unresolved_reviews: true } },
+      { to: "ready", when: { review_decision: "approved" } }
+    ]);
+  });
+
   it("rejects terminal states that also declare work or outgoing transitions", async () => {
     const root = await makeTempRoot();
     const workflowPath = path.join(root, "workflow.yml");


### PR DESCRIPTION
Project wait and merge states now receive normalized review_decision and has_unresolved_reviews signals, while preserving the numeric unresolved_review_threads signal and strict-equality dispatch. The workflow parser and contract docs accept and describe the new predicates.\n\nValidation:\n- npm run lint\n- npm run typecheck\n- npm test\n- npm run build\n\nCloses #132