### PR TITLE
refactor: extract pure workspace path planner

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,10 +21,11 @@ import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
 import type { InitOptions, InitProvider, InitReport } from "./init.js";
 import { runInit } from "./init.js";
 import type { ProjectIssuePollReport } from "./issue-polling.js";
-import type { RuntimeReloadStatus } from "./reload.js";
+import { RuntimeConfigReloader, type RuntimeReloadStatus } from "./reload.js";
 import type {
   ListRunsFilter,
   OpenRunStoreOptions,
+  RunDetail,
   ProjectState,
   RunArtifactDescriptor,
   RunState,
@@ -51,6 +52,10 @@ import {
   loadProjectWorkflow,
   type ExpandedWorkflow
 } from "./workflow.js";
+import {
+  planWorkspacePaths,
+  type WorkspacePathPlan
+} from "./workspace-paths.js";
 
 export type CliDependencies = {
   fetch?: FetchFn;
@@ -637,8 +642,8 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .option("--config <path>", "service config path")
     .option("--events <n>", "max recent events", parsePositiveInt, 25)
     .action(async (id: string, options: { config?: string; events: number }) => {
-      const stateRoot = resolveStateRoot(withConfigPath(options.config)).stateRoot;
-      const store = openRunStore({ stateRoot });
+      const state = resolveStateRoot(withConfigPath(options.config));
+      const store = openRunStore({ stateRoot: state.stateRoot });
       try {
         const detail = store.getRun(id);
         if (detail === undefined) {
@@ -646,15 +651,19 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
           program.error(`run ${id} not found`, { exitCode: 1 });
           return;
         }
-        writeOut(program, `id:           ${detail.id}\n`);
-        writeOut(program, `project:      ${detail.project}\n`);
-        writeOut(program, `issue:        #${detail.issueNumber} ${detail.issueTitle}\n`);
-        writeOut(program, `state:        ${detail.state}\n`);
-        writeOut(program, `provider:     ${detail.provider}\n`);
-        writeOut(program, `started:      ${detail.createdAt}\n`);
-        writeOut(program, `updated:      ${detail.updatedAt}\n`);
-        writeOut(program, `branch:       ${formatPath(detail.branchName)}\n`);
-        writeOut(program, `workspace:    ${formatPath(detail.workspacePath)}\n`);
+        const displayDetail = await fillMissingRunDisplayPaths(detail, {
+          configDir: state.configDir,
+          configPath: state.configPath
+        });
+        writeOut(program, `id:           ${displayDetail.id}\n`);
+        writeOut(program, `project:      ${displayDetail.project}\n`);
+        writeOut(program, `issue:        #${displayDetail.issueNumber} ${displayDetail.issueTitle}\n`);
+        writeOut(program, `state:        ${displayDetail.state}\n`);
+        writeOut(program, `provider:     ${displayDetail.provider}\n`);
+        writeOut(program, `started:      ${displayDetail.createdAt}\n`);
+        writeOut(program, `updated:      ${displayDetail.updatedAt}\n`);
+        writeOut(program, `branch:       ${formatPath(displayDetail.branchName)}\n`);
+        writeOut(program, `workspace:    ${formatPath(displayDetail.workspacePath)}\n`);
         writeOut(program, `artifacts:    ${formatArtifactKinds(store.listRunArtifacts(detail.id))}\n`);
         writeOut(program, formatWorkflowGraphSummary(await store.getWorkflowGraph(detail.id)));
         writeOut(program, `retries:      ${detail.retryCount}${detail.isContinuation ? " (continuation)" : ""}\n`);
@@ -1329,6 +1338,51 @@ function formatArtifactKinds(artifacts: RunArtifactDescriptor[]): string {
         : `${artifact.kind}(${artifact.sizeBytes} bytes)`
     );
   return present.length === 0 ? "(none)" : present.join(", ");
+}
+
+async function fillMissingRunDisplayPaths(
+  detail: RunDetail,
+  input: { configDir: string; configPath: string }
+): Promise<RunDetail> {
+  if (detail.branchName.length > 0 && detail.workspacePath.length > 0) {
+    return detail;
+  }
+
+  const plan = await planRunWorkspacePaths(detail, input);
+  if (plan === undefined) {
+    return detail;
+  }
+
+  return {
+    ...detail,
+    branchName: detail.branchName.length === 0 ? plan.branchName : detail.branchName,
+    workspacePath:
+      detail.workspacePath.length === 0 ? plan.workspacePath : detail.workspacePath
+  };
+}
+
+async function planRunWorkspacePaths(
+  detail: RunStatus,
+  input: { configDir: string; configPath: string }
+): Promise<WorkspacePathPlan | undefined> {
+  try {
+    const reloader = new RuntimeConfigReloader({ configPath: input.configPath });
+    const snapshot = await reloader.reload();
+    const project = snapshot?.projects.find((entry) => entry.name === detail.project);
+    if (project === undefined) {
+      return undefined;
+    }
+    return planWorkspacePaths({
+      configDir: input.configDir,
+      issue: {
+        number: detail.issueNumber,
+        title: detail.issueTitle
+      },
+      project
+    });
+  } catch {
+    return undefined;
+  }
 }
 
 function formatWorkflowGraphSummary(graph: ExpandedWorkflow | undefined): string {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -524,8 +524,10 @@ export async function startDaemon(
     getScheduled: () => activeRuns.peekDelayed(),
     getStatusSnapshot: () =>
       buildStatusSnapshot({
+        configDir: state.configDir,
         configPath: state.configPath,
         issuePollStatus,
+        projectsByName: runtimeConfig.projectsByName(),
         reloadStatus: runtimeConfig.getStatus(),
         runStore,
         stateRoot: state.stateRoot

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,7 +1,13 @@
+import path from "node:path";
+
 import type { DoctorProjectReport, DoctorReport } from "./doctor.js";
 import type { IssuePollStatus } from "./issue-polling.js";
 import type { RuntimeReloadStatus } from "./reload.js";
 import type { ProjectState, RunStatus, RunStore } from "./run-store.js";
+import {
+  planWorkspacePaths,
+  type WorkspacePathInputs
+} from "./workspace-paths.js";
 
 export type StatusSnapshot = {
   configPath: string;
@@ -20,9 +26,11 @@ export type StatusSnapshot = {
 };
 
 export type BuildStatusSnapshotInput = {
+  configDir?: string;
   configPath: string;
   doctorReport?: DoctorReport;
   issuePollStatus: IssuePollStatus;
+  projectsByName?: ReadonlyMap<string, WorkspacePathInputs["project"]>;
   reloadStatus?: RuntimeReloadStatus;
   runStore: RunStore;
   stateRoot: string;
@@ -38,7 +46,9 @@ const ACTIVE_STATES = new Set([
 export function buildStatusSnapshot(
   input: BuildStatusSnapshotInput
 ): StatusSnapshot {
-  const allRuns = input.runStore.listRuns();
+  const allRuns = input.runStore
+    .listRuns()
+    .map((run) => fillMissingWorkspacePlan(run, input));
   const active = allRuns.filter((run) => ACTIVE_STATES.has(run.state));
   const failed = allRuns.filter((run) => run.state === "failed");
   const stale = allRuns.filter((run) => run.state === "stale");
@@ -62,6 +72,33 @@ export function buildStatusSnapshot(
       stale
     },
     stateRoot: input.stateRoot
+  };
+}
+
+function fillMissingWorkspacePlan(
+  run: RunStatus,
+  input: BuildStatusSnapshotInput
+): RunStatus {
+  if (run.branchName.length > 0 && run.workspacePath.length > 0) {
+    return run;
+  }
+  const project = input.projectsByName?.get(run.project);
+  if (project === undefined) {
+    return run;
+  }
+  const plan = planWorkspacePaths({
+    configDir: input.configDir ?? path.dirname(input.configPath),
+    issue: {
+      number: run.issueNumber,
+      title: run.issueTitle
+    },
+    project
+  });
+  return {
+    ...run,
+    branchName: run.branchName.length === 0 ? plan.branchName : run.branchName,
+    workspacePath:
+      run.workspacePath.length === 0 ? plan.workspacePath : run.workspacePath
   };
 }
 

--- a/src/workspace-paths.ts
+++ b/src/workspace-paths.ts
@@ -1,0 +1,51 @@
+import path from "node:path";
+
+export type WorkspacePathInputs = {
+  configDir?: string;
+  issue: { number: number; title: string };
+  project: {
+    name: string;
+    workspace: { root: string };
+  };
+};
+
+export type WorkspacePathPlan = {
+  branchName: string;
+  branchRef: string;
+  cachePath: string;
+  issueDirectoryName: string;
+  workspacePath: string;
+};
+
+export function planWorkspacePaths(
+  input: WorkspacePathInputs
+): WorkspacePathPlan {
+  const projectSlug = slugify(input.project.name, "project");
+  const issueSlug = slugify(input.issue.title, "issue");
+  const issueDirectoryName = `${input.issue.number}-${issueSlug}`;
+  const workspaceRoot = path.resolve(
+    input.configDir ?? process.cwd(),
+    input.project.workspace.root
+  );
+  const branchName = `sym/${projectSlug}/${issueDirectoryName}`;
+
+  return {
+    branchName,
+    branchRef: `refs/heads/${branchName}`,
+    cachePath: path.join(workspaceRoot, ".cache", "repo.git"),
+    issueDirectoryName,
+    workspacePath: path.join(workspaceRoot, "issues", issueDirectoryName)
+  };
+}
+
+function slugify(input: string, fallback: string): string {
+  const asciiInput = Array.from(input.normalize("NFKD"))
+    .filter((character) => character.charCodeAt(0) <= 0x7f)
+    .join("");
+  const slug = asciiInput
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug.length === 0 ? fallback : slug;
+}

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -3,6 +3,11 @@ import { mkdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
+import {
+  planWorkspacePaths,
+  type WorkspacePathPlan
+} from "./workspace-paths.js";
+
 const execFileAsync = promisify(execFile);
 
 export type WorkspaceProject = {
@@ -27,14 +32,7 @@ export type PrepareIssueWorkspaceInput = {
   project: WorkspaceProject;
 };
 
-export type PreparedIssueWorkspace = {
-  branchName: string;
-  branchRef: string;
-  cachePath: string;
-  issueDirectoryName: string;
-  reused: boolean;
-  workspacePath: string;
-};
+export type PreparedIssueWorkspace = WorkspacePathPlan & { reused: boolean };
 
 export type WorkspacePreparationErrorCode =
   | "branch_conflict"
@@ -62,16 +60,16 @@ export class WorkspacePreparationError extends Error {
 export async function prepareIssueWorkspace(
   input: PrepareIssueWorkspaceInput
 ): Promise<PreparedIssueWorkspace> {
-  const prepared = issueWorkspacePaths(input);
+  const plan = planWorkspacePaths(input);
 
-  await ensureRepositoryCache(input.project, prepared.cachePath);
-  await ensureIssueBranch(input.project, prepared.cachePath, prepared.branchName);
-  if (await exists(prepared.workspacePath)) {
+  await ensureRepositoryCache(input.project, plan.cachePath);
+  await ensureIssueBranch(input.project, plan.cachePath, plan.branchName);
+  if (await exists(plan.workspacePath)) {
     let currentBranch: string;
     try {
       currentBranch = await git([
         "-C",
-        prepared.workspacePath,
+        plan.workspacePath,
         "rev-parse",
         "--abbrev-ref",
         "HEAD"
@@ -79,60 +77,63 @@ export async function prepareIssueWorkspace(
     } catch (error) {
       throw new WorkspacePreparationError(
         "workspace_conflict",
-        `workspace path ${prepared.workspacePath} exists but is not a reusable Git worktree for ${prepared.branchName}`,
+        `workspace path ${plan.workspacePath} exists but is not a reusable Git worktree for ${plan.branchName}`,
         error
       );
     }
 
-    if (currentBranch === prepared.branchName) {
-      if (!(await isWorktreeRoot(prepared.workspacePath))) {
+    if (currentBranch === plan.branchName) {
+      if (!(await isWorktreeRoot(plan.workspacePath))) {
         throw new WorkspacePreparationError(
           "workspace_conflict",
-          `workspace path ${prepared.workspacePath} is checked out on ${prepared.branchName} but is not the Git worktree root`
+          `workspace path ${plan.workspacePath} is checked out on ${plan.branchName} but is not the Git worktree root`
         );
       }
 
-      if (!(await isWorktreeForCache(prepared.workspacePath, prepared.cachePath))) {
+      if (!(await isWorktreeForCache(plan.workspacePath, plan.cachePath))) {
         throw new WorkspacePreparationError(
           "workspace_conflict",
-          `workspace path ${prepared.workspacePath} is checked out on ${prepared.branchName} but is not linked to cache ${prepared.cachePath}`
+          `workspace path ${plan.workspacePath} is checked out on ${plan.branchName} but is not linked to cache ${plan.cachePath}`
         );
       }
 
       return {
-        ...prepared,
+        ...plan,
         reused: true
       };
     }
 
     throw new WorkspacePreparationError(
       "workspace_conflict",
-      `workspace path ${prepared.workspacePath} is already checked out on ${currentBranch}, expected ${prepared.branchName}`
+      `workspace path ${plan.workspacePath} is already checked out on ${currentBranch}, expected ${plan.branchName}`
     );
   }
 
   const conflictingWorktreePath = await worktreePathForBranch(
-    prepared.cachePath,
-    prepared.branchName
+    plan.cachePath,
+    plan.branchName
   );
   if (conflictingWorktreePath !== undefined) {
     throw new WorkspacePreparationError(
       "branch_conflict",
-      `issue branch ${prepared.branchName} is already checked out at ${conflictingWorktreePath}`
+      `issue branch ${plan.branchName} is already checked out at ${conflictingWorktreePath}`
     );
   }
 
-  await mkdir(path.dirname(prepared.workspacePath), { recursive: true });
+  await mkdir(path.dirname(plan.workspacePath), { recursive: true });
   await git([
     "-C",
-    prepared.cachePath,
+    plan.cachePath,
     "worktree",
     "add",
-    prepared.workspacePath,
-    prepared.branchName
+    plan.workspacePath,
+    plan.branchName
   ]);
 
-  return prepared;
+  return {
+    ...plan,
+    reused: false
+  };
 }
 
 async function isWorktreeRoot(workspacePath: string): Promise<boolean> {
@@ -189,28 +190,6 @@ async function worktreePathForBranch(
   }
 
   return undefined;
-}
-
-function issueWorkspacePaths(
-  input: PrepareIssueWorkspaceInput
-): PreparedIssueWorkspace {
-  const projectSlug = slugify(input.project.name, "project");
-  const issueSlug = slugify(input.issue.title, "issue");
-  const issueDirectoryName = `${input.issue.number}-${issueSlug}`;
-  const workspaceRoot = path.resolve(
-    input.configDir ?? process.cwd(),
-    input.project.workspace.root
-  );
-  const branchName = `sym/${projectSlug}/${issueDirectoryName}`;
-
-  return {
-    branchName,
-    branchRef: `refs/heads/${branchName}`,
-    cachePath: path.join(workspaceRoot, ".cache", "repo.git"),
-    issueDirectoryName,
-    reused: false,
-    workspacePath: path.join(workspaceRoot, "issues", issueDirectoryName)
-  };
 }
 
 async function ensureRepositoryCache(
@@ -272,18 +251,6 @@ async function ensureIssueBranch(
     branchName,
     `origin/${project.workspace.git.base_branch}`
   ]);
-}
-
-function slugify(input: string, fallback: string): string {
-  const asciiInput = Array.from(input.normalize("NFKD"))
-    .filter((character) => character.charCodeAt(0) <= 0x7f)
-    .join("");
-  const slug = asciiInput
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-  return slug.length === 0 ? fallback : slug;
 }
 
 async function exists(filePath: string): Promise<boolean> {

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -707,6 +707,36 @@ describe("CLI run commands", () => {
     expect(present.output.stdout).toContain("<not yet recorded>");
   });
 
+  it("show-run fills missing branch and workspace fields from the deterministic path plan", async () => {
+    const stateRoot = await makeTempRoot();
+    const configDir = await makeTempRoot();
+    const cfg = await writeWorkspacePlanningConfig(configDir, stateRoot);
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "show-planned",
+      issue: sampleIssue({ number: 31, title: "Missing evidence" }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.close();
+
+    const present = captureProgram(stateRoot);
+    await present.program.parseAsync([
+      "node",
+      "symphonika",
+      "show-run",
+      "show-planned",
+      "--config",
+      cfg
+    ]);
+
+    expect(present.output.stdout).toContain("branch:       sym/alpha/31-missing-evidence");
+    expect(present.output.stdout).toContain(
+      `workspace:    ${path.join(configDir, "workspaces", "alpha", "issues", "31-missing-evidence")}`
+    );
+  });
+
   it("show-run prints the workflow graph summary when graph evidence is present", async () => {
     const stateRoot = await makeTempRoot();
     const evidenceDir = path.join(stateRoot, "logs", "runs", "show-graph");
@@ -1121,3 +1151,48 @@ describe("CLI run commands", () => {
     );
   });
 });
+
+async function writeWorkspacePlanningConfig(
+  configDir: string,
+  stateRoot: string
+): Promise<string> {
+  await mkdir(configDir, { recursive: true });
+  await writeFile(path.join(configDir, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+  const configPath = path.join(configDir, "symphonika.yml");
+  await writeFile(
+    configPath,
+    [
+      "state:",
+      `  root: ${stateRoot}`,
+      "providers:",
+      "  codex:",
+      '    command: "codex app-server"',
+      "  claude:",
+      '    command: "claude -p"',
+      "projects:",
+      "  - name: alpha",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./workspaces/alpha",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      ""
+    ].join("\n")
+  );
+  return configPath;
+}

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -138,4 +138,55 @@ describe("buildStatusSnapshot", () => {
       runStore.close();
     }
   });
+
+  it("fills missing run branch and workspace fields from the deterministic path plan", async () => {
+    const stateRoot = await makeTempRoot();
+    const configDir = await makeTempRoot();
+    const runStore = openRunStore({ stateRoot });
+    try {
+      runStore.createRun({
+        id: "r-planned",
+        issue: sampleIssue({
+          number: 146,
+          title: "Extract pure workspace paths"
+        }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      runStore.updateRunState("r-planned", "running");
+
+      const snapshot = buildStatusSnapshot({
+        configDir,
+        configPath: path.join(configDir, "symphonika.yml"),
+        issuePollStatus: emptyPollStatus(),
+        projectsByName: new Map([
+          [
+            "alpha",
+            {
+              name: "Alpha Project",
+              workspace: {
+                root: "./workspaces/alpha"
+              }
+            }
+          ]
+        ]),
+        runStore,
+        stateRoot
+      });
+
+      expect(snapshot.runs.active[0]).toMatchObject({
+        branchName: "sym/alpha-project/146-extract-pure-workspace-paths",
+        workspacePath: path.join(
+          configDir,
+          "workspaces",
+          "alpha",
+          "issues",
+          "146-extract-pure-workspace-paths"
+        )
+      });
+    } finally {
+      runStore.close();
+    }
+  });
 });

--- a/tests/workspace-paths.test.ts
+++ b/tests/workspace-paths.test.ts
@@ -1,0 +1,147 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { planWorkspacePaths } from "../src/workspace-paths.js";
+
+describe("planWorkspacePaths", () => {
+  it("returns the same deterministic workspace plan for the same project and issue", () => {
+    const input = {
+      configDir: "/config",
+      issue: {
+        number: 146,
+        title: "Extract a pure planWorkspacePaths module"
+      },
+      project: {
+        name: "Symphonika",
+        workspace: {
+          root: "./.symphonika/workspaces/symphonika"
+        }
+      }
+    };
+
+    const first = planWorkspacePaths(input);
+    const second = planWorkspacePaths(input);
+
+    expect(second).toEqual(first);
+    expect(first).toEqual({
+      branchName: "sym/symphonika/146-extract-a-pure-planworkspacepaths-module",
+      branchRef:
+        "refs/heads/sym/symphonika/146-extract-a-pure-planworkspacepaths-module",
+      cachePath: path.join(
+        "/config",
+        ".symphonika",
+        "workspaces",
+        "symphonika",
+        ".cache",
+        "repo.git"
+      ),
+      issueDirectoryName: "146-extract-a-pure-planworkspacepaths-module",
+      workspacePath: path.join(
+        "/config",
+        ".symphonika",
+        "workspaces",
+        "symphonika",
+        "issues",
+        "146-extract-a-pure-planworkspacepaths-module"
+      )
+    });
+  });
+
+  it("returns different plans for different project and issue inputs", () => {
+    const base = planWorkspacePaths({
+      configDir: "/config",
+      issue: {
+        number: 146,
+        title: "Extract a pure planWorkspacePaths module"
+      },
+      project: {
+        name: "symphonika",
+        workspace: {
+          root: "./.symphonika/workspaces/symphonika"
+        }
+      }
+    });
+
+    const differentIssue = planWorkspacePaths({
+      configDir: "/config",
+      issue: {
+        number: 147,
+        title: "Extract a pure planWorkspacePaths module"
+      },
+      project: {
+        name: "symphonika",
+        workspace: {
+          root: "./.symphonika/workspaces/symphonika"
+        }
+      }
+    });
+    const differentProject = planWorkspacePaths({
+      configDir: "/config",
+      issue: {
+        number: 146,
+        title: "Extract a pure planWorkspacePaths module"
+      },
+      project: {
+        name: "other project",
+        workspace: {
+          root: "./.symphonika/workspaces/other"
+        }
+      }
+    });
+
+    expect(differentIssue).not.toEqual(base);
+    expect(differentIssue.issueDirectoryName).toBe(
+      "147-extract-a-pure-planworkspacepaths-module"
+    );
+    expect(differentProject.branchName).toBe(
+      "sym/other-project/146-extract-a-pure-planworkspacepaths-module"
+    );
+    expect(differentProject.workspacePath).toBe(
+      path.join(
+        "/config",
+        ".symphonika",
+        "workspaces",
+        "other",
+        "issues",
+        "146-extract-a-pure-planworkspacepaths-module"
+      )
+    );
+  });
+
+  it("keeps slug output stable for Unicode and edge-case titles", () => {
+    const unicode = planWorkspacePaths({
+      configDir: "/config",
+      issue: {
+        number: 42,
+        title: "Déjà vu / workspace prep ✨"
+      },
+      project: {
+        name: "Crème Brûlée",
+        workspace: {
+          root: "workspaces/unicode"
+        }
+      }
+    });
+    const punctuationOnly = planWorkspacePaths({
+      configDir: "/config",
+      issue: {
+        number: 43,
+        title: "✨ / ../ !!!"
+      },
+      project: {
+        name: "✨",
+        workspace: {
+          root: "workspaces/fallback"
+        }
+      }
+    });
+
+    expect(unicode.branchName).toBe("sym/creme-brulee/42-deja-vu-workspace-prep");
+    expect(unicode.issueDirectoryName).toBe("42-deja-vu-workspace-prep");
+    expect(punctuationOnly.branchName).toBe("sym/project/43-issue");
+    expect(punctuationOnly.issueDirectoryName).toBe("43-issue");
+    expect(punctuationOnly.issueDirectoryName).not.toContain("/");
+    expect(punctuationOnly.issueDirectoryName).not.toContain("..");
+  });
+});


### PR DESCRIPTION
Summary:
- add pure planWorkspacePaths module for deterministic Workspace and Issue Branch mapping
- make prepareIssueWorkspace delegate path planning while keeping Git preparation in workspace.ts
- use planned paths for missing run display fields in status snapshots and show-run

Purity check:
- manual grep: rg -n 'node:fs|node:child_process|node:util|promisify' src/workspace-paths.ts returned no matches

Validation:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #146