### PR TITLE
fix: reload state provider before delayed advance

### DIFF
--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -1032,6 +1032,29 @@ export class RunController {
       return;
     }
 
+    // Mirror the schedule-time terminal short-circuit in executeWaitPark
+    // (see the `next?.terminal !== undefined` branch above). When a workflow
+    // edit during the continuation delay rewrites payload.toStateId into a
+    // terminal state, recording the transition is the entire intent — no
+    // provider should be launched on a state with no agent action.
+    if (targetState.terminal !== undefined) {
+      const providerName = project.agent.provider;
+      const providerCommand =
+        (providersConfig as Partial<RunControllerProvidersConfig>)[providerName]
+          ?.command ?? "";
+      await this.recordStateAdvanceTerminalTarget({
+        issue: refreshed,
+        parentRunId: payload.parentRunId,
+        project,
+        providerCommand,
+        providerName,
+        repository,
+        runId,
+        targetState
+      });
+      return;
+    }
+
     const providerName =
       targetState.action?.kind === "agent" &&
       targetState.action.provider !== undefined
@@ -1152,6 +1175,75 @@ export class RunController {
         kind: "failed",
         reason: input.reason
       },
+      repository: input.repository,
+      willRetry: false
+    });
+  }
+
+  private async recordStateAdvanceTerminalTarget(input: {
+    issue: IssueSnapshot;
+    parentRunId: string;
+    project: RunControllerProjectConfig;
+    providerCommand: string;
+    providerName: AgentProviderName;
+    repository: GitHubIssueRepositoryInput;
+    runId: string;
+    targetState: ExpandedWorkflowState;
+  }): Promise<void> {
+    await this.bestEffort(
+      () =>
+        (this.githubIssuesApi as LabelWritingGitHubIssuesApi).addLabelsToIssue({
+          ...input.repository,
+          issueNumber: input.issue.number,
+          labels: ["sym:claimed"]
+        }),
+      {
+        issueNumber: input.issue.number,
+        label: "sym:claimed",
+        operation: "addLabel",
+        phase: "state-advance-terminal-target",
+        project: input.project.name,
+        runId: input.runId
+      }
+    );
+    this.runStore.createContinuationRun({
+      id: input.runId,
+      issue: input.issue,
+      parentRunId: input.parentRunId,
+      projectName: input.project.name,
+      providerCommand: input.providerCommand,
+      providerName: input.providerName
+    });
+    const transitionReason = `reloaded target ${input.targetState.id} is terminal`;
+    this.runStore.recordWorkflowTerminal(input.runId, {
+      terminalStateId: input.targetState.id,
+      transitionReason
+    });
+    const terminalLabel = narrowTerminalLabel(input.targetState.terminal);
+    const outcome = fuseWorkflowTerminal(
+      { kind: "success", reason: transitionReason },
+      terminalLabel
+    );
+    this.runStore.recordTerminalReason(
+      input.runId,
+      outcome.reason,
+      outcome.classification
+    );
+    this.runStore.updateRunState(input.runId, mapOutcomeToRunState(outcome));
+    this.logger?.info(
+      {
+        issueNumber: input.issue.number,
+        parentRunId: input.parentRunId,
+        project: input.project.name,
+        runId: input.runId,
+        targetStateId: input.targetState.id,
+        terminal: input.targetState.terminal
+      },
+      "symphonika state advance recorded reloaded terminal target without launching provider"
+    );
+    await this.applyTerminalLabels({
+      issueNumber: input.issue.number,
+      outcome,
       repository: input.repository,
       willRetry: false
     });

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -74,6 +74,7 @@ export type WorkflowSnapshot = {
   body: string;
   contentHash: string;
   expandedWorkflow: ExpandedWorkflow;
+  format: WorkflowReference["format"];
   path: string;
 };
 
@@ -82,6 +83,7 @@ type LoadedWorkflow = {
   contentHash: string;
   errors: string[];
   expandedWorkflow: ExpandedWorkflow;
+  format: WorkflowReference["format"];
   path: string;
 };
 
@@ -219,14 +221,13 @@ type ContinuationPayload = {
 };
 
 type StateAdvancePayload = {
-  action?: WorkflowAction;
   issue: IssueSnapshot;
   parentRunId: string;
   projectName: string;
+  toStateId: string;
 };
 
 type WorkflowOutcomeResult = {
-  advancedToAction?: WorkflowAction;
   advancedToState: string | null;
   advancedToTerminal: boolean;
   blocked: boolean;
@@ -890,10 +891,10 @@ export class RunController {
         delayMs: this.lifecyclePolicy.continuation.delayMs,
         fire: () =>
           this.executeStateAdvance({
-            ...(next?.action === undefined ? {} : { action: next.action }),
             issue: refreshed,
             parentRunId: runId,
-            projectName: project.name
+            projectName: project.name,
+            toStateId: decision.to
           }),
         issueNumber: refreshed.number,
         kind: "state_advance",
@@ -932,15 +933,7 @@ export class RunController {
       return;
     }
 
-    const providerName =
-      payload.action?.kind === "agent" && payload.action.provider !== undefined
-        ? payload.action.provider
-        : project.agent.provider;
     const providersConfig = await this.providersLoader();
-    const providerConfig = (providersConfig as Partial<RunControllerProvidersConfig>)[
-      providerName
-    ];
-    const providerCommand = providerConfig?.command;
 
     if (!isLabelWritingGitHubIssuesApi(this.githubIssuesApi)) {
       return;
@@ -976,6 +969,79 @@ export class RunController {
     }
 
     const runId = this.createRunId();
+    let loadedWorkflow: LoadedWorkflow;
+    try {
+      loadedWorkflow = await this.loadWorkflow(project.workflow, {
+        forceReload: true
+      });
+    } catch (error) {
+      const providerName = project.agent.provider;
+      const providerCommand =
+        (providersConfig as Partial<RunControllerProvidersConfig>)[providerName]
+          ?.command ?? "";
+      const message = error instanceof Error ? error.message : String(error);
+      await this.failStateAdvanceBeforeProvider({
+        issue: refreshed,
+        parentRunId: payload.parentRunId,
+        project,
+        providerCommand,
+        providerName,
+        reason: `workflow_load_failed: ${message}`,
+        repository,
+        runId
+      });
+      return;
+    }
+    if (loadedWorkflow.errors.length > 0) {
+      const providerName = project.agent.provider;
+      const providerCommand =
+        (providersConfig as Partial<RunControllerProvidersConfig>)[providerName]
+          ?.command ?? "";
+      await this.failStateAdvanceBeforeProvider({
+        issue: refreshed,
+        parentRunId: payload.parentRunId,
+        project,
+        providerCommand,
+        providerName,
+        reason: `workflow_load_failed: ${loadedWorkflow.errors.join("; ")}`,
+        repository,
+        runId
+      });
+      return;
+    }
+
+    const targetState = findWorkflowState(
+      loadedWorkflow.expandedWorkflow,
+      payload.toStateId
+    );
+    if (targetState === undefined) {
+      const providerName = project.agent.provider;
+      const providerCommand =
+        (providersConfig as Partial<RunControllerProvidersConfig>)[providerName]
+          ?.command ?? "";
+      await this.failStateAdvanceBeforeProvider({
+        issue: refreshed,
+        parentRunId: payload.parentRunId,
+        project,
+        providerCommand,
+        providerName,
+        reason: `workflow_state_not_found: ${payload.toStateId}`,
+        repository,
+        runId
+      });
+      return;
+    }
+
+    const providerName =
+      targetState.action?.kind === "agent" &&
+      targetState.action.provider !== undefined
+        ? targetState.action.provider
+        : project.agent.provider;
+    const providerConfig = (providersConfig as Partial<RunControllerProvidersConfig>)[
+      providerName
+    ];
+    const providerCommand = providerConfig?.command;
+
     if (providerCommand === undefined || providerCommand.trim().length === 0) {
       await this.failStateAdvanceBeforeProvider({
         issue: refreshed,
@@ -1010,7 +1076,16 @@ export class RunController {
       isContinuation: true,
       issue: refreshed,
       parentRunId: payload.parentRunId,
-      project,
+      project: {
+        ...project,
+        workflow: {
+          body: loadedWorkflow.body,
+          contentHash: loadedWorkflow.contentHash,
+          expandedWorkflow: loadedWorkflow.expandedWorkflow,
+          format: loadedWorkflow.format,
+          path: loadedWorkflow.path
+        }
+      },
       provider,
       providerCommand,
       providerName,
@@ -1480,6 +1555,7 @@ export class RunController {
           body: loadedWorkflow.body,
           contentHash: loadedWorkflow.contentHash,
           expandedWorkflow: loadedWorkflow.expandedWorkflow,
+          format: loadedWorkflow.format,
           path: loadedWorkflow.path
         }
       };
@@ -1718,9 +1794,6 @@ export class RunController {
             workflowOutcome.advancedToState !== null &&
             workflowOutcome.parkAsWait !== true
               ? {
-                  ...(workflowOutcome.advancedToAction === undefined
-                    ? {}
-                    : { action: workflowOutcome.advancedToAction }),
                   toStateId: workflowOutcome.advancedToState
                 }
               : null,
@@ -1897,7 +1970,6 @@ export class RunController {
         };
       }
       return {
-        ...(next?.action === undefined ? {} : { advancedToAction: next.action }),
         advancedToState: decision.to,
         advancedToTerminal: false,
         blocked: false
@@ -1930,15 +2002,17 @@ export class RunController {
   }
 
   private async loadWorkflow(
-    workflow: WorkflowReference | WorkflowSnapshot
+    workflow: WorkflowReference | WorkflowSnapshot,
+    options: { forceReload?: boolean } = {}
   ): Promise<LoadedWorkflow> {
-    if (!("expandedWorkflow" in workflow)) {
+    if (!("expandedWorkflow" in workflow) || options.forceReload === true) {
       const workflowPath = path.resolve(this.configDir, workflow.path);
       const contents = await readFile(workflowPath, "utf8");
+      const format = workflow.format;
       const expanded = await expandWorkflowDefinition(
         contents,
         workflowPath,
-        workflow.format
+        format
       );
       // Raw FSM YAML files commonly open with the `---` document marker; the
       // markdown contract parser would reject those as missing a closing
@@ -1950,6 +2024,7 @@ export class RunController {
           contentHash: expanded.workflow.contentHash,
           errors: expanded.errors,
           expandedWorkflow: expanded.workflow,
+          format,
           path: workflowPath
         };
       }
@@ -1959,6 +2034,7 @@ export class RunController {
         contentHash: contract.contentHash,
         errors: [...contract.errors, ...expanded.errors],
         expandedWorkflow: expanded.workflow,
+        format,
         path: workflowPath
       };
     }
@@ -1968,6 +2044,7 @@ export class RunController {
       contentHash: workflow.contentHash,
       errors: [],
       expandedWorkflow: workflow.expandedWorkflow,
+      format: workflow.format,
       path: workflow.path
     };
   }
@@ -2154,7 +2231,7 @@ export class RunController {
     respectsIssueLabels?: boolean;
     runId: string;
     runtimeAttemptNumber: number;
-    stateAdvance?: { action?: WorkflowAction; toStateId: string } | null;
+    stateAdvance?: { toStateId: string } | null;
     suppressContinuation?: boolean;
     waitPark?: { waitingRunId: string } | null;
   }): Promise<void> {
@@ -2233,12 +2310,10 @@ export class RunController {
         delayMs: this.lifecyclePolicy.continuation.delayMs,
         fire: () =>
           this.executeStateAdvance({
-            ...(stateAdvance.action === undefined
-              ? {}
-              : { action: stateAdvance.action }),
             issue: refreshedForAdvance,
             parentRunId: input.runId,
-            projectName: input.project.name
+            projectName: input.project.name,
+            toStateId: stateAdvance.toStateId
           }),
         issueNumber: refreshedForAdvance.number,
         kind: "state_advance",

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -975,39 +975,71 @@ export class RunController {
         forceReload: true
       });
     } catch (error) {
-      const providerName = project.agent.provider;
-      const providerCommand =
-        (providersConfig as Partial<RunControllerProvidersConfig>)[providerName]
-          ?.command ?? "";
       const message = error instanceof Error ? error.message : String(error);
-      await this.failStateAdvanceBeforeProvider({
-        issue: refreshed,
-        parentRunId: payload.parentRunId,
-        project,
-        providerCommand,
-        providerName,
-        reason: `workflow_load_failed: ${message}`,
-        repository,
-        runId
-      });
-      return;
+      const fallback = this.lastKnownGoodLoadedWorkflow(project.workflow);
+      if (fallback === undefined) {
+        const providerName = project.agent.provider;
+        const providerCommand =
+          (providersConfig as Partial<RunControllerProvidersConfig>)[providerName]
+            ?.command ?? "";
+        await this.failStateAdvanceBeforeProvider({
+          issue: refreshed,
+          parentRunId: payload.parentRunId,
+          project,
+          providerCommand,
+          providerName,
+          reason: `workflow_load_failed: ${message}`,
+          repository,
+          runId
+        });
+        return;
+      }
+      // SPEC §5.2: report the reload error but continue with the last-known-good
+      // workflow snapshot. A transient malformed edit during the delay must not
+      // mark an otherwise valid mid-walk run as failed.
+      this.logger?.warn(
+        {
+          issueNumber: refreshed.number,
+          parentRunId: payload.parentRunId,
+          project: project.name,
+          reason: `workflow_load_failed: ${message}`,
+          runId
+        },
+        "symphonika state advance reload failed; using last known good workflow"
+      );
+      loadedWorkflow = fallback;
     }
     if (loadedWorkflow.errors.length > 0) {
-      const providerName = project.agent.provider;
-      const providerCommand =
-        (providersConfig as Partial<RunControllerProvidersConfig>)[providerName]
-          ?.command ?? "";
-      await this.failStateAdvanceBeforeProvider({
-        issue: refreshed,
-        parentRunId: payload.parentRunId,
-        project,
-        providerCommand,
-        providerName,
-        reason: `workflow_load_failed: ${loadedWorkflow.errors.join("; ")}`,
-        repository,
-        runId
-      });
-      return;
+      const fallback = this.lastKnownGoodLoadedWorkflow(project.workflow);
+      const reason = `workflow_load_failed: ${loadedWorkflow.errors.join("; ")}`;
+      if (fallback === undefined) {
+        const providerName = project.agent.provider;
+        const providerCommand =
+          (providersConfig as Partial<RunControllerProvidersConfig>)[providerName]
+            ?.command ?? "";
+        await this.failStateAdvanceBeforeProvider({
+          issue: refreshed,
+          parentRunId: payload.parentRunId,
+          project,
+          providerCommand,
+          providerName,
+          reason,
+          repository,
+          runId
+        });
+        return;
+      }
+      this.logger?.warn(
+        {
+          issueNumber: refreshed.number,
+          parentRunId: payload.parentRunId,
+          project: project.name,
+          reason,
+          runId
+        },
+        "symphonika state advance reload invalid; using last known good workflow"
+      );
+      loadedWorkflow = fallback;
     }
 
     const targetState = findWorkflowState(
@@ -2091,6 +2123,22 @@ export class RunController {
     }
 
     return { advancedToState: null, advancedToTerminal: false, blocked: false };
+  }
+
+  private lastKnownGoodLoadedWorkflow(
+    workflow: WorkflowReference | WorkflowSnapshot
+  ): LoadedWorkflow | undefined {
+    if (!("expandedWorkflow" in workflow)) {
+      return undefined;
+    }
+    return {
+      body: workflow.body,
+      contentHash: workflow.contentHash,
+      errors: [],
+      expandedWorkflow: workflow.expandedWorkflow,
+      format: workflow.format,
+      path: workflow.path
+    };
   }
 
   private async loadWorkflow(

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -375,6 +375,7 @@ async function readWorkflowSnapshot(
       body: "",
       contentHash: expanded.workflow.contentHash,
       expandedWorkflow: expanded.workflow,
+      format,
       path: workflowPath
     };
   }
@@ -389,6 +390,7 @@ async function readWorkflowSnapshot(
     body: workflow.body,
     contentHash: workflow.contentHash,
     expandedWorkflow: expanded.workflow,
+    format,
     path: workflow.path
   };
 }

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1623,6 +1623,64 @@ describe("daemon dispatch", () => {
     }
   });
 
+  it("falls back to last-known-good workflow when a delayed advance reload is invalid", async () => {
+    const root = await makeTempRoot();
+    await writePerStateProviderRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 10,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexInputs: ProviderRunInput[] = [];
+    const claudeInputs: ProviderRunInput[] = [];
+    const codexProvider = successfulProvider("codex", codexInputs);
+    const claudeProvider = successfulProvider("claude", claudeInputs);
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { claude: claudeProvider, codex: codexProvider },
+      createRunId: () => `run-fsm-stale-reload-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 250 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForStoredRunState(root, "succeeded");
+      // Simulate a mid-save / malformed edit during the continuation delay.
+      // SPEC §5.2: the daemon must keep the last-known-good effective workflow
+      // for future work and must not fail the mid-walk run.
+      await writeFile(path.join(root, "workflow.yml"), "workflow:\n  initial:\n    -\n");
+      await waitForTerminalState(root, "done");
+
+      // The state-advance must still complete the autofix state using the
+      // last-known-good workflow (claude per writePerStateProviderRawFsmProject).
+      expect(claudeInputs).toHaveLength(1);
+      expect(codexInputs).toHaveLength(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("falls back to the project provider when the next agent state omits provider", async () => {
     const root = await makeTempRoot();
     await writeFallbackProviderRawFsmProject(root);

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1546,6 +1546,83 @@ describe("daemon dispatch", () => {
     }
   });
 
+  it("records a reloaded terminal target without launching the next provider", async () => {
+    const root = await makeTempRoot();
+    await writePerStateProviderRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 9,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexInputs: ProviderRunInput[] = [];
+    const claudeInputs: ProviderRunInput[] = [];
+    const codexProvider = successfulProvider("codex", codexInputs);
+    const claudeProvider = successfulProvider("claude", claudeInputs);
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { claude: claudeProvider, codex: codexProvider },
+      createRunId: () => `run-fsm-terminal-target-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 250 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForStoredRunState(root, "succeeded");
+      await writeWorkflowWithTerminalAutofix(root);
+      await waitForTerminalState(root, "autofix");
+
+      // planning ran once (codex); the reloaded autofix is terminal, so neither
+      // provider was invoked for the state-advance attempt.
+      expect(codexInputs).toHaveLength(1);
+      expect(claudeInputs).toHaveLength(0);
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const rows = database
+          .prepare(
+            "select id, state, terminal_state_id from runs order by created_at"
+          )
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toMatchObject([
+          { id: "run-fsm-terminal-target-1", state: "succeeded" },
+          {
+            id: "run-fsm-terminal-target-2",
+            state: "succeeded",
+            terminal_state_id: "autofix"
+          }
+        ]);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("falls back to the project provider when the next agent state omits provider", async () => {
     const root = await makeTempRoot();
     await writeFallbackProviderRawFsmProject(root);
@@ -2838,6 +2915,33 @@ async function writeProviderRoutingWorkflow(
   await writeFile(
     path.join(root, "autofix-prompt.md"),
     "Apply the autofix for #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+async function writeWorkflowWithTerminalAutofix(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: provider_routing",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: autofix",
+      "    autofix:",
+      "      terminal: success",
+      "    done:",
+      "      terminal: success",
+      ""
+    ].join("\n")
   );
 }
 

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1477,6 +1477,75 @@ describe("daemon dispatch", () => {
     }
   });
 
+  it("recomputes the target state provider when a delayed state advance fires", async () => {
+    const root = await makeTempRoot();
+    await writePerStateProviderRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexInputs: ProviderRunInput[] = [];
+    const claudeInputs: ProviderRunInput[] = [];
+    const codexProvider = successfulProvider("codex", codexInputs);
+    const claudeProvider = successfulProvider("claude", claudeInputs);
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { claude: claudeProvider, codex: codexProvider },
+      createRunId: () => `run-fsm-reloaded-provider-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 250 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForStoredRunState(root, "succeeded");
+      await writeProviderRoutingWorkflow(root, "codex");
+      await waitForTerminalState(root, "done");
+
+      expect(codexInputs).toHaveLength(2);
+      expect(claudeInputs).toHaveLength(0);
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const rows = database
+          .prepare("select id, provider_name from runs order by created_at")
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toMatchObject([
+          { id: "run-fsm-reloaded-provider-1", provider_name: "codex" },
+          { id: "run-fsm-reloaded-provider-2", provider_name: "codex" }
+        ]);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("falls back to the project provider when the next agent state omits provider", async () => {
     const root = await makeTempRoot();
     await writeFallbackProviderRawFsmProject(root);
@@ -2723,6 +2792,13 @@ async function writeMultiStateRawFsmProject(root: string): Promise<void> {
 
 async function writePerStateProviderRawFsmProject(root: string): Promise<void> {
   await writeRawFsmProjectConfig(root);
+  await writeProviderRoutingWorkflow(root, "claude");
+}
+
+async function writeProviderRoutingWorkflow(
+  root: string,
+  autofixProvider: "codex" | "claude"
+): Promise<void> {
   await writeFile(
     path.join(root, "workflow.yml"),
     [
@@ -2743,7 +2819,7 @@ async function writePerStateProviderRawFsmProject(root: string): Promise<void> {
       "    autofix:",
       "      action:",
       "        kind: agent",
-      "        provider: claude",
+      `        provider: ${autofixProvider}`,
       "        prompt: autofix-prompt.md",
       "      complete_when:",
       "        provider_success: true",


### PR DESCRIPTION
Summary:
- Recompute raw-FSM state advance provider from the target state when the delayed advance fires.
- Force the state-advance workflow snapshot back to disk so edits made during the delay apply to the next attempt.
- Add a daemon regression for provider edits before a delayed state advance fires.

Validation:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #155