### PR TITLE
refactor: move workflow graph types to shared module

### DIFF
--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -6,6 +6,26 @@ import { BUILTIN_WORKFLOW_TEMPLATES } from "./builtin-templates.js";
 import type { WorkflowFormat } from "./config-schemas.js";
 import type { IssueSnapshot } from "./issue-polling.js";
 import { isPathInside } from "./path-safety.js";
+import type {
+  ExpandedWorkflow,
+  ExpandedWorkflowState,
+  WorkflowAction,
+  WorkflowActionKind,
+  WorkflowPredicateMap,
+  WorkflowSourceKind,
+  WorkflowTransition
+} from "./workflow/types.js";
+
+export type {
+  ExpandedWorkflow,
+  ExpandedWorkflowState,
+  WorkflowAction,
+  WorkflowActionKind,
+  WorkflowPredicateMap,
+  WorkflowPredicateValue,
+  WorkflowSourceKind,
+  WorkflowTransition
+} from "./workflow/types.js";
 
 export const AUTONOMY_PREAMBLE_VERSION = "autonomy-preamble-v2";
 
@@ -74,53 +94,6 @@ export type WorkflowContract = {
   contentHash: string;
   errors: string[];
   path: string;
-};
-
-export type WorkflowSourceKind = "markdown" | "raw_fsm";
-
-export type WorkflowActionKind =
-  | "agent"
-  | "close_issue"
-  | "comment"
-  | "fail"
-  | "label_issue"
-  | "merge_pr"
-  | "wait";
-
-export type WorkflowPredicateValue = boolean | number | string;
-
-export type WorkflowPredicateMap = Record<string, WorkflowPredicateValue>;
-
-export type WorkflowAction = {
-  kind: WorkflowActionKind;
-  method?: string;
-  prompt?: string;
-  provider?: "codex" | "claude";
-};
-
-export type WorkflowTransition = {
-  to: string;
-  when: WorkflowPredicateMap;
-};
-
-export type ExpandedWorkflowState = {
-  action?: WorkflowAction;
-  completeWhen: WorkflowPredicateMap;
-  id: string;
-  terminal?: string;
-  transitions: WorkflowTransition[];
-};
-
-export type ExpandedWorkflow = {
-  contentHash: string;
-  initial: string;
-  name: string;
-  source: {
-    kind: WorkflowSourceKind;
-    path: string;
-  };
-  states: ExpandedWorkflowState[];
-  templateFiles: string[];
 };
 
 type WorkflowTemplateInputType =

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -1,0 +1,46 @@
+export type WorkflowSourceKind = "markdown" | "raw_fsm";
+
+export type WorkflowActionKind =
+  | "agent"
+  | "close_issue"
+  | "comment"
+  | "fail"
+  | "label_issue"
+  | "merge_pr"
+  | "wait";
+
+export type WorkflowPredicateValue = boolean | number | string;
+
+export type WorkflowPredicateMap = Record<string, WorkflowPredicateValue>;
+
+export type WorkflowAction = {
+  kind: WorkflowActionKind;
+  method?: string;
+  prompt?: string;
+  provider?: "codex" | "claude";
+};
+
+export type WorkflowTransition = {
+  to: string;
+  when: WorkflowPredicateMap;
+};
+
+export type ExpandedWorkflowState = {
+  action?: WorkflowAction;
+  completeWhen: WorkflowPredicateMap;
+  id: string;
+  terminal?: string;
+  transitions: WorkflowTransition[];
+};
+
+export type ExpandedWorkflow = {
+  contentHash: string;
+  initial: string;
+  name: string;
+  source: {
+    kind: WorkflowSourceKind;
+    path: string;
+  };
+  states: ExpandedWorkflowState[];
+  templateFiles: string[];
+};

--- a/tests/workflow-types.test.ts
+++ b/tests/workflow-types.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ExpandedWorkflow,
+  ExpandedWorkflowState,
+  WorkflowAction,
+  WorkflowActionKind,
+  WorkflowPredicateMap,
+  WorkflowPredicateValue,
+  WorkflowSourceKind,
+  WorkflowTransition
+} from "../src/workflow.js";
+import type {
+  ExpandedWorkflow as CanonicalExpandedWorkflow,
+  ExpandedWorkflowState as CanonicalExpandedWorkflowState,
+  WorkflowAction as CanonicalWorkflowAction,
+  WorkflowActionKind as CanonicalWorkflowActionKind,
+  WorkflowPredicateMap as CanonicalWorkflowPredicateMap,
+  WorkflowPredicateValue as CanonicalWorkflowPredicateValue,
+  WorkflowSourceKind as CanonicalWorkflowSourceKind,
+  WorkflowTransition as CanonicalWorkflowTransition
+} from "../src/workflow/types.js";
+
+type TypeEquals<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends (
+    <Value>() => Value extends Right ? 1 : 2
+  )
+    ? (<Value>() => Value extends Right ? 1 : 2) extends (
+        <Value>() => Value extends Left ? 1 : 2
+      )
+      ? true
+      : false
+    : false;
+
+type AssertTrue<Value extends true> = Value;
+
+type PublicFacadeMatchesCanonicalWorkflowTypes = [
+  AssertTrue<TypeEquals<WorkflowSourceKind, CanonicalWorkflowSourceKind>>,
+  AssertTrue<TypeEquals<WorkflowActionKind, CanonicalWorkflowActionKind>>,
+  AssertTrue<TypeEquals<WorkflowPredicateValue, CanonicalWorkflowPredicateValue>>,
+  AssertTrue<TypeEquals<WorkflowPredicateMap, CanonicalWorkflowPredicateMap>>,
+  AssertTrue<TypeEquals<WorkflowAction, CanonicalWorkflowAction>>,
+  AssertTrue<TypeEquals<WorkflowTransition, CanonicalWorkflowTransition>>,
+  AssertTrue<TypeEquals<ExpandedWorkflowState, CanonicalExpandedWorkflowState>>,
+  AssertTrue<TypeEquals<ExpandedWorkflow, CanonicalExpandedWorkflow>>
+];
+
+describe("workflow shared types", () => {
+  it("keeps the public workflow facade aligned with the canonical shared types module", () => {
+    const compileTimeAssertions: PublicFacadeMatchesCanonicalWorkflowTypes = [
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ];
+
+    expect(compileTimeAssertions).toHaveLength(8);
+  });
+});


### PR DESCRIPTION
## Summary
- add src/workflow/types.ts as the canonical home for shared workflow graph and predicate/action types
- keep src/workflow.ts as the compatibility facade for existing consumers
- add a type-level regression test that the facade exports match the canonical module

## Tests
- npm run lint
- npm run typecheck
- npm test
- npm run build
- npm run quality

Closes #156