### PR TITLE
Honor state action provider during state advance

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -264,6 +264,10 @@ workflow snapshot for future work until a valid reload is available.
 Service discovery, tracker settings, workspace roots, provider selection, and GitHub labels belong
 in `symphonika.yml`, not in `WORKFLOW.md`.
 
+Raw FSM agent states may declare `action.provider` to route that state to a specific configured
+Agent Provider. If an agent state omits `action.provider`, Symphonika uses the Project's
+`agent.provider` from `symphonika.yml`.
+
 The daemon must not dispatch a Project when its workflow contract is missing or invalid.
 
 ### 5.3 Templating

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -50,6 +50,7 @@ import {
 import type {
   ExpandedWorkflow,
   ExpandedWorkflowState,
+  WorkflowAction,
   WorkflowPredicateMap
 } from "../workflow.js";
 
@@ -210,12 +211,14 @@ type ContinuationPayload = {
 };
 
 type StateAdvancePayload = {
+  action?: WorkflowAction;
   issue: IssueSnapshot;
   parentRunId: string;
   projectName: string;
 };
 
 type WorkflowOutcomeResult = {
+  advancedToAction?: WorkflowAction;
   advancedToState: string | null;
   advancedToTerminal: boolean;
   blocked: boolean;
@@ -756,6 +759,7 @@ export class RunController {
         delayMs: this.lifecyclePolicy.continuation.delayMs,
         fire: () =>
           this.executeStateAdvance({
+            ...(next?.action === undefined ? {} : { action: next.action }),
             issue: refreshed,
             parentRunId: runId,
             projectName: project.name
@@ -797,13 +801,15 @@ export class RunController {
       return;
     }
 
-    const provider = this.agentProviders[project.agent.provider];
-    if (provider === undefined) {
-      return;
-    }
-
+    const providerName =
+      payload.action?.kind === "agent" && payload.action.provider !== undefined
+        ? payload.action.provider
+        : project.agent.provider;
     const providersConfig = await this.providersLoader();
-    const providerCommand = providersConfig[project.agent.provider].command;
+    const providerConfig = (providersConfig as Partial<RunControllerProvidersConfig>)[
+      providerName
+    ];
+    const providerCommand = providerConfig?.command;
 
     if (!isLabelWritingGitHubIssuesApi(this.githubIssuesApi)) {
       return;
@@ -839,6 +845,35 @@ export class RunController {
     }
 
     const runId = this.createRunId();
+    if (providerCommand === undefined || providerCommand.trim().length === 0) {
+      await this.failStateAdvanceBeforeProvider({
+        issue: refreshed,
+        parentRunId: payload.parentRunId,
+        project,
+        providerCommand: providerCommand ?? "",
+        providerName,
+        reason: `provider_command_missing: ${providerName}`,
+        repository,
+        runId
+      });
+      return;
+    }
+
+    const provider = this.agentProviders[providerName];
+    if (provider === undefined) {
+      await this.failStateAdvanceBeforeProvider({
+        issue: refreshed,
+        parentRunId: payload.parentRunId,
+        project,
+        providerCommand,
+        providerName,
+        reason: `provider_not_registered: ${providerName}`,
+        repository,
+        runId
+      });
+      return;
+    }
+
     await this.runFreshLifecycle({
       attemptNumber: 1,
       isContinuation: true,
@@ -847,9 +882,72 @@ export class RunController {
       project,
       provider,
       providerCommand,
-      providerName: project.agent.provider,
+      providerName,
       repository,
       runId
+    });
+  }
+
+  private async failStateAdvanceBeforeProvider(input: {
+    issue: IssueSnapshot;
+    parentRunId: string;
+    project: RunControllerProjectConfig;
+    providerCommand: string;
+    providerName: AgentProviderName;
+    reason: string;
+    repository: GitHubIssueRepositoryInput;
+    runId: string;
+  }): Promise<void> {
+    await this.bestEffort(
+      () =>
+        (this.githubIssuesApi as LabelWritingGitHubIssuesApi).addLabelsToIssue({
+          ...input.repository,
+          issueNumber: input.issue.number,
+          labels: ["sym:claimed"]
+        }),
+      {
+        issueNumber: input.issue.number,
+        label: "sym:claimed",
+        operation: "addLabel",
+        phase: "state-advance-provider-resolution",
+        project: input.project.name,
+        runId: input.runId
+      }
+    );
+    this.runStore.createContinuationRun({
+      id: input.runId,
+      issue: input.issue,
+      parentRunId: input.parentRunId,
+      projectName: input.project.name,
+      providerCommand: input.providerCommand,
+      providerName: input.providerName
+    });
+    this.runStore.recordTerminalReason(
+      input.runId,
+      input.reason,
+      "deterministic"
+    );
+    this.runStore.updateRunState(input.runId, "failed");
+    this.logger?.warn(
+      {
+        issueNumber: input.issue.number,
+        parentRunId: input.parentRunId,
+        project: input.project.name,
+        provider: input.providerName,
+        reason: input.reason,
+        runId: input.runId
+      },
+      "symphonika state advance failed before provider launch"
+    );
+    await this.applyTerminalLabels({
+      issueNumber: input.issue.number,
+      outcome: {
+        classification: "deterministic",
+        kind: "failed",
+        reason: input.reason
+      },
+      repository: input.repository,
+      willRetry: false
     });
   }
 
@@ -1486,7 +1584,12 @@ export class RunController {
             isRawFsm &&
             workflowOutcome.advancedToState !== null &&
             workflowOutcome.parkAsWait !== true
-              ? { toStateId: workflowOutcome.advancedToState }
+              ? {
+                  ...(workflowOutcome.advancedToAction === undefined
+                    ? {}
+                    : { action: workflowOutcome.advancedToAction }),
+                  toStateId: workflowOutcome.advancedToState
+                }
               : null,
           waitPark:
             isRawFsm &&
@@ -1661,6 +1764,7 @@ export class RunController {
         };
       }
       return {
+        ...(next?.action === undefined ? {} : { advancedToAction: next.action }),
         advancedToState: decision.to,
         advancedToTerminal: false,
         blocked: false
@@ -1915,7 +2019,7 @@ export class RunController {
     respectsIssueLabels?: boolean;
     runId: string;
     runtimeAttemptNumber: number;
-    stateAdvance?: { toStateId: string } | null;
+    stateAdvance?: { action?: WorkflowAction; toStateId: string } | null;
     suppressContinuation?: boolean;
     waitPark?: { waitingRunId: string } | null;
   }): Promise<void> {
@@ -1966,6 +2070,7 @@ export class RunController {
     // and skips the labels_all / labels_none re-check; only require that the
     // issue is still open. See ADR 0046.
     if (input.stateAdvance != null) {
+      const stateAdvance = input.stateAdvance;
       const refreshedForAdvance = await this.refreshIssue({
         project: input.project,
         issueNumber: input.issue.number,
@@ -1983,7 +2088,7 @@ export class RunController {
           issueNumber: refreshedForAdvance.number,
           parentRunId: input.runId,
           project: input.project.name,
-          toStateId: input.stateAdvance.toStateId
+          toStateId: stateAdvance.toStateId
         },
         "symphonika scheduling state advance"
       );
@@ -1991,6 +2096,9 @@ export class RunController {
         delayMs: this.lifecyclePolicy.continuation.delayMs,
         fire: () =>
           this.executeStateAdvance({
+            ...(stateAdvance.action === undefined
+              ? {}
+              : { action: stateAdvance.action }),
             issue: refreshedForAdvance,
             parentRunId: input.runId,
             projectName: input.project.name

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -319,8 +319,67 @@ export class RunController {
       repo: target.project.tracker.repo,
       token
     };
-    const providerCommand =
-      providersConfig[target.project.agent.provider].command;
+
+    // Honor action.provider on the initial raw-FSM state, matching the
+    // per-state routing executeStateAdvance applies to subsequent advances.
+    // runAttemptLifecycle reloads the workflow downstream regardless, so
+    // loading it once here pays only on actually-selected dispatches. Falls
+    // back to the project default for contract workflows or when the
+    // initial agent action declares no provider.
+    let initialAction: WorkflowAction | undefined;
+    try {
+      const loaded = await this.loadWorkflow(target.project.workflow);
+      if (
+        loaded.errors.length === 0 &&
+        loaded.expandedWorkflow.source.kind === "raw_fsm"
+      ) {
+        const initialState = findWorkflowState(
+          loaded.expandedWorkflow,
+          loaded.expandedWorkflow.initial
+        );
+        if (initialState?.action !== undefined) {
+          initialAction = initialState.action;
+        }
+      }
+    } catch {
+      // Workflow load failure falls back to the project default; the same
+      // error surfaces from runAttemptLifecycle's reload during the attempt.
+    }
+
+    const providerName =
+      initialAction?.kind === "agent" && initialAction.provider !== undefined
+        ? initialAction.provider
+        : target.project.agent.provider;
+    const providerCommand = (
+      providersConfig as Partial<RunControllerProvidersConfig>
+    )[providerName]?.command;
+
+    if (providerCommand === undefined || providerCommand.trim().length === 0) {
+      await this.failFreshDispatchBeforeProvider({
+        issue: target.candidate.issue,
+        project: target.project,
+        providerCommand: providerCommand ?? "",
+        providerName,
+        reason: `provider_command_missing: ${providerName}`,
+        repository,
+        runId
+      });
+      return { dispatched: true, runId };
+    }
+
+    const provider = this.agentProviders[providerName];
+    if (provider === undefined) {
+      await this.failFreshDispatchBeforeProvider({
+        issue: target.candidate.issue,
+        project: target.project,
+        providerCommand,
+        providerName,
+        reason: `provider_not_registered: ${providerName}`,
+        repository,
+        runId
+      });
+      return { dispatched: true, runId };
+    }
 
     await this.runFreshLifecycle({
       attemptNumber: 1,
@@ -328,15 +387,75 @@ export class RunController {
       issue: target.candidate.issue,
       parentRunId: null,
       project: target.project,
-      provider: target.provider,
+      provider,
       providerCommand,
-      providerName: target.project.agent.provider,
+      providerName,
       repository,
       runId,
       schedulerWeights: target.schedulerWeights
     });
 
     return { dispatched: true, runId };
+  }
+
+  private async failFreshDispatchBeforeProvider(input: {
+    issue: IssueSnapshot;
+    project: RunControllerProjectConfig;
+    providerCommand: string;
+    providerName: AgentProviderName;
+    reason: string;
+    repository: GitHubIssueRepositoryInput;
+    runId: string;
+  }): Promise<void> {
+    await this.bestEffort(
+      () =>
+        (this.githubIssuesApi as LabelWritingGitHubIssuesApi).addLabelsToIssue({
+          ...input.repository,
+          issueNumber: input.issue.number,
+          labels: ["sym:claimed"]
+        }),
+      {
+        issueNumber: input.issue.number,
+        label: "sym:claimed",
+        operation: "addLabel",
+        phase: "fresh-dispatch-provider-resolution",
+        project: input.project.name,
+        runId: input.runId
+      }
+    );
+    this.runStore.createRun({
+      id: input.runId,
+      issue: input.issue,
+      projectName: input.project.name,
+      providerCommand: input.providerCommand,
+      providerName: input.providerName
+    });
+    this.runStore.recordTerminalReason(
+      input.runId,
+      input.reason,
+      "deterministic"
+    );
+    this.runStore.updateRunState(input.runId, "failed");
+    this.logger?.warn(
+      {
+        issueNumber: input.issue.number,
+        project: input.project.name,
+        provider: input.providerName,
+        reason: input.reason,
+        runId: input.runId
+      },
+      "symphonika fresh dispatch failed before provider launch"
+    );
+    await this.applyTerminalLabels({
+      issueNumber: input.issue.number,
+      outcome: {
+        classification: "deterministic",
+        kind: "failed",
+        reason: input.reason
+      },
+      repository: input.repository,
+      willRetry: false
+    });
   }
 
   async executeRetry(payload: RetryPayload): Promise<void> {

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -196,6 +196,13 @@ type RetryPayload = {
   extraInstructions?: string;
   issue: IssueSnapshot;
   projectName: string;
+  // Carry the provider chosen for this run (which may be a per-state override
+  // from a raw FSM action.provider) so the retry executes the same provider
+  // and command, not the project default. Without this, a state declaring
+  // action.provider: claude in a project whose default is codex would retry
+  // on codex and produce inconsistent prompts/evidence.
+  providerCommand: string;
+  providerName: AgentProviderName;
   // When false (raw FSM mid-walk runs), executeRetry skips the labels_all /
   // labels_none re-check so a transient provider failure stays recoverable
   // even when labels drift during the FSM walk. CLOSED_ISSUE still cancels.
@@ -343,17 +350,20 @@ export class RunController {
       return;
     }
 
-    const provider = this.agentProviders[project.agent.provider];
+    const provider = this.agentProviders[payload.providerName];
     if (provider === undefined) {
       this.logger?.warn(
-        { projectName: payload.projectName, runId: payload.runId },
+        {
+          projectName: payload.projectName,
+          providerName: payload.providerName,
+          runId: payload.runId
+        },
         "symphonika retry dropped: provider missing"
       );
       return;
     }
 
-    const providersConfig = await this.providersLoader();
-    const providerCommand = providersConfig[project.agent.provider].command;
+    const providerCommand = payload.providerCommand;
 
     if (!isLabelWritingGitHubIssuesApi(this.githubIssuesApi)) {
       this.logger?.warn(
@@ -448,7 +458,7 @@ export class RunController {
       project,
       provider,
       providerCommand,
-      providerName: project.agent.provider,
+      providerName: payload.providerName,
       repository,
       runId: payload.runId
     });
@@ -1576,6 +1586,8 @@ export class RunController {
           issue: input.issue,
           outcome: effectiveOutcome,
           project: input.project,
+          providerCommand: input.providerCommand,
+          providerName: input.providerName,
           repository: input.repository,
           respectsIssueLabels,
           runId: input.runId,
@@ -2015,6 +2027,8 @@ export class RunController {
     issue: IssueSnapshot;
     outcome: ClassifiedTerminal;
     project: RunControllerProjectConfig;
+    providerCommand: string;
+    providerName: AgentProviderName;
     repository: GitHubIssueRepositoryInput;
     respectsIssueLabels?: boolean;
     runId: string;
@@ -2047,6 +2061,8 @@ export class RunController {
               : { extraInstructions: input.extraInstructions }),
             issue: input.issue,
             projectName: input.project.name,
+            providerCommand: input.providerCommand,
+            providerName: input.providerName,
             // Carry the FSM mid-walk label-immunity bit into the retry. Without
             // this a transient provider failure during a raw FSM walk would be
             // cancelled with ELIGIBILITY_LOSS the moment labels drift, even

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1337,9 +1337,13 @@ function parseWorkflowAction(
   const method = stringProperty(rawAction, "method");
 
   if (kind === "agent") {
-    if (provider !== "codex" && provider !== "claude") {
+    if (
+      provider !== undefined &&
+      provider !== "codex" &&
+      provider !== "claude"
+    ) {
       errors.push(
-        `workflow state ${stateId} at ${workflowPath} agent action must define provider codex or claude`
+        `workflow state ${stateId} at ${workflowPath} agent action provider must be codex or claude`
       );
     }
     if (prompt === undefined) {

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1637,6 +1637,117 @@ describe("daemon dispatch", () => {
     }
   });
 
+  it("retries a transient failure on the state-selected provider, not the project default", async () => {
+    const root = await makeTempRoot();
+    await writePerStateProviderRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexInputs: ProviderRunInput[] = [];
+    const claudeInputs: ProviderRunInput[] = [];
+    const codexProvider = successfulProvider("codex", codexInputs);
+    let claudeAttempts = 0;
+    const claudeProvider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "claude",
+      runAttempt: vi.fn(async function* (
+        input: ProviderRunInput
+      ): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        claudeInputs.push(input);
+        claudeAttempts += 1;
+        if (claudeAttempts === 1) {
+          yield {
+            normalized: { exitCode: 1, type: "process_exit" },
+            raw: { code: 1, kind: "exit" }
+          };
+          return;
+        }
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { claude: claudeProvider, codex: codexProvider },
+      createRunId: () => `run-fsm-retry-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 1, delaysMs: [5], maxBackoffMs: 10 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForTerminalState(root, "done");
+
+      // planning runs once on codex; autofix runs twice on claude
+      // (transient failure, then retry succeeds — both on claude, not the
+      // project default of codex).
+      expect(codexInputs).toHaveLength(1);
+      expect(claudeInputs).toHaveLength(2);
+      expect(claudeInputs[0]?.provider).toMatchObject({
+        command:
+          "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json",
+        name: "claude"
+      });
+      expect(claudeInputs[1]?.provider).toMatchObject({
+        command:
+          "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json",
+        name: "claude"
+      });
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const attemptRows = database
+          .prepare(
+            "select run_id, attempt_number, provider_name from attempts order by created_at"
+          )
+          .all() as Array<Record<string, unknown>>;
+        // Attempts: 1 planning (codex), 2 autofix (claude x2 — both retries).
+        expect(attemptRows).toMatchObject([
+          { provider_name: "codex", run_id: "run-fsm-retry-1" },
+          { provider_name: "claude", run_id: "run-fsm-retry-2" },
+          { provider_name: "claude", run_id: "run-fsm-retry-2" }
+        ]);
+        const retriedRun = database
+          .prepare("select retry_count from runs where id = ?")
+          .get("run-fsm-retry-2") as { retry_count: number } | undefined;
+        expect(retriedRun?.retry_count).toBe(1);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("picks the first transition in YAML order when multiple transitions match the observed signals", async () => {
     const root = await makeTempRoot();
     await writeTransitionOrderRawFsmProject(root);

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1410,6 +1410,233 @@ describe("daemon dispatch", () => {
     }
   });
 
+  it("routes a state advance through the provider declared on the next agent state", async () => {
+    const root = await makeTempRoot();
+    await writePerStateProviderRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexInputs: ProviderRunInput[] = [];
+    const claudeInputs: ProviderRunInput[] = [];
+    const codexProvider = successfulProvider("codex", codexInputs);
+    const claudeProvider = successfulProvider("claude", claudeInputs);
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { claude: claudeProvider, codex: codexProvider },
+      createRunId: () => `run-fsm-provider-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForTerminalState(root, "done");
+
+      expect(codexInputs).toHaveLength(1);
+      expect(claudeInputs).toHaveLength(1);
+      expect(codexInputs[0]?.provider).toMatchObject({
+        name: "codex",
+        command: DEFAULT_CODEX_COMMAND
+      });
+      expect(claudeInputs[0]?.provider).toMatchObject({
+        name: "claude",
+        command:
+          "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"
+      });
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const rows = database
+          .prepare("select id, provider_name from runs order by created_at")
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toMatchObject([
+          { id: "run-fsm-provider-1", provider_name: "codex" },
+          { id: "run-fsm-provider-2", provider_name: "claude" }
+        ]);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("falls back to the project provider when the next agent state omits provider", async () => {
+    const root = await makeTempRoot();
+    await writeFallbackProviderRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexInputs: ProviderRunInput[] = [];
+    const claudeInputs: ProviderRunInput[] = [];
+    const codexProvider = successfulProvider("codex", codexInputs);
+    const claudeProvider = successfulProvider("claude", claudeInputs);
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { claude: claudeProvider, codex: codexProvider },
+      createRunId: () => `run-fsm-fallback-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForTerminalState(root, "done");
+
+      expect(codexInputs).toHaveLength(2);
+      expect(claudeInputs).toHaveLength(0);
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const rows = database
+          .prepare("select id, provider_name from runs order by created_at")
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toMatchObject([
+          { id: "run-fsm-fallback-1", provider_name: "codex" },
+          { id: "run-fsm-fallback-2", provider_name: "codex" }
+        ]);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("records a deterministic state-advance failure when the chosen provider is not registered", async () => {
+    const root = await makeTempRoot();
+    await writePerStateProviderRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulProvider("codex");
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => `run-fsm-missing-provider-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForStoredRunState(root, "failed");
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const rows = database
+          .prepare(
+            [
+              "select id, state, provider_name, terminal_reason,",
+              "failure_classification from runs order by created_at"
+            ].join(" ")
+          )
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toMatchObject([
+          {
+            id: "run-fsm-missing-provider-1",
+            provider_name: "codex",
+            state: "succeeded"
+          },
+          {
+            failure_classification: "deterministic",
+            id: "run-fsm-missing-provider-2",
+            provider_name: "claude",
+            state: "failed",
+            terminal_reason: "provider_not_registered: claude"
+          }
+        ]);
+      } finally {
+        database.close();
+      }
+
+      const failedLabelCalls = githubIssuesApi.addLabelsToIssue.mock.calls.filter(
+        (call) => {
+          const arg = call[0] as { labels?: string[] } | undefined;
+          return arg?.labels?.includes("sym:failed") ?? false;
+        }
+      );
+      expect(failedLabelCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("picks the first transition in YAML order when multiple transitions match the observed signals", async () => {
     const root = await makeTempRoot();
     await writeTransitionOrderRawFsmProject(root);
@@ -1892,11 +2119,21 @@ function issueSnapshotFixture(overrides: {
 }
 
 function successfulCodexProvider(): AgentProvider {
+  return successfulProvider("codex");
+}
+
+function successfulProvider(
+  name: "codex" | "claude",
+  inputs: ProviderRunInput[] = []
+): AgentProvider {
   return {
     cancel: vi.fn().mockResolvedValue(undefined),
-    name: "codex",
-    runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+    name,
+    runAttempt: vi.fn(async function* (
+      input: ProviderRunInput
+    ): AsyncGenerator<ProviderEvent> {
       await Promise.resolve();
+      inputs.push(input);
       yield {
         normalized: {
           exitCode: 0,
@@ -2139,7 +2376,10 @@ async function writeNoMatchingTransitionRawFsmProject(
   );
 }
 
-async function writeRawFsmProjectConfig(root: string): Promise<void> {
+async function writeRawFsmProjectConfig(
+  root: string,
+  options: { agentProvider?: "codex" | "claude" } = {}
+): Promise<void> {
   await writeFile(
     path.join(root, "symphonika.yml"),
     [
@@ -2174,7 +2414,7 @@ async function writeRawFsmProjectConfig(root: string): Promise<void> {
       "        remote: git@github.com:pmatos/symphonika.git",
       "        base_branch: main",
       "    agent:",
-      "      provider: codex",
+      `      provider: ${options.agentProvider ?? "codex"}`,
       "    workflow: ./workflow.yml",
       ""
     ].join("\n")
@@ -2204,6 +2444,93 @@ async function writeMultiStateRawFsmProject(root: string): Promise<void> {
       "      action:",
       "        kind: agent",
       "        provider: codex",
+      "        prompt: implement-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Draft a plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+  await writeFile(
+    path.join(root, "implement-prompt.md"),
+    "Implement the plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+async function writePerStateProviderRawFsmProject(root: string): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: provider_routing",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: autofix",
+      "    autofix:",
+      "      action:",
+      "        kind: agent",
+      "        provider: claude",
+      "        prompt: autofix-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Draft a plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+  await writeFile(
+    path.join(root, "autofix-prompt.md"),
+    "Apply the autofix for #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+async function writeFallbackProviderRawFsmProject(root: string): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: provider_fallback",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: implementation",
+      "    implementation:",
+      "      action:",
+      "        kind: agent",
       "        prompt: implement-prompt.md",
       "      complete_when:",
       "        provider_success: true",
@@ -2330,6 +2657,72 @@ async function waitForRun(
   }
 
   throw new Error(`run did not reach ${state} before timeout`);
+}
+
+async function waitForTerminalState(
+  root: string,
+  terminalStateId: string,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const intervalMs = options.intervalMs ?? 20;
+  const deadline = Date.now() + timeoutMs;
+  const databaseFile = path.join(root, ".symphonika", "symphonika.db");
+
+  while (Date.now() < deadline) {
+    try {
+      const database = new Database(databaseFile, { readonly: true });
+      try {
+        const row = database
+          .prepare("select count(*) as c from runs where terminal_state_id = ?")
+          .get(terminalStateId) as { c: number };
+        if (row.c >= 1) {
+          return;
+        }
+      } finally {
+        database.close();
+      }
+    } catch {
+      // The daemon may still be starting and creating its SQLite store.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`run did not reach terminal state ${terminalStateId}`);
+}
+
+async function waitForStoredRunState(
+  root: string,
+  state: string,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const intervalMs = options.intervalMs ?? 20;
+  const deadline = Date.now() + timeoutMs;
+  const databaseFile = path.join(root, ".symphonika", "symphonika.db");
+
+  while (Date.now() < deadline) {
+    try {
+      const database = new Database(databaseFile, { readonly: true });
+      try {
+        const row = database
+          .prepare("select count(*) as c from runs where state = ?")
+          .get(state) as { c: number };
+        if (row.c >= 1) {
+          return;
+        }
+      } finally {
+        database.close();
+      }
+    } catch {
+      // The daemon may still be starting and creating its SQLite store.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`run did not reach state ${state}`);
 }
 
 async function waitForStatusError(

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1748,6 +1748,160 @@ describe("daemon dispatch", () => {
     }
   });
 
+  it("honors action.provider on the initial raw-FSM state during fresh dispatch", async () => {
+    const root = await makeTempRoot();
+    await writeInitialStateClaudeRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexInputs: ProviderRunInput[] = [];
+    const claudeInputs: ProviderRunInput[] = [];
+    const codexProvider = successfulProvider("codex", codexInputs);
+    const claudeProvider = successfulProvider("claude", claudeInputs);
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { claude: claudeProvider, codex: codexProvider },
+      createRunId: () => `run-fsm-initial-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForTerminalState(root, "done");
+
+      // Project default is codex, initial state declares provider: claude.
+      // The first attempt MUST launch claude, not codex — the SPEC contract
+      // applies to raw-FSM agent states broadly, including the initial one.
+      expect(claudeInputs).toHaveLength(1);
+      expect(codexInputs).toHaveLength(0);
+      expect(claudeInputs[0]?.provider).toMatchObject({
+        command:
+          "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json",
+        name: "claude"
+      });
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const rows = database
+          .prepare("select id, provider_name from runs order by created_at")
+          .all() as Array<Record<string, unknown>>;
+        expect(rows[0]).toMatchObject({
+          id: "run-fsm-initial-1",
+          provider_name: "claude"
+        });
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("records a deterministic fresh-dispatch failure when the initial state's provider is not registered", async () => {
+    const root = await makeTempRoot();
+    await writeInitialStateClaudeRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulProvider("codex");
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => `run-fsm-initial-missing-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForStoredRunState(root, "failed");
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const row = database
+          .prepare(
+            [
+              "select id, state, provider_name, terminal_reason,",
+              "failure_classification, is_continuation from runs",
+              "order by created_at"
+            ].join(" ")
+          )
+          .get() as Record<string, unknown>;
+        expect(row).toMatchObject({
+          failure_classification: "deterministic",
+          id: "run-fsm-initial-missing-1",
+          is_continuation: 0,
+          provider_name: "claude",
+          state: "failed",
+          terminal_reason: "provider_not_registered: claude"
+        });
+      } finally {
+        database.close();
+      }
+
+      const failedLabelCalls = githubIssuesApi.addLabelsToIssue.mock.calls.filter(
+        (call) => {
+          const arg = call[0] as { labels?: string[] } | undefined;
+          return arg?.labels?.includes("sym:failed") ?? false;
+        }
+      );
+      expect(failedLabelCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("picks the first transition in YAML order when multiple transitions match the observed signals", async () => {
     const root = await makeTempRoot();
     await writeTransitionOrderRawFsmProject(root);
@@ -2660,6 +2814,38 @@ async function writeFallbackProviderRawFsmProject(root: string): Promise<void> {
   await writeFile(
     path.join(root, "implement-prompt.md"),
     "Implement the plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+async function writeInitialStateClaudeRawFsmProject(root: string): Promise<void> {
+  // Project default is codex; the initial raw-FSM state declares claude so a
+  // fresh dispatch must honor the per-state override on attempt 1.
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: initial_state_provider_routing",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: claude",
+      "        prompt: plan-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Draft a plan for #{{issue.number}}: {{issue.title}}.\n"
   );
 }
 


### PR DESCRIPTION
## Summary
- route raw-FSM state advances through state.action.provider when present
- fall back to the project default provider when an agent state omits provider
- record deterministic failed continuation runs when the chosen state provider cannot be resolved

## Tests
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #133