### PR TITLE
feat(lifecycle): propose run lifecycle interface

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,21 @@ _Avoid_: event log when referring to scheduler state
 One orchestrator-managed execution lifecycle for one issue in one workspace.
 _Avoid_: issue when referring to execution status
 
+**Run Lifecycle**:
+The stateful progression of one Run from dispatch selection through provider execution, scheduling,
+waiting, cancellation, or terminal labels.
+_Avoid_: daemon loop when referring to Run-local progression
+
+**Lifecycle Event**:
+A value that asks the Run Lifecycle to decide what should happen next, such as a fresh dispatch
+request, retry timer firing, provider attempt completion, or waiting-row recheck.
+_Avoid_: entrypoint payload
+
+**Planned Step**:
+The next effect chosen by the Run Lifecycle, such as start a label-eligible run, start an FSM-owned
+run, schedule retry, re-evaluate a waiting row, cancel, or mark failed.
+_Avoid_: callback when referring to lifecycle policy
+
 **Continuation**:
 A follow-up run for the same issue after a provider completed successfully but the issue remains eligible.
 _Avoid_: retry when the prior run succeeded
@@ -129,6 +144,7 @@ _Avoid_: chat session
 - A **Normalized Event Log** is derived from a **Provider Event Log**
 - A **Run Store** records durable orchestration state across process restarts
 - A **Run** can succeed even when its **Issue** remains open
+- A **Run Lifecycle** consumes **Lifecycle Events** and chooses **Planned Steps**
 - A **Continuation** is capped so an eligible issue cannot loop forever
 - A **State Advance** is not capped by the continuation cap; the FSM bounds the walk via terminal states
 - A **Bootstrap Slice** operates on one real **Project** before full multi-project behavior is complete

--- a/docs/specs/2026-05-15-run-lifecycle-interface.md
+++ b/docs/specs/2026-05-15-run-lifecycle-interface.md
@@ -1,0 +1,142 @@
+# Run Lifecycle Interface
+
+Status: proposed
+Date: 2026-05-15
+
+## Context
+
+`RunController` currently exposes seven public async entrypoints. Each one is useful, but together
+they make the Run lifecycle hard to inspect: the caller chooses a dispatch flavor and the controller
+finds the lifecycle rule inside private helper choreography. The proposed next shape keeps
+`RunController`'s current behavior intact while introducing a smaller interface:
+
+```ts
+type RunLifecyclePlanner = (input: {
+  state: RunLifecycleState;
+  event: LifecycleEvent;
+}) => PlannedRunLifecycleStep;
+```
+
+This proposal PR only publishes the draft value shapes in
+`src/lifecycle/run-lifecycle-interface.ts`. It does not move existing runtime code.
+
+## Proposed Values
+
+### RunLifecycleState
+
+`RunLifecycleState` is the durable lifecycle posture of a Run or dispatch slot:
+
+- `idle` means no Run has been selected yet.
+- `queued`, `preparing_workspace`, and `running` model provider-backed Runs with their origin
+  (`fresh`, `retry`, `continuation`, `state_advance`, or `review_followup`).
+- `waiting` models a persisted wait or merge state row that must be reconciled by polling.
+- `terminal` models completed rows (`succeeded`, `failed`, `cancelled`, `stale`, or legacy
+  `input_required`).
+
+### LifecycleEvent
+
+`LifecycleEvent` is the stimulus that asks the lifecycle module to decide what should happen next:
+
+- `fresh_dispatch_requested`
+- `retry_due`
+- `continuation_due`
+- `state_advance_due`
+- `wait_park_due`
+- `waiting_run_recheck_due`
+- `review_followup_requested`
+- `provider_attempt_completed`
+- `issue_closed_observed`
+- `eligibility_lost_observed`
+
+The daemon should eventually emit events instead of constructing the current entrypoint payloads
+directly.
+
+### PlannedRunLifecycleStep
+
+`PlannedRunLifecycleStep` is the next effect the lifecycle module wants the runtime to perform:
+
+- start a label-eligible run
+- start a retry attempt
+- start an FSM-owned run
+- start a review follow-up run
+- schedule retry, continuation, state advance, or wait re-evaluation
+- re-evaluate a waiting row
+- cancel a run
+- mark an issue failed
+- do nothing with an explicit reason
+
+The important grain is that policy is carried by the step kind. Label-driven steps and FSM-owned
+steps are different values, so callers do not need to pass a separate `respectsIssueLabels` boolean.
+
+## Entrypoint Mapping
+
+| Current entrypoint | Lifecycle event | First planned step |
+| --- | --- | --- |
+| `dispatchOneFresh` | `fresh_dispatch_requested` | `start_label_eligible_run` |
+| `executeRetry` | `retry_due` | `start_retry_attempt` |
+| `executeContinuation` | `continuation_due` | `start_label_eligible_run` |
+| `executeStateAdvance` | `state_advance_due` | `start_fsm_owned_run` |
+| `executeWaitPark` | `wait_park_due` | `re_evaluate_waiting_run` |
+| `reEvaluateWaitingRun` | `waiting_run_recheck_due` | `re_evaluate_waiting_run` |
+| `dispatchReviewFollowup` | `review_followup_requested` | `start_review_followup_run` |
+
+`executeWaitPark` and `reEvaluateWaitingRun` intentionally converge on the same planned step. The
+former is just the scheduled callback for a waiting row; the latter is the actual polling
+re-evaluation.
+
+## ADR Rule Placement
+
+| ADR | Rule owner in the new shape |
+| --- | --- |
+| ADR 0019, capped continuations | The `provider_attempt_completed:success` planner branch decides whether to emit `schedule_continuation` or `mark_issue_failed` with `cap_reached:*`. |
+| ADR 0020, retry transient only | The failed-outcome planner branch emits `schedule_retry` only for transient classifications; `retry_due` revalidates before `start_retry_attempt`. |
+| ADR 0022, closed issue cancellation | Shared refresh gates for retry, continuation, state advance, and waiting recheck emit `cancel_run` with `closed_issue`. |
+| ADR 0023, eligibility-loss cancellation | Only label-eligible planned steps can emit `cancel_run` with `eligibility_loss`; FSM-owned steps skip that branch. |
+| ADR 0046, state advance vs continuation | `start_fsm_owned_run` and `schedule_state_advance` bypass continuation cap and label re-check by construction. |
+| ADR 0047, poll-driven wait states | `schedule_wait_park` and `re_evaluate_waiting_run` keep wait states as persisted rows reconciled by polling, not provider dispatches. |
+
+## `respectsIssueLabels`
+
+Today the boolean is threaded through `RunController`, `ActiveRunRegistry`, and reconciliation. The
+proposal removes it from the caller-visible lifecycle interface:
+
+- `start_label_eligible_run` means labels are part of the gate.
+- `start_fsm_owned_run` means only issue open/closed state is checked.
+- `re_evaluate_waiting_run` follows the waiting-row rule from ADR 0047.
+- `start_retry_attempt` keeps a temporary `retryScope` because retry can apply to either a
+  label-driven run or an FSM-owned run; during migration this replaces the current boolean at the
+  boundary, then can collapse into separate retry step kinds if the implementation reads better.
+
+## Test Migration
+
+Tests expected to survive verbatim:
+
+- `tests/property-invariants.test.ts`
+- `tests/classify-failure.test.ts`
+- `tests/terminal-reason.test.ts`
+- `tests/pr-signal-projection.test.ts`
+
+Tests expected to get simpler by driving events and planned steps instead of seven entrypoints:
+
+- `tests/dispatch-continuation.test.ts`
+- `tests/dispatch-retry.test.ts`
+- `tests/wait-state.test.ts`
+- `tests/cap-reached-context.test.ts`
+
+Tests expected to be rewritten around the new planner boundary:
+
+- `tests/state-machine-dispatch.test.ts`
+- `tests/daemon-dispatch.test.ts`
+
+## Migration Sketch
+
+1. Add a planner that accepts `RunLifecycleState` and `LifecycleEvent` and returns a
+   `PlannedRunLifecycleStep`.
+2. Route one existing entrypoint through the planner without changing behavior.
+3. Repeat for each entrypoint, keeping every PR independently reviewable.
+4. Move `respectsIssueLabels` policy behind planned step kinds.
+5. Let `daemon.ts` emit lifecycle events instead of constructing entrypoint-specific payloads.
+
+No new ADR is proposed in this PR. The interface is deliberately marked `proposed`; if reviewers
+accept this shape as load-bearing, the accepted follow-up can promote the decision into an ADR
+before runtime migration continues.

--- a/src/lifecycle/run-lifecycle-interface.ts
+++ b/src/lifecycle/run-lifecycle-interface.ts
@@ -1,0 +1,288 @@
+export type RunLifecycleRunKind =
+  | "fresh"
+  | "retry"
+  | "continuation"
+  | "state_advance"
+  | "wait_park"
+  | "review_followup";
+
+export type RunLifecycleState =
+  | { kind: "idle" }
+  | {
+      currentStateId?: string | null;
+      issueNumber: number;
+      kind: "queued" | "preparing_workspace" | "running";
+      projectName: string;
+      runId: string;
+      runKind: Exclude<RunLifecycleRunKind, "wait_park">;
+    }
+  | {
+      currentStateId: string;
+      issueNumber: number;
+      kind: "waiting";
+      projectName: string;
+      runId: string;
+      waitingKind: "wait" | "merge_pr";
+    }
+  | {
+      issueNumber: number;
+      kind: "terminal";
+      projectName: string;
+      runId: string;
+      terminalReason?: string;
+      terminalState:
+        | "cancelled"
+        | "failed"
+        | "input_required"
+        | "stale"
+        | "succeeded";
+    };
+
+export type LifecycleEvent =
+  | { kind: "fresh_dispatch_requested" }
+  | {
+      attemptNumber: number;
+      issueNumber: number;
+      kind: "retry_due";
+      projectName: string;
+      runId: string;
+    }
+  | {
+      issueNumber: number;
+      kind: "continuation_due" | "state_advance_due";
+      parentRunId: string;
+      projectName: string;
+    }
+  | { kind: "wait_park_due"; waitingRunId: string }
+  | { kind: "waiting_run_recheck_due"; runId: string }
+  | {
+      issueNumber: number;
+      kind: "review_followup_requested";
+      parentRunId: string;
+      projectName: string;
+      pullRequestNumber: number;
+    }
+  | {
+      issueNumber: number;
+      kind: "provider_attempt_completed";
+      outcome: "success" | "failed" | "cancelled" | "input_required";
+      projectName: string;
+      runId: string;
+    }
+  | {
+      issueNumber: number;
+      kind: "issue_closed_observed" | "eligibility_lost_observed";
+      projectName: string;
+      runId: string;
+    };
+
+export type PlannedRunLifecycleStep =
+  | {
+      issueNumber: number;
+      kind: "start_label_eligible_run";
+      parentRunId?: string;
+      projectName: string;
+      runKind: "fresh" | "continuation";
+    }
+  | {
+      attemptNumber: number;
+      issueNumber: number;
+      kind: "start_retry_attempt";
+      projectName: string;
+      retryScope: "label_eligible" | "fsm_owned";
+      runId: string;
+    }
+  | {
+      issueNumber: number;
+      kind: "start_fsm_owned_run";
+      parentRunId: string;
+      projectName: string;
+      toStateId?: string;
+    }
+  | {
+      issueNumber: number;
+      kind: "start_review_followup_run";
+      parentRunId: string;
+      projectName: string;
+      pullRequestNumber: number;
+    }
+  | {
+      kind: "re_evaluate_waiting_run";
+      waitingRunId: string;
+    }
+  | {
+      delayMs: number;
+      issueNumber: number;
+      kind:
+        | "schedule_retry"
+        | "schedule_continuation"
+        | "schedule_state_advance";
+      parentRunId?: string;
+      projectName: string;
+      runId?: string;
+      toStateId?: string;
+    }
+  | {
+      delayMs: number;
+      issueNumber: number;
+      kind: "schedule_wait_park";
+      projectName: string;
+      waitingRunId: string;
+    }
+  | {
+      issueNumber: number;
+      kind: "cancel_run";
+      projectName: string;
+      reason: "closed_issue" | "eligibility_loss" | "operator";
+      runId: string;
+    }
+  | {
+      issueNumber: number;
+      kind: "mark_issue_failed";
+      projectName: string;
+      reason: string;
+      runId: string;
+    }
+  | { kind: "no_op"; reason: string };
+
+export type LegacyRunControllerEntrypoint =
+  | "dispatchOneFresh"
+  | "executeRetry"
+  | "executeContinuation"
+  | "executeStateAdvance"
+  | "executeWaitPark"
+  | "reEvaluateWaitingRun"
+  | "dispatchReviewFollowup";
+
+export type LifecycleEventKind = LifecycleEvent["kind"];
+export type PlannedRunLifecycleStepKind = PlannedRunLifecycleStep["kind"];
+
+export type RunLifecycleEntrypointMapping = {
+  eventKind: LifecycleEventKind;
+  legacyEntrypoint: LegacyRunControllerEntrypoint;
+  plannedStepKind: PlannedRunLifecycleStepKind;
+  rule: string;
+};
+
+export const RUN_LIFECYCLE_ENTRYPOINT_MAPPING = [
+  {
+    eventKind: "fresh_dispatch_requested",
+    legacyEntrypoint: "dispatchOneFresh",
+    plannedStepKind: "start_label_eligible_run",
+    rule:
+      "Select one eligible issue, claim it, create the first run, and execute the first provider attempt."
+  },
+  {
+    eventKind: "retry_due",
+    legacyEntrypoint: "executeRetry",
+    plannedStepKind: "start_retry_attempt",
+    rule:
+      "Retry only a transient failure; closed issues always cancel, while label checks depend on the retry scope."
+  },
+  {
+    eventKind: "continuation_due",
+    legacyEntrypoint: "executeContinuation",
+    plannedStepKind: "start_label_eligible_run",
+    rule:
+      "Start a capped follow-up run only if the issue is still open and still label eligible."
+  },
+  {
+    eventKind: "state_advance_due",
+    legacyEntrypoint: "executeStateAdvance",
+    plannedStepKind: "start_fsm_owned_run",
+    rule:
+      "Start the next raw-FSM agent state after verifying only that the issue is still open."
+  },
+  {
+    eventKind: "wait_park_due",
+    legacyEntrypoint: "executeWaitPark",
+    plannedStepKind: "re_evaluate_waiting_run",
+    rule:
+      "Re-evaluate an already-persisted waiting row without launching a provider."
+  },
+  {
+    eventKind: "waiting_run_recheck_due",
+    legacyEntrypoint: "reEvaluateWaitingRun",
+    plannedStepKind: "re_evaluate_waiting_run",
+    rule:
+      "Poll GitHub PR signals for a waiting row, then advance, park again, terminate, or cancel."
+  },
+  {
+    eventKind: "review_followup_requested",
+    legacyEntrypoint: "dispatchReviewFollowup",
+    plannedStepKind: "start_review_followup_run",
+    rule:
+      "Start a same-branch PR follow-up run when tracked review feedback requires more work."
+  }
+] as const satisfies readonly RunLifecycleEntrypointMapping[];
+
+export type RunLifecycleAdrRule = {
+  adr: "0019" | "0020" | "0022" | "0023" | "0046" | "0047";
+  plannedStepKinds: readonly PlannedRunLifecycleStepKind[];
+  ruleLocation: string;
+  summary: string;
+};
+
+export const RUN_LIFECYCLE_ADR_RULES = [
+  {
+    adr: "0019",
+    plannedStepKinds: ["schedule_continuation", "mark_issue_failed"],
+    ruleLocation: "Planner branch for provider_attempt_completed:success",
+    summary:
+      "Capped label-driven continuations live where success events decide whether to schedule a continuation or surface cap_reached."
+  },
+  {
+    adr: "0020",
+    plannedStepKinds: ["schedule_retry", "start_retry_attempt"],
+    ruleLocation: "Planner branch for transient failed outcomes and retry_due",
+    summary:
+      "Retry eligibility is decided once from the classified failure; deterministic failures never plan retry steps."
+  },
+  {
+    adr: "0022",
+    plannedStepKinds: ["cancel_run"],
+    ruleLocation: "Refresh gates shared by retry, continuation, state advance, and waiting recheck",
+    summary:
+      "Closed issues plan cancellation and terminal label cleanup without deleting workspace evidence."
+  },
+  {
+    adr: "0023",
+    plannedStepKinds: ["cancel_run"],
+    ruleLocation: "Label-eligible active run and scheduled retry/continuation gates",
+    summary:
+      "Eligibility loss cancels only runs or scheduled work whose planned step is label eligible."
+  },
+  {
+    adr: "0046",
+    plannedStepKinds: ["start_fsm_owned_run", "schedule_state_advance"],
+    ruleLocation: "FSM-owned planned step kinds",
+    summary:
+      "State advance bypasses continuation caps and label re-checks; the planned step kind encodes that policy directly."
+  },
+  {
+    adr: "0047",
+    plannedStepKinds: ["schedule_wait_park", "re_evaluate_waiting_run"],
+    ruleLocation: "Waiting-row planner branch",
+    summary:
+      "Wait states are persisted as waiting rows and re-evaluated by polling, not dispatched as provider attempts."
+  }
+] as const satisfies readonly RunLifecycleAdrRule[];
+
+export const RUN_LIFECYCLE_TEST_MIGRATION_PLAN = {
+  surviveVerbatim: [
+    "tests/property-invariants.test.ts",
+    "tests/classify-failure.test.ts",
+    "tests/terminal-reason.test.ts",
+    "tests/pr-signal-projection.test.ts"
+  ],
+  getSimpler: [
+    "tests/dispatch-continuation.test.ts",
+    "tests/dispatch-retry.test.ts",
+    "tests/wait-state.test.ts",
+    "tests/cap-reached-context.test.ts"
+  ],
+  getRewritten: [
+    "tests/state-machine-dispatch.test.ts",
+    "tests/daemon-dispatch.test.ts"
+  ]
+} as const;

--- a/tests/run-lifecycle-interface.test.ts
+++ b/tests/run-lifecycle-interface.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RUN_LIFECYCLE_ADR_RULES,
+  RUN_LIFECYCLE_ENTRYPOINT_MAPPING,
+  RUN_LIFECYCLE_TEST_MIGRATION_PLAN,
+  type LifecycleEvent,
+  type PlannedRunLifecycleStep,
+  type RunLifecycleState
+} from "../src/lifecycle/run-lifecycle-interface.js";
+
+describe("run lifecycle interface proposal", () => {
+  it("maps every current RunController entrypoint onto a lifecycle event and planned step", () => {
+    expect(
+      RUN_LIFECYCLE_ENTRYPOINT_MAPPING.map((entry) => entry.legacyEntrypoint)
+    ).toEqual([
+      "dispatchOneFresh",
+      "executeRetry",
+      "executeContinuation",
+      "executeStateAdvance",
+      "executeWaitPark",
+      "reEvaluateWaitingRun",
+      "dispatchReviewFollowup"
+    ]);
+
+    expect(
+      RUN_LIFECYCLE_ENTRYPOINT_MAPPING.map((entry) => [
+        entry.eventKind,
+        entry.plannedStepKind
+      ])
+    ).toEqual([
+      ["fresh_dispatch_requested", "start_label_eligible_run"],
+      ["retry_due", "start_retry_attempt"],
+      ["continuation_due", "start_label_eligible_run"],
+      ["state_advance_due", "start_fsm_owned_run"],
+      ["wait_park_due", "re_evaluate_waiting_run"],
+      ["waiting_run_recheck_due", "re_evaluate_waiting_run"],
+      ["review_followup_requested", "start_review_followup_run"]
+    ]);
+  });
+
+  it("keeps the accepted ADR rules attached to proposed planner ownership", () => {
+    expect(RUN_LIFECYCLE_ADR_RULES.map((rule) => rule.adr)).toEqual([
+      "0019",
+      "0020",
+      "0022",
+      "0023",
+      "0046",
+      "0047"
+    ]);
+
+    for (const rule of RUN_LIFECYCLE_ADR_RULES) {
+      expect(rule.ruleLocation).not.toHaveLength(0);
+      expect(rule.plannedStepKinds.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("documents which lifecycle tests survive, simplify, and get rewritten", () => {
+    expect(RUN_LIFECYCLE_TEST_MIGRATION_PLAN.surviveVerbatim).toContain(
+      "tests/property-invariants.test.ts"
+    );
+    expect(RUN_LIFECYCLE_TEST_MIGRATION_PLAN.getSimpler).toContain(
+      "tests/dispatch-continuation.test.ts"
+    );
+    expect(RUN_LIFECYCLE_TEST_MIGRATION_PLAN.getRewritten).toContain(
+      "tests/state-machine-dispatch.test.ts"
+    );
+  });
+
+  it("defines the proposed state, event, and planned-step values as a consumable interface", () => {
+    const state: RunLifecycleState = {
+      currentStateId: "implement",
+      issueNumber: 139,
+      kind: "running",
+      projectName: "symphonika",
+      runId: "run-139",
+      runKind: "state_advance"
+    };
+    const event: LifecycleEvent = {
+      issueNumber: 139,
+      kind: "provider_attempt_completed",
+      outcome: "success",
+      projectName: "symphonika",
+      runId: "run-139"
+    };
+    const planned: PlannedRunLifecycleStep = {
+      delayMs: 1_000,
+      issueNumber: 139,
+      kind: "schedule_state_advance",
+      parentRunId: "run-139",
+      projectName: "symphonika",
+      toStateId: "review"
+    };
+
+    expect([state.kind, event.kind, planned.kind]).toEqual([
+      "running",
+      "provider_attempt_completed",
+      "schedule_state_advance"
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add proposed Run Lifecycle state, Lifecycle Event, and Planned Step types.
- Document how the seven current RunController entrypoints map onto the new interface.
- Add Run Lifecycle, Lifecycle Event, and Planned Step to CONTEXT.md.

## ADR Rule Placement
- ADR 0019: capped continuations live in the provider_attempt_completed:success planner branch, which chooses schedule_continuation or mark_issue_failed with cap_reached.
- ADR 0020: transient-only retry lives in the failed-outcome planner branch and retry_due validation before start_retry_attempt.
- ADR 0022: closed issue cancellation lives in shared refresh gates for retry, continuation, state advance, and waiting recheck, which plan cancel_run closed_issue.
- ADR 0023: eligibility-loss cancellation lives only on label-eligible planned steps; FSM-owned steps skip label eligibility.
- ADR 0046: state advance rules live on start_fsm_owned_run and schedule_state_advance, bypassing continuation cap and label re-check.
- ADR 0047: wait-state polling lives on schedule_wait_park and re_evaluate_waiting_run, preserving persisted waiting rows instead of provider dispatch.

## Tests
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #139