### PR TITLE
refactor: centralize pull request state interpretation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,10 @@ _Avoid_: orchestrator workflow
 The orchestrator-owned polling loop for pull requests discovered from Symphonika-created Issue Branches; it re-dispatches review feedback and merges PRs only when policy says they are clear.
 _Avoid_: arbitrary PR detection
 
+**Pull Request State**:
+Symphonika's normalized interpretation of a GitHub PR's merged, mergeable, checks, unresolved-thread, and review-decision state; it is the single source of meaning consumed by both Workflow Predicate projection and PR Follow-up verdicts.
+_Avoid_: raw GitHub pull request state
+
 **Coding Agent**:
 An external automation runtime that works on an issue inside a workspace.
 _Avoid_: orchestrator, worker
@@ -136,6 +140,7 @@ _Avoid_: chat session
 - A **Coding Agent** may write **Workflow Labels**
 - A **Coding Agent** owns the **PR Workflow**
 - A **PR Follow-up** watches only PRs associated with completed Symphonika **Runs**
+- **Pull Request State** is derived from tracker observations and feeds **Workflow Predicate** projection and **PR Follow-up** verdicts
 - Each dispatched **Issue** has exactly one active **Workspace** per run
 - Each **Workspace** uses one **Issue Branch**
 - A **Coding Agent** executes within a **Workspace** for one **Issue**

--- a/docs/adr/0047-poll-driven-wait-states.md
+++ b/docs/adr/0047-poll-driven-wait-states.md
@@ -67,5 +67,6 @@ Unresolved review feedback is projected as both the exact `unresolved_review_thr
 derived `has_unresolved_reviews` boolean, so strict-equality transitions can match "any unresolved
 review exists" without comparator syntax.
 
-The PR follow-up logic in `src/pull-request-followup.ts` shares `projectPullRequestSignals` with
-the wait handler so the two paths cannot drift in how they interpret a given GitHub state.
+Raw GitHub PR observations are first interpreted as **Pull Request State**. The PR follow-up
+verdicts in `src/pull-request-followup.ts` and the wait-handler predicate projection both derive
+from that normalized value so the two paths cannot drift in how they interpret a given GitHub state.

--- a/src/lifecycle/pr-signal-projection.ts
+++ b/src/lifecycle/pr-signal-projection.ts
@@ -1,70 +1,45 @@
-import type { RawGitHubPullRequestFollowupState } from "../issue-polling.js";
+import type { PullRequestState } from "../pull-request-state.js";
 import type { WorkflowPredicateMap } from "../workflow.js";
 
-// Wait-state re-evaluation uses these signals via decideNextStep. The PR
-// follow-up dispatcher in src/pull-request-followup.ts reads the same
-// `RawGitHubPullRequestFollowupState` but produces binary verdicts
-// (pullRequestNeedsReviewFollowup, pullRequestReadyToMerge) rather than a
-// predicate map. If either side changes how it interprets a given GitHub
-// state (e.g. mergeable=UNKNOWN), update both to keep them aligned. See
-// ADR 0047.
 export function projectPullRequestSignals(
-  state: RawGitHubPullRequestFollowupState
+  state: PullRequestState
 ): WorkflowPredicateMap {
   const signals: WorkflowPredicateMap = {
-    pr_open: state.state === "OPEN"
+    pr_open: state.open
   };
 
-  if (state.merged === true) {
+  if (state.merged) {
     signals.pr_merged = true;
   }
 
-  if (state.mergeable === "MERGEABLE") {
+  if (state.mergeable === "mergeable") {
     signals.mergeable = true;
-  } else if (state.mergeable === "CONFLICTING") {
+  } else if (state.mergeable === "conflicting") {
     signals.mergeable = false;
   }
 
-  const checks = mapStatusCheckRollup(state.statusCheckRollupState);
-  if (checks !== null) {
-    signals.checks = checks;
+  if (state.checks !== "unknown") {
+    signals.checks = state.checks;
   }
 
   signals.review_decision = mapReviewDecision(state.reviewDecision);
-  signals.unresolved_review_threads = state.unresolvedReviewThreads.length;
-  signals.has_unresolved_reviews = state.unresolvedReviewThreads.length > 0;
+  signals.unresolved_review_threads = state.unresolvedReviewThreads;
+  signals.has_unresolved_reviews = state.unresolvedReviewThreads > 0;
 
   return signals;
 }
 
 function mapReviewDecision(
-  reviewDecision: RawGitHubPullRequestFollowupState["reviewDecision"]
+  reviewDecision: PullRequestState["reviewDecision"]
 ): "approved" | "changes_requested" | "none" | "review_required" {
   switch (reviewDecision) {
-    case "APPROVED":
+    case "approved":
       return "approved";
-    case "CHANGES_REQUESTED":
+    case "changes_requested":
       return "changes_requested";
-    case "REVIEW_REQUIRED":
+    case "review_required":
       return "review_required";
     default:
       return "none";
-  }
-}
-
-function mapStatusCheckRollup(
-  rollup: RawGitHubPullRequestFollowupState["statusCheckRollupState"]
-): "failure" | "pending" | "success" | null {
-  switch (rollup) {
-    case "SUCCESS":
-      return "success";
-    case "FAILURE":
-    case "ERROR":
-      return "failure";
-    case "PENDING":
-    case "EXPECTED":
-      return "pending";
-    default:
-      return null;
   }
 }

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -24,6 +24,7 @@ import {
   pullRequestReadyToMerge,
   type PullRequestFollowupPolicy
 } from "../pull-request-followup.js";
+import { interpretPullRequest } from "../pull-request-state.js";
 import { projectPullRequestSignals } from "./pr-signal-projection.js";
 import type {
   AgentProvider,
@@ -741,9 +742,10 @@ export class RunController {
       return;
     }
 
+    const pullRequestState = interpretPullRequest(prState);
     const signals: WorkflowPredicateMap = {
       provider_success: true,
-      ...projectPullRequestSignals(prState)
+      ...projectPullRequestSignals(pullRequestState)
     };
 
     if (isMergePr) {
@@ -759,10 +761,10 @@ export class RunController {
           { runId },
           "symphonika merge_pr re-eval: merge disabled by policy"
         );
-      } else if (pullRequestReadyToMerge(prState, policy)) {
+      } else if (pullRequestReadyToMerge(pullRequestState, policy)) {
         try {
           const merged = await tryMergePullRequest(this.githubIssuesApi, {
-            expectedHeadSha: prState.headSha,
+            expectedHeadSha: pullRequestState.headSha,
             method,
             owner: repository.owner,
             pullNumber: tracked.prNumber,
@@ -777,17 +779,17 @@ export class RunController {
             // pre-merge fetch and a refetch-style transition would silently
             // stay parked even though the merge succeeded.
             const mergedSignals = projectPullRequestSignals({
-              ...prState,
+              ...pullRequestState,
               merged: true,
-              state: "MERGED"
+              open: false
             });
             for (const key of Object.keys(mergedSignals)) {
               signals[key] = mergedSignals[key]!;
             }
             this.runStore.recordPullRequestObservation({
-              headSha: prState.headSha,
+              headSha: pullRequestState.headSha,
               id: tracked.id,
-              prUrl: prState.url,
+              prUrl: pullRequestState.url,
               state: "merged"
             });
             this.runStore.recordWaitingActivity(

--- a/src/pull-request-followup.ts
+++ b/src/pull-request-followup.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 
 import type { Logger } from "pino";
@@ -22,6 +21,10 @@ import type {
   RunController,
   RunControllerProjectConfig
 } from "./lifecycle/run-controller.js";
+import {
+  interpretPullRequest,
+  type PullRequestState
+} from "./pull-request-state.js";
 import type { RunStore, TrackedPullRequest } from "./run-store.js";
 
 export type PullRequestFollowupPolicy = {
@@ -173,65 +176,44 @@ export function pullRequestFollowupPolicyFromRaw(
 }
 
 export function pullRequestNeedsReviewFollowup(
-  state: RawGitHubPullRequestFollowupState
+  state: PullRequestState
 ): boolean {
   return (
-    state.reviewDecision === "CHANGES_REQUESTED" ||
-    state.unresolvedReviewThreads.length > 0
+    state.reviewDecision === "changes_requested" ||
+    state.unresolvedReviewThreads > 0
   );
 }
 
 export function pullRequestReadyToMerge(
-  state: RawGitHubPullRequestFollowupState,
+  state: PullRequestState,
   policy: PullRequestFollowupPolicy = DEFAULT_PULL_REQUEST_FOLLOWUP_POLICY
 ): boolean {
-  if (!policy.merge.enabled || state.draft || state.merged || state.state !== "OPEN") {
+  if (!policy.merge.enabled || state.draft || state.merged || !state.open) {
     return false;
   }
-  if (state.mergeable !== "MERGEABLE") {
+  if (state.mergeable !== "mergeable") {
     return false;
   }
-  if (
-    policy.merge.requireStatusSuccess &&
-    state.statusCheckRollupState !== "SUCCESS"
-  ) {
+  if (policy.merge.requireStatusSuccess && state.checks !== "success") {
     return false;
   }
   if (
     policy.merge.requireReviewDecision &&
-    state.reviewDecision !== "APPROVED"
+    state.reviewDecision !== "approved"
   ) {
     return false;
   }
   return (
-    state.reviewDecision !== "CHANGES_REQUESTED" &&
-    state.reviewDecision !== "REVIEW_REQUIRED" &&
-    state.unresolvedReviewThreads.length === 0
+    state.reviewDecision !== "changes_requested" &&
+    state.reviewDecision !== "review_required" &&
+    state.unresolvedReviewThreads === 0
   );
 }
 
 export function reviewFeedbackFingerprint(
-  state: RawGitHubPullRequestFollowupState
+  state: PullRequestState
 ): string {
-  return `sha256:${createHash("sha256")
-    .update(
-      JSON.stringify({
-        headSha: state.headSha,
-        reviewDecision: state.reviewDecision,
-        threads: state.unresolvedReviewThreads.map((thread) => ({
-          comments: thread.comments.map((comment) => ({
-            body: comment.body,
-            createdAt: comment.createdAt,
-            url: comment.url
-          })),
-          id: thread.id,
-          isOutdated: thread.isOutdated,
-          line: thread.line,
-          path: thread.path
-        }))
-      })
-    )
-    .digest("hex")}`;
+  return state.reviewFollowup.feedbackFingerprint;
 }
 
 async function discoverPullRequests(input: {
@@ -304,16 +286,16 @@ async function processTrackedPullRequests(input: {
     if (project === undefined || repository === undefined) {
       continue;
     }
-    const state = await loadPullRequestState({
+    const rawState = await loadRawPullRequestState({
       api: input.githubIssuesApi,
       ...(input.logger === undefined ? {} : { logger: input.logger }),
       repository,
       tracked
     });
-    if (state === undefined) {
+    if (rawState === undefined) {
       continue;
     }
-    if (state === null) {
+    if (rawState === null) {
       input.runStore.recordPullRequestObservation({
         headSha: tracked.lastSeenHeadSha,
         id: tracked.id,
@@ -323,6 +305,7 @@ async function processTrackedPullRequests(input: {
       continue;
     }
 
+    const state = interpretPullRequest(rawState);
     const trackingState = trackedStateFor(state);
     input.runStore.recordPullRequestObservation({
       headSha: state.headSha,
@@ -396,7 +379,7 @@ async function dispatchReviewFollowupIfNeeded(input: {
   policy: PullRequestFollowupPolicy;
   runController: RunController;
   runStore: RunStore;
-  state: RawGitHubPullRequestFollowupState;
+  state: PullRequestState;
   tracked: TrackedPullRequest;
 }): Promise<PullRequestFollowupResult | undefined> {
   if (
@@ -434,7 +417,7 @@ async function dispatchReviewFollowupIfNeeded(input: {
   };
 }
 
-async function loadPullRequestState(input: {
+async function loadRawPullRequestState(input: {
   api: GitHubIssuesApi;
   logger?: Logger;
   repository: GitHubIssueRepositoryInput;
@@ -488,27 +471,19 @@ function selectOpenPullRequest(
   );
 }
 
-function trackedStateFor(
-  state: RawGitHubPullRequestFollowupState
-): "closed" | "merged" | "open" {
-  if (state.merged || state.state === "MERGED") {
-    return "merged";
-  }
-  if (state.state === "CLOSED") {
-    return "closed";
-  }
-  return "open";
+function trackedStateFor(state: PullRequestState): "closed" | "merged" | "open" {
+  return state.trackingState;
 }
 
 function reviewContextFromState(
-  state: RawGitHubPullRequestFollowupState
+  state: PullRequestState
 ): ReviewFollowupContext {
   return {
     headSha: state.headSha,
     pullRequestNumber: state.number,
     pullRequestUrl: state.url,
-    reviewDecision: state.reviewDecision,
-    statusCheckRollupState: state.statusCheckRollupState,
-    unresolvedThreads: state.unresolvedReviewThreads
+    reviewDecision: state.reviewFollowup.decision,
+    statusCheckRollupState: state.reviewFollowup.checks,
+    unresolvedThreads: state.reviewFollowup.unresolvedThreads
   };
 }

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -1,0 +1,142 @@
+import { createHash } from "node:crypto";
+
+import type {
+  RawGitHubPullRequestFollowupState,
+  RawGitHubPullRequestReviewThread
+} from "./issue-polling.js";
+
+export type PullRequestChecksState =
+  | "failure"
+  | "pending"
+  | "success"
+  | "unknown";
+
+export type PullRequestState = {
+  headSha: string;
+  open: boolean;
+  merged: boolean;
+  draft: boolean;
+  number: number;
+  url: string;
+  mergeable: "mergeable" | "conflicting" | "unknown";
+  checks: PullRequestChecksState;
+  reviewDecision:
+    | "approved"
+    | "changes_requested"
+    | "review_required"
+    | "commented"
+    | "unknown";
+  reviewFollowup: {
+    checks: RawGitHubPullRequestFollowupState["statusCheckRollupState"];
+    decision: RawGitHubPullRequestFollowupState["reviewDecision"];
+    feedbackFingerprint: string;
+    unresolvedThreads: RawGitHubPullRequestReviewThread[];
+  };
+  trackingState: "closed" | "merged" | "open";
+  unresolvedReviewThreads: number;
+};
+
+export function interpretPullRequest(
+  raw: RawGitHubPullRequestFollowupState
+): PullRequestState {
+  return {
+    checks: interpretChecks(raw.statusCheckRollupState),
+    draft: raw.draft,
+    headSha: raw.headSha,
+    mergeable: interpretMergeable(raw.mergeable),
+    merged: raw.merged || raw.state === "MERGED",
+    number: raw.number,
+    open: raw.state === "OPEN",
+    reviewDecision: interpretReviewDecision(raw.reviewDecision),
+    reviewFollowup: {
+      checks: raw.statusCheckRollupState,
+      decision: raw.reviewDecision,
+      feedbackFingerprint: computeReviewFeedbackFingerprint(raw),
+      unresolvedThreads: raw.unresolvedReviewThreads
+    },
+    trackingState: interpretTrackingState(raw),
+    unresolvedReviewThreads: raw.unresolvedReviewThreads.length,
+    url: raw.url
+  };
+}
+
+function interpretTrackingState(
+  raw: RawGitHubPullRequestFollowupState
+): PullRequestState["trackingState"] {
+  if (raw.merged || raw.state === "MERGED") {
+    return "merged";
+  }
+  if (raw.state === "CLOSED") {
+    return "closed";
+  }
+  return "open";
+}
+
+function interpretMergeable(
+  mergeable: RawGitHubPullRequestFollowupState["mergeable"]
+): PullRequestState["mergeable"] {
+  switch (mergeable) {
+    case "MERGEABLE":
+      return "mergeable";
+    case "CONFLICTING":
+      return "conflicting";
+    default:
+      return "unknown";
+  }
+}
+
+function interpretChecks(
+  rollup: RawGitHubPullRequestFollowupState["statusCheckRollupState"]
+): PullRequestChecksState {
+  switch (rollup) {
+    case "SUCCESS":
+      return "success";
+    case "FAILURE":
+    case "ERROR":
+      return "failure";
+    case "PENDING":
+    case "EXPECTED":
+      return "pending";
+    default:
+      return "unknown";
+  }
+}
+
+function interpretReviewDecision(
+  decision: RawGitHubPullRequestFollowupState["reviewDecision"]
+): PullRequestState["reviewDecision"] {
+  switch (decision) {
+    case "APPROVED":
+      return "approved";
+    case "CHANGES_REQUESTED":
+      return "changes_requested";
+    case "REVIEW_REQUIRED":
+      return "review_required";
+    default:
+      return "unknown";
+  }
+}
+
+function computeReviewFeedbackFingerprint(
+  raw: RawGitHubPullRequestFollowupState
+): string {
+  return `sha256:${createHash("sha256")
+    .update(
+      JSON.stringify({
+        headSha: raw.headSha,
+        reviewDecision: raw.reviewDecision,
+        threads: raw.unresolvedReviewThreads.map((thread) => ({
+          comments: thread.comments.map((comment) => ({
+            body: comment.body,
+            createdAt: comment.createdAt,
+            url: comment.url
+          })),
+          id: thread.id,
+          isOutdated: thread.isOutdated,
+          line: thread.line,
+          path: thread.path
+        }))
+      })
+    )
+    .digest("hex")}`;
+}

--- a/tests/pr-signal-projection.test.ts
+++ b/tests/pr-signal-projection.test.ts
@@ -1,21 +1,28 @@
 import { describe, expect, it } from "vitest";
 
-import type { RawGitHubPullRequestFollowupState } from "../src/issue-polling.js";
 import { projectPullRequestSignals } from "../src/lifecycle/pr-signal-projection.js";
+import type { PullRequestState } from "../src/pull-request-state.js";
 
 function makePullRequestState(
-  overrides: Partial<RawGitHubPullRequestFollowupState> = {}
-): RawGitHubPullRequestFollowupState {
+  overrides: Partial<PullRequestState> = {}
+): PullRequestState {
   return {
+    checks: "unknown",
     draft: false,
     headSha: "deadbeef",
-    mergeable: null,
+    mergeable: "unknown",
     merged: false,
     number: 42,
-    reviewDecision: null,
-    state: "OPEN",
-    statusCheckRollupState: null,
-    unresolvedReviewThreads: [],
+    open: true,
+    reviewDecision: "unknown",
+    reviewFollowup: {
+      checks: null,
+      decision: null,
+      feedbackFingerprint: "sha256:test",
+      unresolvedThreads: []
+    },
+    trackingState: "open",
+    unresolvedReviewThreads: 0,
     url: "https://example.test/pr/42",
     ...overrides
   };
@@ -23,18 +30,18 @@ function makePullRequestState(
 
 describe("projectPullRequestSignals", () => {
   it("emits pr_open: true for an open pull request", () => {
-    const signals = projectPullRequestSignals(makePullRequestState({ state: "OPEN" }));
+    const signals = projectPullRequestSignals(makePullRequestState({ open: true }));
     expect(signals.pr_open).toBe(true);
   });
 
   it("emits pr_open: false for a closed pull request", () => {
-    const signals = projectPullRequestSignals(makePullRequestState({ state: "CLOSED" }));
+    const signals = projectPullRequestSignals(makePullRequestState({ open: false }));
     expect(signals.pr_open).toBe(false);
   });
 
   it("emits pr_merged: true when the pull request is merged", () => {
     const signals = projectPullRequestSignals(
-      makePullRequestState({ state: "MERGED", merged: true })
+      makePullRequestState({ merged: true, open: false })
     );
     expect(signals.pr_merged).toBe(true);
     expect(signals.pr_open).toBe(false);
@@ -46,63 +53,52 @@ describe("projectPullRequestSignals", () => {
   });
 
   it("emits mergeable: true for MERGEABLE state", () => {
-    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: "MERGEABLE" }));
+    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: "mergeable" }));
     expect(signals.mergeable).toBe(true);
   });
 
   it("emits mergeable: false for CONFLICTING state", () => {
-    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: "CONFLICTING" }));
+    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: "conflicting" }));
     expect(signals.mergeable).toBe(false);
   });
 
-  it("omits mergeable when state is UNKNOWN", () => {
-    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: "UNKNOWN" }));
+  it("omits mergeable when state is unknown", () => {
+    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: "unknown" }));
     expect("mergeable" in signals).toBe(false);
   });
 
-  it("omits mergeable when state is null", () => {
-    const signals = projectPullRequestSignals(makePullRequestState({ mergeable: null }));
-    expect("mergeable" in signals).toBe(false);
-  });
-
-  it("emits checks: 'success' for SUCCESS rollup", () => {
+  it("emits checks: 'success' for successful checks", () => {
     const signals = projectPullRequestSignals(
-      makePullRequestState({ statusCheckRollupState: "SUCCESS" })
+      makePullRequestState({ checks: "success" })
     );
     expect(signals.checks).toBe("success");
   });
 
-  it("emits checks: 'failure' for FAILURE and ERROR rollups", () => {
-    for (const rollup of ["FAILURE", "ERROR"] as const) {
-      const signals = projectPullRequestSignals(
-        makePullRequestState({ statusCheckRollupState: rollup })
-      );
-      expect(signals.checks).toBe("failure");
-    }
-  });
-
-  it("emits checks: 'pending' for PENDING and EXPECTED rollups", () => {
-    for (const rollup of ["PENDING", "EXPECTED"] as const) {
-      const signals = projectPullRequestSignals(
-        makePullRequestState({ statusCheckRollupState: rollup })
-      );
-      expect(signals.checks).toBe("pending");
-    }
-  });
-
-  it("omits checks when rollup is null", () => {
+  it("emits checks: 'failure' for failed checks", () => {
     const signals = projectPullRequestSignals(
-      makePullRequestState({ statusCheckRollupState: null })
+      makePullRequestState({ checks: "failure" })
     );
+    expect(signals.checks).toBe("failure");
+  });
+
+  it("emits checks: 'pending' for pending checks", () => {
+    const signals = projectPullRequestSignals(
+      makePullRequestState({ checks: "pending" })
+    );
+    expect(signals.checks).toBe("pending");
+  });
+
+  it("omits checks when checks are unknown", () => {
+    const signals = projectPullRequestSignals(makePullRequestState({ checks: "unknown" }));
     expect("checks" in signals).toBe(false);
   });
 
   it("emits normalized review_decision states", () => {
     const cases = [
-      ["APPROVED", "approved"],
-      ["CHANGES_REQUESTED", "changes_requested"],
-      ["REVIEW_REQUIRED", "review_required"],
-      [null, "none"]
+      ["approved", "approved"],
+      ["changes_requested", "changes_requested"],
+      ["review_required", "review_required"],
+      ["unknown", "none"]
     ] as const;
 
     for (const [reviewDecision, expected] of cases) {
@@ -115,31 +111,24 @@ describe("projectPullRequestSignals", () => {
 
   it("emits unresolved_review_threads as the numeric count", () => {
     const zero = projectPullRequestSignals(
-      makePullRequestState({ unresolvedReviewThreads: [] })
+      makePullRequestState({ unresolvedReviewThreads: 0 })
     );
     expect(zero.unresolved_review_threads).toBe(0);
 
     const two = projectPullRequestSignals(
-      makePullRequestState({
-        unresolvedReviewThreads: [
-          { id: "t1", isResolved: false, comments: [] },
-          { id: "t2", isResolved: false, comments: [] }
-        ]
-      })
+      makePullRequestState({ unresolvedReviewThreads: 2 })
     );
     expect(two.unresolved_review_threads).toBe(2);
   });
 
   it("emits has_unresolved_reviews from the unresolved review thread count", () => {
     const zero = projectPullRequestSignals(
-      makePullRequestState({ unresolvedReviewThreads: [] })
+      makePullRequestState({ unresolvedReviewThreads: 0 })
     );
     expect(zero.has_unresolved_reviews).toBe(false);
 
     const one = projectPullRequestSignals(
-      makePullRequestState({
-        unresolvedReviewThreads: [{ id: "t1", isResolved: false, comments: [] }]
-      })
+      makePullRequestState({ unresolvedReviewThreads: 1 })
     );
     expect(one.has_unresolved_reviews).toBe(true);
   });

--- a/tests/pull-request-followup.test.ts
+++ b/tests/pull-request-followup.test.ts
@@ -20,9 +20,11 @@ import type {
   ProviderRunInput
 } from "../src/provider.js";
 import {
+  pullRequestNeedsReviewFollowup,
   pullRequestReadyToMerge,
   runPullRequestFollowup
 } from "../src/pull-request-followup.js";
+import { interpretPullRequest } from "../src/pull-request-state.js";
 import { openRunStore, type RunStore } from "../src/run-store.js";
 import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
 
@@ -401,11 +403,45 @@ describe("pull request follow-up", () => {
   it("does not merge when status checks are missing under the default policy", () => {
     expect(
       pullRequestReadyToMerge(
-        prState({
-          statusCheckRollupState: null
-        })
+        interpretPullRequest(
+          prState({
+            statusCheckRollupState: null
+          })
+        )
       )
     ).toBe(false);
+  });
+
+  it("needs review follow-up when requested changes are unresolved", () => {
+    expect(
+      pullRequestNeedsReviewFollowup(
+        interpretPullRequest(
+          prState({
+            reviewDecision: "CHANGES_REQUESTED"
+          })
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("needs review follow-up when unresolved review threads remain", () => {
+    expect(
+      pullRequestNeedsReviewFollowup(
+        interpretPullRequest(
+          prState({
+            unresolvedReviewThreads: [
+              {
+                comments: [],
+                id: "PRRT_kwDO",
+                isResolved: false,
+                line: 24,
+                path: "src/daemon.ts"
+              }
+            ]
+          })
+        )
+      )
+    ).toBe(true);
   });
 });
 

--- a/tests/pull-request-state.test.ts
+++ b/tests/pull-request-state.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import type { RawGitHubPullRequestFollowupState } from "../src/issue-polling.js";
+import { interpretPullRequest } from "../src/pull-request-state.js";
+
+function rawPullRequestState(
+  overrides: Partial<RawGitHubPullRequestFollowupState> = {}
+): RawGitHubPullRequestFollowupState {
+  return {
+    draft: false,
+    headSha: "abc123",
+    mergeable: "MERGEABLE",
+    merged: false,
+    number: 42,
+    reviewDecision: "APPROVED",
+    state: "OPEN",
+    statusCheckRollupState: "SUCCESS",
+    unresolvedReviewThreads: [],
+    url: "https://example.test/pull/42",
+    ...overrides
+  };
+}
+
+describe("interpretPullRequest", () => {
+  it("normalizes unknown mergeability and expected checks without choosing a branch", () => {
+    const state = interpretPullRequest(
+      rawPullRequestState({
+        mergeable: "UNKNOWN",
+        statusCheckRollupState: "EXPECTED"
+      })
+    );
+
+    expect(state).toMatchObject({
+      checks: "pending",
+      mergeable: "unknown"
+    });
+  });
+
+  it("keeps unknown tracker state pollable without projecting the PR as open", () => {
+    const state = interpretPullRequest(
+      rawPullRequestState({
+        state: "UNKNOWN"
+      })
+    );
+
+    expect(state.open).toBe(false);
+    expect(state.trackingState).toBe("open");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a PullRequestState module that normalizes raw GitHub PR follow-up observations.
- Derive FSM PR signals and PR follow-up verdicts from the normalized state.
- Document the Pull Request State term in CONTEXT.md and update ADR 0047.

## Tests
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #141