### PR TITLE
feat(lifecycle): propose issue eligibility interface

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,17 @@ _Avoid_: ticket, task
 An open issue that matches a Project's required labels, avoids excluded labels, and is not already claimed by the orchestrator; v1 treats excluded labels such as `blocked` as the only blocker signal.
 _Avoid_: active issue unless referring to tracker state
 
+**Dispatch Eligibility**:
+The question "may this Project freshly claim this Issue?", including open state, required labels,
+excluded labels, and blocking operational labels.
+_Avoid_: continuation eligibility when referring to first claim selection
+
+**Continuation Eligibility**:
+The question "may this already-owned Run lifecycle keep going?", including open state for every Run,
+and label re-checks only for label-controlled work. State Advance and waiting rows keep going on
+label drift but still stop when the Issue closes.
+_Avoid_: dispatch eligibility when referring to active-run or scheduled-work re-checks
+
 **Operational Label**:
 A GitHub issue label owned by the orchestrator for dispatch safety and runtime bookkeeping; v1 labels are `sym:claimed`, `sym:running`, `sym:failed`, and `sym:stale`.
 _Avoid_: workflow label
@@ -115,6 +126,8 @@ _Avoid_: chat session
 - A **Project** references one **Workflow Contract**
 - An **Issue Tracker** provides many **Issues**
 - An **Eligible Issue** is an **Issue** that a **Project** may dispatch
+- **Dispatch Eligibility** and **Continuation Eligibility** are separate questions over the same
+  Issue predicate family
 - An **Orchestrator** dispatches zero or more **Issues** across one or more **Projects**
 - An **Orchestrator** may write **Operational Labels**
 - A **Stale Claim** blocks automatic dispatch until explicitly cleared in v1

--- a/docs/adr/0051-explicit-eligibility-questions.md
+++ b/docs/adr/0051-explicit-eligibility-questions.md
@@ -1,0 +1,23 @@
+# Explicit eligibility questions own re-check semantics
+
+Symphonika will split Issue eligibility into explicit questions rather than passing boolean flags
+across lifecycle modules. Dispatch Eligibility asks whether a Project may freshly claim an Issue and
+includes open state, configured `labels_all`, configured `labels_none`, and blocking operational
+labels. Continuation Eligibility asks whether already-owned lifecycle work may keep going and has
+two scopes: label-controlled work re-checks open state plus configured labels while ignoring the
+orchestrator's own active operational labels; FSM-owned work checks only open state.
+
+The state-advance exception from ADR 0046 lives in the lifecycle module as the choice of question,
+not as an answer stored on `ActiveRunEntry`. A state-advance, waiting-row recheck, or FSM-owned
+retry asks the eligibility module the FSM-owned Continuation Eligibility question. Normal active
+runs, label-driven continuations, and label-controlled retries ask the label-controlled
+Continuation Eligibility question. This keeps the eligibility module responsible for predicate
+semantics while the lifecycle module remains responsible for identifying what kind of lifecycle
+work is being re-checked.
+
+`ActiveRunEntry` must not carry eligibility-specific metadata such as `respectsIssueLabels`. If a
+future lifecycle interface keeps a general run mode or Planned Step kind for status, scheduling, or
+reconciliation, eligibility is still derived from that lifecycle value at the re-check site rather
+than stored as a separate predicate flag. The `ignoreOperationalLabels` option on
+`evaluateProjectEligibility` should disappear during migration because operational-label treatment
+is part of the selected eligibility question.

--- a/docs/specs/2026-05-15-issue-eligibility-interface.md
+++ b/docs/specs/2026-05-15-issue-eligibility-interface.md
@@ -1,0 +1,125 @@
+# Issue Eligibility Interface
+
+Status: proposed
+Date: 2026-05-15
+
+## Context
+
+Issue eligibility is currently split across three modules:
+
+- `src/issue-polling.ts` owns `evaluateProjectEligibility(issue, project, options)`.
+- `src/lifecycle/reconcile.ts` consumes the predicate and skips it for state-advance runs.
+- `src/lifecycle/active-runs.ts` stores `respectsIssueLabels`, which is set from
+  `src/lifecycle/run-controller.ts` and consumed only by reconciliation.
+
+The predicate is valuable. The flags that describe which version of the predicate to ask are the
+part to remove. This proposal publishes a type-only sketch in
+`src/lifecycle/eligibility-interface.ts`; it does not move existing runtime code.
+
+## Proposed Module
+
+The implementation module should be `src/lifecycle/issue-eligibility.ts` and should expose three
+functions:
+
+```ts
+evaluateDispatchEligibility(issue, project): IssueEligibilityDecision
+
+evaluateRunContinuationEligibility(
+  issue,
+  project,
+  question: { scope: "label_controlled" | "fsm_owned" }
+): IssueEligibilityDecision
+
+evaluateIssueEligibility(issue, project, question): IssueEligibilityDecision
+```
+
+`evaluateIssueEligibility` is the shared implementation. The two named helpers are the public
+questions that callers should prefer.
+
+## Questions
+
+### Dispatch Eligibility
+
+Dispatch Eligibility answers: may this Project freshly claim this Issue?
+
+It checks:
+
+- issue state is open
+- every configured `labels_all` label is present
+- no configured `labels_none` label is present
+- no Symphonika operational label is present
+
+This replaces fresh-dispatch use of `evaluateProjectEligibility`.
+
+### Continuation Eligibility
+
+Continuation Eligibility answers: may already-owned lifecycle work keep going?
+
+It always checks open/closed state first. After that it depends on scope:
+
+- `label_controlled` checks configured `labels_all` and `labels_none`, but ignores active
+  operational labels such as `sym:claimed` and `sym:running` because they are expected on an
+  already-owned issue.
+- `fsm_owned` skips configured label re-checks. State Advance, waiting rows, and FSM-owned retries
+  use this scope because the state machine owns the next step while the walk is in flight.
+
+The current `ignoreOperationalLabels` option disappears because operational-label handling is part
+of the question, not a caller-supplied predicate modifier.
+
+## State-Advance Rule Placement
+
+Decision: the lifecycle module passes the question, not the answer.
+
+The eligibility module should not know `RunController` entrypoints or raw FSM internals. It only
+knows the two Continuation Eligibility scopes. The lifecycle module maps its own values to the
+question:
+
+- normal active run, label-driven continuation, and label-controlled retry:
+  `continue_run / label_controlled`
+- state advance, waiting-row recheck, wait-park callback, and FSM-owned retry:
+  `continue_run / fsm_owned`
+
+This coordinates with PR #147 for issue #139. If the Run Lifecycle proposal lands first, Planned
+Step kinds such as `start_label_eligible_run`, `start_fsm_owned_run`, and
+`re_evaluate_waiting_run` become the source of the eligibility question. If this proposal lands
+first, the follow-up implementation should still avoid `respectsIssueLabels` and keep any temporary
+scope value local to lifecycle planning or scheduling, not on `ActiveRunEntry`.
+
+## ActiveRunEntry
+
+`ActiveRunEntry` should keep no eligibility-related field.
+
+The registry owns active run identity, provider cancellation, cancellation reason, and issue
+liveness locks. It may grow a general lifecycle mode later if issue #139 needs one for status or
+planning, but it should not carry `respectsIssueLabels` or any replacement boolean.
+
+## Consumer Migration
+
+| File | Rewrite |
+| --- | --- |
+| `src/issue-polling.ts` | Import `evaluateDispatchEligibility` for candidate filtering. |
+| `src/lifecycle/reconcile.ts` | Ask `evaluateRunContinuationEligibility` with a lifecycle-derived scope. |
+| `src/lifecycle/active-runs.ts` | Remove `respectsIssueLabels`; keep cancellation and liveness only. |
+| `src/lifecycle/run-controller.ts` | Stop threading `respectsIssueLabels`; derive the question from lifecycle event or planned-step kind at each re-check. |
+
+## Test Migration
+
+| Test | Rewrite |
+| --- | --- |
+| `tests/eligibility-helpers.test.ts` | Move to the new module and cover dispatch, label-controlled continuation, and FSM-owned continuation. |
+| `tests/reconcile.test.ts` | Replace direct `respectsIssueLabels: false` setup with lifecycle-derived continuation questions; closed issue still wins. |
+| `tests/active-runs.test.ts` | Remove any eligibility-field assertions from registry tests. |
+| `tests/dispatch-cancellation.test.ts` | Keep public behavior: label loss cancels label-controlled active runs and removes only `sym:running`. |
+| `tests/dispatch-retry.test.ts` | Replace boolean retry payload expectations with label-controlled vs FSM-owned retry questions. |
+| `tests/property-invariants.test.ts` | Add properties: dispatch includes operational-label exclusion; label-controlled continuation preserves ADR 0023; FSM-owned continuation ignores label drift but never closure. |
+
+## Follow-Up Implementation Slices
+
+1. Add the real `src/lifecycle/issue-eligibility.ts` implementation behind the proposed interface.
+2. Move `evaluateProjectEligibility` callers to dispatch and continuation questions without
+   changing behavior.
+3. Remove `ignoreOperationalLabels` after all callers use question-specific helpers.
+4. Remove `respectsIssueLabels` from `ActiveRunEntry` and retry scheduling once lifecycle-derived
+   scopes cover active and scheduled re-checks.
+5. Add property tests for the three eligibility invariants and keep the existing daemon behavior
+   tests green.

--- a/src/lifecycle/eligibility-interface.ts
+++ b/src/lifecycle/eligibility-interface.ts
@@ -1,0 +1,146 @@
+export type IssueEligibilityQuestion =
+  | { kind: "dispatch" }
+  | {
+      kind: "continue_run";
+      scope: "label_controlled" | "fsm_owned";
+    };
+
+export type IssueEligibilityFailure =
+  | "closed_issue"
+  | "label_mismatch"
+  | "operational_label_blocked";
+
+export type IssueEligibilityDecision =
+  | { eligible: true; reasons: [] }
+  | {
+      eligible: false;
+      failure: IssueEligibilityFailure;
+      reasons: string[];
+    };
+
+export type ProposedIssueEligibilityExport =
+  | "evaluateDispatchEligibility"
+  | "evaluateRunContinuationEligibility"
+  | "evaluateIssueEligibility";
+
+export const PROPOSED_ISSUE_ELIGIBILITY_MODULE =
+  "src/lifecycle/issue-eligibility.ts";
+
+export const PROPOSED_ISSUE_ELIGIBILITY_EXPORTS = [
+  "evaluateDispatchEligibility",
+  "evaluateRunContinuationEligibility",
+  "evaluateIssueEligibility"
+] as const satisfies readonly ProposedIssueEligibilityExport[];
+
+export type EligibilityConsumerMigration = {
+  currentSmell: string;
+  file: string;
+  proposedRewrite: string;
+};
+
+export const ELIGIBILITY_CONSUMER_MIGRATION = [
+  {
+    currentSmell:
+      "Owns evaluateProjectEligibility plus the ignoreOperationalLabels option.",
+    file: "src/issue-polling.ts",
+    proposedRewrite:
+      "Import evaluateDispatchEligibility from the eligibility module for fresh candidate filtering."
+  },
+  {
+    currentSmell:
+      "Combines the respectsIssueLabels escape hatch with a direct predicate call.",
+    file: "src/lifecycle/reconcile.ts",
+    proposedRewrite:
+      "Ask evaluateRunContinuationEligibility with a lifecycle-derived question: label_controlled or fsm_owned."
+  },
+  {
+    currentSmell:
+      "Stores respectsIssueLabels on ActiveRunEntry even though the registry only owns liveness and cancellation.",
+    file: "src/lifecycle/active-runs.ts",
+    proposedRewrite:
+      "Remove eligibility fields; keep only active run identity, cancellation, provider, and liveness data."
+  },
+  {
+    currentSmell:
+      "Computes and threads respectsIssueLabels through active registration, retry scheduling, and scheduleNext.",
+    file: "src/lifecycle/run-controller.ts",
+    proposedRewrite:
+      "Derive the eligibility question from lifecycle event or planned-step kind at the point of re-check."
+  }
+] as const satisfies readonly EligibilityConsumerMigration[];
+
+export type EligibilityTestMigration = {
+  file: string;
+  rewrite: string;
+};
+
+export const ELIGIBILITY_TEST_MIGRATION_PLAN = [
+  {
+    file: "tests/eligibility-helpers.test.ts",
+    rewrite:
+      "Move assertions to the new eligibility module: dispatch includes operational labels; label-controlled continuation ignores them; FSM-owned continuation ignores label drift but not closure."
+  },
+  {
+    file: "tests/reconcile.test.ts",
+    rewrite:
+      "Replace direct respectsIssueLabels setup with lifecycle-derived continuation questions and assert closed_issue still wins."
+  },
+  {
+    file: "tests/active-runs.test.ts",
+    rewrite:
+      "Delete any eligibility-field expectations; ActiveRunRegistry remains a liveness and cancellation registry."
+  },
+  {
+    file: "tests/dispatch-cancellation.test.ts",
+    rewrite:
+      "Keep the public daemon behavior assertion that label loss cancels a label-controlled active run."
+  },
+  {
+    file: "tests/dispatch-retry.test.ts",
+    rewrite:
+      "Drive scheduled retry eligibility through label-controlled vs FSM-owned questions instead of a boolean payload."
+  },
+  {
+    file: "tests/property-invariants.test.ts",
+    rewrite:
+      "Add property coverage for dispatch, label-controlled continuation, and FSM-owned continuation invariants."
+  }
+] as const satisfies readonly EligibilityTestMigration[];
+
+export type IssueEligibilityAdrRule = {
+  adr: "0022" | "0023" | "0046" | "0047";
+  question: IssueEligibilityQuestion;
+  ruleLocation: string;
+  summary: string;
+};
+
+export const ISSUE_ELIGIBILITY_ADR_RULES = [
+  {
+    adr: "0022",
+    question: { kind: "continue_run", scope: "fsm_owned" },
+    ruleLocation: "All continuation questions check issue open/closed state first.",
+    summary:
+      "Closed issues cancel active, scheduled, state-advance, and waiting work regardless of label scope."
+  },
+  {
+    adr: "0023",
+    question: { kind: "continue_run", scope: "label_controlled" },
+    ruleLocation: "Label-controlled continuation eligibility evaluates labels_all and labels_none.",
+    summary:
+      "Eligibility loss remains the operator control surface for normal active runs and scheduled retries."
+  },
+  {
+    adr: "0046",
+    question: { kind: "continue_run", scope: "fsm_owned" },
+    ruleLocation: "Lifecycle state-advance work asks the FSM-owned continuation question.",
+    summary:
+      "State advances skip labels_all and labels_none re-checks while still cancelling on closed issues."
+  },
+  {
+    adr: "0047",
+    question: { kind: "continue_run", scope: "fsm_owned" },
+    ruleLocation: "Waiting-row reconciliation asks the same FSM-owned continuation question.",
+    summary:
+      "Wait states inherit state-advance label immunity and remain poll-reconciled instead of dispatch-gated."
+  }
+] as const satisfies readonly IssueEligibilityAdrRule[];

--- a/tests/eligibility-interface.test.ts
+++ b/tests/eligibility-interface.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ELIGIBILITY_CONSUMER_MIGRATION,
+  ELIGIBILITY_TEST_MIGRATION_PLAN,
+  ISSUE_ELIGIBILITY_ADR_RULES,
+  PROPOSED_ISSUE_ELIGIBILITY_EXPORTS,
+  type IssueEligibilityDecision,
+  type IssueEligibilityQuestion
+} from "../src/lifecycle/eligibility-interface.js";
+
+describe("issue eligibility interface proposal", () => {
+  it("defines dispatch and continuation questions without boolean label flags", () => {
+    const dispatch: IssueEligibilityQuestion = { kind: "dispatch" };
+    const labelControlled: IssueEligibilityQuestion = {
+      kind: "continue_run",
+      scope: "label_controlled"
+    };
+    const fsmOwned: IssueEligibilityQuestion = {
+      kind: "continue_run",
+      scope: "fsm_owned"
+    };
+
+    expect([dispatch.kind, labelControlled.scope, fsmOwned.scope]).toEqual([
+      "dispatch",
+      "label_controlled",
+      "fsm_owned"
+    ]);
+  });
+
+  it("keeps proposed module exports focused on the two eligibility questions", () => {
+    expect(PROPOSED_ISSUE_ELIGIBILITY_EXPORTS).toEqual([
+      "evaluateDispatchEligibility",
+      "evaluateRunContinuationEligibility",
+      "evaluateIssueEligibility"
+    ]);
+  });
+
+  it("maps every current consumer away from scattered eligibility flags", () => {
+    expect(ELIGIBILITY_CONSUMER_MIGRATION.map((entry) => entry.file)).toEqual([
+      "src/issue-polling.ts",
+      "src/lifecycle/reconcile.ts",
+      "src/lifecycle/active-runs.ts",
+      "src/lifecycle/run-controller.ts"
+    ]);
+
+    expect(
+      ELIGIBILITY_CONSUMER_MIGRATION.some((entry) =>
+        entry.currentSmell.includes("respectsIssueLabels")
+      )
+    ).toBe(true);
+    expect(
+      ELIGIBILITY_CONSUMER_MIGRATION.some((entry) =>
+        entry.currentSmell.includes("ignoreOperationalLabels")
+      )
+    ).toBe(true);
+  });
+
+  it("documents the test rewrite plan for each eligibility-specific suite", () => {
+    expect(ELIGIBILITY_TEST_MIGRATION_PLAN.map((entry) => entry.file)).toEqual([
+      "tests/eligibility-helpers.test.ts",
+      "tests/reconcile.test.ts",
+      "tests/active-runs.test.ts",
+      "tests/dispatch-cancellation.test.ts",
+      "tests/dispatch-retry.test.ts",
+      "tests/property-invariants.test.ts"
+    ]);
+
+    expect(
+      ELIGIBILITY_TEST_MIGRATION_PLAN.find(
+        (entry) => entry.file === "tests/property-invariants.test.ts"
+      )?.rewrite
+    ).toContain("property");
+  });
+
+  it("places ADR cancellation rules on explicit eligibility outcomes", () => {
+    expect(ISSUE_ELIGIBILITY_ADR_RULES.map((rule) => rule.adr)).toEqual([
+      "0022",
+      "0023",
+      "0046",
+      "0047"
+    ]);
+
+    const closed: IssueEligibilityDecision = {
+      eligible: false,
+      failure: "closed_issue",
+      reasons: ["state closed is not eligible"]
+    };
+    expect(closed.failure).toBe("closed_issue");
+  });
+});


### PR DESCRIPTION
## Summary
- Add proposed Issue Eligibility interface types and migration tables.
- Document Dispatch Eligibility vs Continuation Eligibility in CONTEXT.md and the proposal doc.
- Add ADR 0051 for the load-bearing decision: lifecycle passes an explicit eligibility question, not a boolean answer.

## Design decision
- The eligibility module owns predicate semantics through dispatch and continuation questions.
- The lifecycle module decides which question to ask: label-controlled work re-checks labels; FSM-owned state advance and waiting work only checks open state.
- ActiveRunEntry keeps no eligibility-related field; ignoreOperationalLabels should disappear during migration.
- Coordination with #139 / PR #147: if Planned Step kinds land first, they become the source of the eligibility question.

## Test migration
- Lists rewrites for eligibility helpers, reconcile, active-runs, dispatch cancellation, dispatch retry, and property invariants.
- Adds a proposal test for the interface shape and migration tables.

## Validation
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #143