### PR TITLE
fix: preserve per-attempt prompt artifacts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -398,13 +398,16 @@ Each provider attempt stores:
 - issue branch
 - issue snapshot
 - expanded workflow graph (workflow name, source kind, source path, content hash, initial
-  state, states, transitions, terminal markers, template files), persisted as
-  `workflow-graph.json` next to `prompt-metadata.json`. Retries write
-  `workflow-graph.attempt-<N>.json` so prior attempts' graphs remain inspectable. Markdown
-  `WORKFLOW.md` workflows record their one-state compatibility graph; explicit raw FSM YAML
-  workflows record their parsed expanded graph. Multi-state raw FSM walks advance through the
-  state machine via a `state_advance` dispatch path that is distinct from label-driven
-  continuations; see ADR 0046.
+  state, states, transitions, terminal markers, template files)
+
+First attempts write `prompt.md`, `prompt-metadata.json`, `issue-snapshot.json`, and
+`workflow-graph.json`. Retries write `prompt.attempt-<N>.md`,
+`prompt-metadata.attempt-<N>.json`, `issue-snapshot.attempt-<N>.json`, and
+`workflow-graph.attempt-<N>.json` so prior attempts' rendered prompts, issue snapshots, metadata,
+and workflow graphs remain inspectable through attempt-scoped artifact descriptors. Markdown
+`WORKFLOW.md` workflows record their one-state compatibility graph; explicit raw FSM YAML workflows
+record their parsed expanded graph. Multi-state raw FSM walks advance through the state machine via
+a `state_advance` dispatch path that is distinct from label-driven continuations; see ADR 0046.
 
 ## 8. Scheduling
 

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -256,7 +256,10 @@ type AttemptRow = {
   branch_name: string;
   created_at: string;
   id: string;
+  issue_snapshot_path: string | null;
+  metadata_path: string | null;
   normalized_log_path: string | null;
+  prompt_path: string | null;
   provider_command: string;
   provider_name: string;
   raw_log_path: string | null;
@@ -278,7 +281,10 @@ type RunArtifactRow = {
 };
 
 type AttemptArtifactRow = {
+  issue_snapshot_path: string | null;
+  metadata_path: string | null;
   normalized_log_path: string | null;
+  prompt_path: string | null;
   raw_log_path: string | null;
   run_id: string;
   workflow_graph_path: string | null;
@@ -877,12 +883,12 @@ export class RunStore {
         [
           "insert into attempts (",
           "id, run_id, attempt_number, state, provider_name, provider_command,",
-          "workspace_path, branch_name, prompt_path, issue_snapshot_path,",
+          "workspace_path, branch_name, prompt_path, metadata_path, issue_snapshot_path,",
           "raw_log_path, normalized_log_path, workflow_graph_path,",
           "created_at, updated_at",
           ") values (",
           "@id, @run_id, @attempt_number, @state, @provider_name, @provider_command,",
-          "@workspace_path, @branch_name, @prompt_path, @issue_snapshot_path,",
+          "@workspace_path, @branch_name, @prompt_path, @metadata_path, @issue_snapshot_path,",
           "@raw_log_path, @normalized_log_path, @workflow_graph_path,",
           "@created_at, @updated_at",
           ")"
@@ -894,6 +900,7 @@ export class RunStore {
         created_at: now,
         id: input.id,
         issue_snapshot_path: input.issueSnapshotPath,
+        metadata_path: input.metadataPath,
         normalized_log_path: input.normalizedLogPath,
         prompt_path: input.promptPath,
         provider_command: input.providerCommand,
@@ -1009,7 +1016,7 @@ export class RunStore {
       .prepare(
         [
           "select id, run_id, attempt_number, state, provider_name, provider_command,",
-          "workspace_path, branch_name,",
+          "workspace_path, branch_name, prompt_path, metadata_path, issue_snapshot_path,",
           "raw_log_path, normalized_log_path, workflow_graph_path,",
           "created_at, updated_at",
           "from attempts where run_id = ? order by attempt_number asc, id asc"
@@ -1563,6 +1570,7 @@ export class RunStore {
         workspace_path text not null,
         branch_name text not null,
         prompt_path text not null,
+        metadata_path text not null,
         issue_snapshot_path text not null,
         raw_log_path text not null,
         normalized_log_path text not null,
@@ -1649,12 +1657,51 @@ export class RunStore {
       ["runs", "terminal_state_id", "text"],
       ["runs", "state_transition_reason", "text"],
       ["attempts", "failure_classification", "text"],
+      ["attempts", "metadata_path", "text"],
       ["attempts", "workflow_graph_path", "text"]
     ];
 
     const apply = this.database.transaction(() => {
       for (const [table, column, decl] of additions) {
         this.ensureColumn(table, column, decl);
+      }
+    });
+    apply();
+    this.backfillAttemptMetadataPaths();
+  }
+
+  private backfillAttemptMetadataPaths(): void {
+    const rows = this.database
+      .prepare(
+        [
+          "select attempts.id, attempts.attempt_number, attempts.prompt_path,",
+          "attempts.metadata_path, runs.metadata_path as run_metadata_path",
+          "from attempts left join runs on runs.id = attempts.run_id",
+          "where attempts.metadata_path is null or attempts.metadata_path = ''"
+        ].join(" ")
+      )
+      .all() as Array<{
+        attempt_number: number;
+        id: string;
+        metadata_path: string | null;
+        prompt_path: string | null;
+        run_metadata_path: string | null;
+      }>;
+    if (rows.length === 0) {
+      return;
+    }
+
+    const update = this.database.prepare(
+      "update attempts set metadata_path = ? where id = ?"
+    );
+    const apply = this.database.transaction(() => {
+      for (const row of rows) {
+        const metadataPath =
+          inferAttemptMetadataPath(row.prompt_path, row.attempt_number) ??
+          row.run_metadata_path;
+        if (metadataPath !== null && metadataPath.length > 0) {
+          update.run(metadataPath, row.id);
+        }
       }
     });
     apply();
@@ -1702,7 +1749,8 @@ export class RunStore {
     return this.database
       .prepare(
         [
-          "select run_id, raw_log_path, normalized_log_path, workflow_graph_path",
+          "select run_id, issue_snapshot_path, prompt_path, metadata_path,",
+          "raw_log_path, normalized_log_path, workflow_graph_path",
           "from attempts where id = ?"
         ].join(" ")
       )
@@ -1847,6 +1895,9 @@ const RUN_ARTIFACT_KINDS: readonly RunArtifactKind[] = [
 ];
 
 const ATTEMPT_ARTIFACT_KINDS: readonly RunArtifactKind[] = [
+  "issue_snapshot",
+  "prompt",
+  "prompt_metadata",
   "workflow_graph",
   "provider_raw",
   "provider_normalized"
@@ -1881,15 +1932,44 @@ function attemptArtifactPath(
   kind: RunArtifactKind
 ): string | null {
   switch (kind) {
+    case "issue_snapshot":
+      return row.issue_snapshot_path;
+    case "prompt":
+      return row.prompt_path;
+    case "prompt_metadata":
+      return row.metadata_path;
     case "workflow_graph":
       return row.workflow_graph_path;
     case "provider_raw":
       return row.raw_log_path;
     case "provider_normalized":
       return row.normalized_log_path;
-    default:
-      return null;
   }
+}
+
+function inferAttemptMetadataPath(
+  promptPath: string | null,
+  attemptNumber: number
+): string | null {
+  if (promptPath === null || promptPath.length === 0) {
+    return null;
+  }
+  const directory = path.dirname(promptPath);
+  const basename = path.basename(promptPath);
+  if (basename === "prompt.md") {
+    return path.join(directory, "prompt-metadata.json");
+  }
+  const attemptMatch = /^prompt\.attempt-(\d+)\.md$/.exec(basename);
+  if (attemptMatch !== null) {
+    return path.join(
+      directory,
+      `prompt-metadata.attempt-${attemptMatch[1]}.json`
+    );
+  }
+  if (attemptNumber > 1) {
+    return path.join(directory, `prompt-metadata.attempt-${attemptNumber}.json`);
+  }
+  return null;
 }
 
 function artifactSize(filePath: string): number | undefined {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1774,9 +1774,18 @@ export async function persistRunEvidence(
 
   await mkdir(runEvidenceDirectory, { recursive: true });
 
-  const promptPath = path.join(runEvidenceDirectory, "prompt.md");
-  const metadataPath = path.join(runEvidenceDirectory, "prompt-metadata.json");
-  const issueSnapshotPath = path.join(runEvidenceDirectory, "issue-snapshot.json");
+  const promptPath = path.join(
+    runEvidenceDirectory,
+    attemptEvidenceFileName("prompt", input.attemptNumber, "md")
+  );
+  const metadataPath = path.join(
+    runEvidenceDirectory,
+    attemptEvidenceFileName("prompt-metadata", input.attemptNumber, "json")
+  );
+  const issueSnapshotPath = path.join(
+    runEvidenceDirectory,
+    attemptEvidenceFileName("issue-snapshot", input.attemptNumber, "json")
+  );
   const workflowGraphPath = path.join(
     runEvidenceDirectory,
     workflowGraphFileName(input.attemptNumber)
@@ -1823,9 +1832,17 @@ export async function persistRunEvidence(
 }
 
 function workflowGraphFileName(attemptNumber: number): string {
+  return attemptEvidenceFileName("workflow-graph", attemptNumber, "json");
+}
+
+function attemptEvidenceFileName(
+  stem: string,
+  attemptNumber: number,
+  extension: string
+): string {
   return attemptNumber === 1
-    ? "workflow-graph.json"
-    : `workflow-graph.attempt-${attemptNumber}.json`;
+    ? `${stem}.${extension}`
+    : `${stem}.attempt-${attemptNumber}.${extension}`;
 }
 
 function previousAttemptNotice(workspace: PromptWorkspace): string {

--- a/tests/http-app-runs.test.ts
+++ b/tests/http-app-runs.test.ts
@@ -583,6 +583,18 @@ describe("HTTP app — runs API and pages", () => {
       await mkdir(evidenceDir, { recursive: true });
       const attempt1Path = path.join(evidenceDir, "workflow-graph.json");
       const attempt2Path = path.join(evidenceDir, "workflow-graph.attempt-2.json");
+      const attempt1Prompt = path.join(evidenceDir, "prompt.md");
+      const attempt2Prompt = path.join(evidenceDir, "prompt.attempt-2.md");
+      const attempt1Metadata = path.join(evidenceDir, "prompt-metadata.json");
+      const attempt2Metadata = path.join(
+        evidenceDir,
+        "prompt-metadata.attempt-2.json"
+      );
+      const attempt1Snapshot = path.join(evidenceDir, "issue-snapshot.json");
+      const attempt2Snapshot = path.join(
+        evidenceDir,
+        "issue-snapshot.attempt-2.json"
+      );
       await writeFile(
         attempt1Path,
         JSON.stringify({
@@ -593,6 +605,18 @@ describe("HTTP app — runs API and pages", () => {
           states: [],
           templateFiles: []
         })
+      );
+      await writeFile(attempt1Prompt, "attempt 1 prompt\n");
+      await writeFile(attempt2Prompt, "attempt 2 prompt\n");
+      await writeFile(attempt1Metadata, JSON.stringify({ attempt: 1 }));
+      await writeFile(attempt2Metadata, JSON.stringify({ attempt: 2 }));
+      await writeFile(
+        attempt1Snapshot,
+        JSON.stringify({ number: 93, title: "attempt 1" })
+      );
+      await writeFile(
+        attempt2Snapshot,
+        JSON.stringify({ number: 93, title: "attempt 2" })
       );
       await writeFile(
         attempt2Path,
@@ -616,10 +640,7 @@ describe("HTTP app — runs API and pages", () => {
       const baseAttempt = {
         branchName: "sym/run-graph-retry",
         branchRef: "refs/heads/sym/run-graph-retry",
-        issueSnapshotPath: "",
-        metadataPath: "",
         normalizedLogPath: "",
-        promptPath: "",
         providerCommand: "x",
         providerName: "codex" as const,
         rawLogPath: "",
@@ -631,21 +652,27 @@ describe("HTTP app — runs API and pages", () => {
         ...baseAttempt,
         attemptNumber: 1,
         id: "run-graph-retry-attempt-1",
+        issueSnapshotPath: attempt1Snapshot,
+        metadataPath: attempt1Metadata,
+        promptPath: attempt1Prompt,
         workflowGraphPath: attempt1Path
       });
       test.runStore.createAttempt({
         ...baseAttempt,
         attemptNumber: 2,
         id: "run-graph-retry-attempt-2",
+        issueSnapshotPath: attempt2Snapshot,
+        metadataPath: attempt2Metadata,
+        promptPath: attempt2Prompt,
         workflowGraphPath: attempt2Path
       });
       test.runStore.updateRunEvidence("run-graph-retry", {
         branchName: baseAttempt.branchName,
         branchRef: baseAttempt.branchRef,
-        issueSnapshotPath: "",
-        metadataPath: "",
+        issueSnapshotPath: attempt2Snapshot,
+        metadataPath: attempt2Metadata,
         normalizedLogPath: "",
-        promptPath: "",
+        promptPath: attempt2Prompt,
         rawLogPath: "",
         workflowGraphPath: attempt2Path,
         workspacePath: test.stateRoot
@@ -669,6 +696,25 @@ describe("HTTP app — runs API and pages", () => {
       expect(JSON.parse(await attempt1Response.text())).toMatchObject({
         name: "single_agent_workflow"
       });
+      const attempt1PromptResponse = await app.request(
+        "/logs/runs/run-graph-retry/attempts/run-graph-retry-attempt-1/prompt"
+      );
+      expect(attempt1PromptResponse.status).toBe(200);
+      expect(await attempt1PromptResponse.text()).toBe("attempt 1 prompt\n");
+      const attempt1MetadataResponse = await app.request(
+        "/logs/runs/run-graph-retry/attempts/run-graph-retry-attempt-1/prompt_metadata"
+      );
+      expect(attempt1MetadataResponse.status).toBe(200);
+      expect(JSON.parse(await attempt1MetadataResponse.text())).toMatchObject({
+        attempt: 1
+      });
+      const attempt1SnapshotResponse = await app.request(
+        "/logs/runs/run-graph-retry/attempts/run-graph-retry-attempt-1/issue_snapshot"
+      );
+      expect(attempt1SnapshotResponse.status).toBe(200);
+      expect(JSON.parse(await attempt1SnapshotResponse.text())).toMatchObject({
+        title: "attempt 1"
+      });
 
       const attempt2Response = await app.request(
         "/logs/runs/run-graph-retry/attempts/run-graph-retry-attempt-2/workflow_graph"
@@ -689,7 +735,7 @@ describe("HTTP app — runs API and pages", () => {
       expect(wrongAttempt.status).toBe(404);
 
       const wrongKind = await app.request(
-        "/logs/runs/run-graph-retry/attempts/run-graph-retry-attempt-1/prompt"
+        "/logs/runs/run-graph-retry/attempts/run-graph-retry-attempt-1/not_a_kind"
       );
       expect(wrongKind.status).toBe(404);
     } finally {

--- a/tests/run-store-detail.test.ts
+++ b/tests/run-store-detail.test.ts
@@ -300,6 +300,9 @@ describe("RunStore detail queries", () => {
         (artifact) => artifact.kind
       );
       expect(attemptKinds).toEqual([
+        "issue_snapshot",
+        "prompt",
+        "prompt_metadata",
         "workflow_graph",
         "provider_raw",
         "provider_normalized"
@@ -326,6 +329,18 @@ describe("RunStore detail queries", () => {
       const attempt2Graph = path.join(
         evidenceDir,
         "workflow-graph.attempt-2.json"
+      );
+      const attempt1Prompt = path.join(evidenceDir, "prompt.md");
+      const attempt2Prompt = path.join(evidenceDir, "prompt.attempt-2.md");
+      const attempt1Metadata = path.join(evidenceDir, "prompt-metadata.json");
+      const attempt2Metadata = path.join(
+        evidenceDir,
+        "prompt-metadata.attempt-2.json"
+      );
+      const attempt1Snapshot = path.join(evidenceDir, "issue-snapshot.json");
+      const attempt2Snapshot = path.join(
+        evidenceDir,
+        "issue-snapshot.attempt-2.json"
       );
       const attempt1Raw = path.join(evidenceDir, "provider.raw.jsonl");
       const attempt2Raw = path.join(
@@ -360,6 +375,28 @@ describe("RunStore detail queries", () => {
           `${JSON.stringify(attempt2Workflow)}\n`,
           "utf8"
         ),
+        writeFile(attempt1Prompt, "attempt 1 prompt\n", "utf8"),
+        writeFile(attempt2Prompt, "attempt 2 prompt\n", "utf8"),
+        writeFile(
+          attempt1Metadata,
+          `${JSON.stringify({ attempt: 1 })}\n`,
+          "utf8"
+        ),
+        writeFile(
+          attempt2Metadata,
+          `${JSON.stringify({ attempt: 2 })}\n`,
+          "utf8"
+        ),
+        writeFile(
+          attempt1Snapshot,
+          `${JSON.stringify({ number: 42, title: "attempt 1" })}\n`,
+          "utf8"
+        ),
+        writeFile(
+          attempt2Snapshot,
+          `${JSON.stringify({ number: 42, title: "attempt 2" })}\n`,
+          "utf8"
+        ),
         writeFile(attempt1Raw, '{"raw":"a1"}\n', "utf8"),
         writeFile(attempt2Raw, '{"raw":"a2"}\n', "utf8"),
         writeFile(attempt1Normalized, '{"normalized":"a1"}\n', "utf8"),
@@ -377,9 +414,6 @@ describe("RunStore detail queries", () => {
       const baseAttempt = {
         branchName: "sym/symphonika/42-retry",
         branchRef: "refs/heads/sym/symphonika/42-retry",
-        issueSnapshotPath: path.join(evidenceDir, "issue-snapshot.json"),
-        metadataPath: path.join(evidenceDir, "prompt-metadata.json"),
-        promptPath: path.join(evidenceDir, "prompt.md"),
         providerCommand: "codex",
         providerName: "codex" as const,
         runId: "run-retry",
@@ -390,7 +424,10 @@ describe("RunStore detail queries", () => {
         ...baseAttempt,
         attemptNumber: 1,
         id: "run-retry-attempt-1",
+        issueSnapshotPath: attempt1Snapshot,
+        metadataPath: attempt1Metadata,
         normalizedLogPath: attempt1Normalized,
+        promptPath: attempt1Prompt,
         rawLogPath: attempt1Raw,
         workflowGraphPath: attempt1Graph
       });
@@ -398,17 +435,20 @@ describe("RunStore detail queries", () => {
         ...baseAttempt,
         attemptNumber: 2,
         id: "run-retry-attempt-2",
+        issueSnapshotPath: attempt2Snapshot,
+        metadataPath: attempt2Metadata,
         normalizedLogPath: attempt2Normalized,
+        promptPath: attempt2Prompt,
         rawLogPath: attempt2Raw,
         workflowGraphPath: attempt2Graph
       });
       store.updateRunEvidence("run-retry", {
         branchName: baseAttempt.branchName,
         branchRef: baseAttempt.branchRef,
-        issueSnapshotPath: baseAttempt.issueSnapshotPath,
-        metadataPath: baseAttempt.metadataPath,
+        issueSnapshotPath: attempt2Snapshot,
+        metadataPath: attempt2Metadata,
         normalizedLogPath: attempt2Normalized,
-        promptPath: baseAttempt.promptPath,
+        promptPath: attempt2Prompt,
         rawLogPath: attempt2Raw,
         workflowGraphPath: attempt2Graph,
         workspacePath: baseAttempt.workspacePath
@@ -416,6 +456,9 @@ describe("RunStore detail queries", () => {
 
       const descriptors1 = store.listAttemptArtifacts("run-retry-attempt-1");
       expect(descriptors1.map((descriptor) => descriptor.kind)).toEqual([
+        "issue_snapshot",
+        "prompt",
+        "prompt_metadata",
         "workflow_graph",
         "provider_raw",
         "provider_normalized"
@@ -434,6 +477,26 @@ describe("RunStore detail queries", () => {
       expect(stream1).toBeDefined();
       const contents1 = await streamText(stream1);
       expect(JSON.parse(contents1)).toMatchObject({ name: "attempt-1" });
+      const prompt1 = await store.openAttemptArtifactStream(
+        "run-retry-attempt-1",
+        "prompt"
+      );
+      expect(prompt1).toBeDefined();
+      await expect(streamText(prompt1)).resolves.toBe("attempt 1 prompt\n");
+      const metadata1 = await store.openAttemptArtifactStream(
+        "run-retry-attempt-1",
+        "prompt_metadata"
+      );
+      expect(metadata1).toBeDefined();
+      await expect(streamText(metadata1)).resolves.toBe('{"attempt":1}\n');
+      const snapshot1 = await store.openAttemptArtifactStream(
+        "run-retry-attempt-1",
+        "issue_snapshot"
+      );
+      expect(snapshot1).toBeDefined();
+      await expect(streamText(snapshot1)).resolves.toBe(
+        '{"number":42,"title":"attempt 1"}\n'
+      );
 
       const stream2 = await store.openAttemptArtifactStream(
         "run-retry-attempt-2",
@@ -442,12 +505,6 @@ describe("RunStore detail queries", () => {
       const contents2 = await streamText(stream2);
       expect(JSON.parse(contents2)).toMatchObject({ name: "attempt-2" });
 
-      expect(
-        await store.openAttemptArtifactStream(
-          "run-retry-attempt-1",
-          "prompt"
-        )
-      ).toBeUndefined();
       expect(
         await store.openAttemptArtifactStream("missing-attempt", "workflow_graph")
       ).toBeUndefined();

--- a/tests/run-store-lifecycle.test.ts
+++ b/tests/run-store-lifecycle.test.ts
@@ -621,9 +621,23 @@ describe("run-store schema migration", () => {
         );
         insert into runs (
           id, project_name, issue_number, issue_title, state, issue_snapshot_json,
-          created_at, updated_at
+          metadata_path, created_at, updated_at
         ) values (
           'legacy-run', 'symphonika', 99, 't', 'succeeded', '{}',
+          '/state/logs/runs/legacy-run/prompt-metadata.attempt-2.json',
+          '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z'
+        );
+        insert into attempts (
+          id, run_id, attempt_number, state, provider_name, provider_command,
+          workspace_path, branch_name, prompt_path, issue_snapshot_path,
+          raw_log_path, normalized_log_path, created_at, updated_at
+        ) values (
+          'legacy-attempt-2', 'legacy-run', 2, 'succeeded', 'codex', 'codex',
+          '/workspace', 'sym/symphonika/99-t',
+          '/state/logs/runs/legacy-run/prompt.attempt-2.md',
+          '/state/logs/runs/legacy-run/issue-snapshot.attempt-2.json',
+          '/state/logs/runs/legacy-run/provider.raw.attempt-2.jsonl',
+          '/state/logs/runs/legacy-run/provider.normalized.attempt-2.jsonl',
           '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z'
         );
       `);
@@ -643,6 +657,9 @@ describe("run-store schema migration", () => {
           "cancel_requested"
         ])
       );
+      expect(columnNames(reader, "attempts")).toEqual(
+        expect.arrayContaining(["metadata_path"])
+      );
       const row = reader.prepare("select id, retry_count, is_continuation from runs where id = ?").get("legacy-run") as
         | { id: string; retry_count: number; is_continuation: number }
         | undefined;
@@ -650,6 +667,12 @@ describe("run-store schema migration", () => {
         id: "legacy-run",
         retry_count: 0,
         is_continuation: 0
+      });
+      const attempt = reader
+        .prepare("select metadata_path from attempts where id = ?")
+        .get("legacy-attempt-2") as { metadata_path: string } | undefined;
+      expect(attempt).toEqual({
+        metadata_path: "/state/logs/runs/legacy-run/prompt-metadata.attempt-2.json"
       });
     } finally {
       reader.close();
@@ -677,7 +700,9 @@ describe("run-store schema migration", () => {
       );
 
       const attempts = columnNames(database, "attempts");
-      expect(attempts).toEqual(expect.arrayContaining(["failure_classification"]));
+      expect(attempts).toEqual(
+        expect.arrayContaining(["failure_classification", "metadata_path"])
+      );
     } finally {
       database.close();
     }

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -339,6 +339,83 @@ describe("workflow prompt rendering", () => {
     });
   });
 
+  it("suffixes all provider-attempt evidence files for retries", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "7-render-prompts"
+    );
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(workflowPath, "Work on {{issue.title}}.\n");
+    const expanded = await loadExpandedWorkflow(workflowPath);
+    expect(expanded.errors).toEqual([]);
+
+    const input = {
+      branch: {
+        name: "sym/symphonika/7-render-prompts",
+        ref: "refs/heads/sym/symphonika/7-render-prompts"
+      },
+      issue: issueSnapshot(),
+      project: { name: "symphonika" },
+      provider: {
+        command: DEFAULT_CODEX_COMMAND,
+        name: "codex" as const
+      },
+      run: {
+        attempt: 2,
+        continuation: false,
+        id: "run-7"
+      },
+      template: "Work on {{issue.title}}.",
+      workflowContentHash: expanded.workflow.contentHash,
+      workflowPath,
+      workspace: {
+        path: workspacePath,
+        previous_attempt: true,
+        root: path.dirname(path.dirname(workspacePath))
+      }
+    };
+    const rendered = renderAutonomousPrompt(input);
+
+    const evidence = await persistRunEvidence({
+      ...input,
+      attemptNumber: 2,
+      expandedWorkflow: expanded.workflow,
+      renderedPrompt: rendered,
+      stateRoot
+    });
+
+    expect(path.basename(evidence.promptPath)).toBe("prompt.attempt-2.md");
+    expect(path.basename(evidence.metadataPath)).toBe(
+      "prompt-metadata.attempt-2.json"
+    );
+    expect(path.basename(evidence.issueSnapshotPath)).toBe(
+      "issue-snapshot.attempt-2.json"
+    );
+    expect(path.basename(evidence.workflowGraphPath)).toBe(
+      "workflow-graph.attempt-2.json"
+    );
+    await expect(readFile(evidence.promptPath, "utf8")).resolves.toBe(
+      rendered.prompt
+    );
+    const metadata = parseJsonRecord(await readFile(evidence.metadataPath, "utf8"));
+    expect(metadata).toMatchObject({
+      issue_snapshot_path: evidence.issueSnapshotPath,
+      prompt_path: evidence.promptPath,
+      workflow: {
+        graph_path: evidence.workflowGraphPath
+      }
+    });
+    await expect(readFile(evidence.issueSnapshotPath, "utf8")).resolves.toContain(
+      "Render autonomous prompts and persist run evidence"
+    );
+  });
+
   it("loads WORKFLOW.md body without front matter and carries its content hash into the rendered prompt", async () => {
     const root = await makeTempRoot();
     const workflowPath = path.join(root, "WORKFLOW.md");


### PR DESCRIPTION
Summary:
- write retry prompt, prompt metadata, issue snapshot, and workflow graph evidence with attempt-suffixed filenames
- expose prompt, prompt_metadata, and issue_snapshot through attempt artifact descriptors and HTTP streams
- add attempts.metadata_path migration/backfill coverage and refresh SPEC 7.4

Validation:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Implementation note:
- Legacy attempts gain attempts.metadata_path by inferring the metadata filename from prompt_path when possible, falling back to the run-level metadata path when historical rows do not carry enough information to reconstruct a better value.

Closes #154