### PR TITLE
Build CLI before npm link

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint .",
     "mutation": "stryker run",
     "mutation:dry": "stryker run --dryRunOnly",
+    "prepare": "npm run build",
     "quality": "npm run lint && npm run typecheck && npm test && npm run build",
     "smoke": "tsx src/cli.ts smoke",
     "smoke:local": "scripts/smoke.sh",

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -46,23 +46,37 @@ describe("CLI", () => {
     const root = await makeTempRoot();
     const prefix = path.join(root, "prefix");
     const binPath = path.join(prefix, "bin", "symphonika");
-    await rm(path.join(repoRoot, "dist"), { force: true, recursive: true });
+    const distPath = path.join(repoRoot, "dist");
+    const distBackup = path.join(repoRoot, "dist.cli-test-backup");
 
-    await execFile("npm", ["link"], {
-      cwd: repoRoot,
-      env: {
-        ...process.env,
-        NPM_CONFIG_PREFIX: prefix
+    await rm(distBackup, { force: true, recursive: true });
+    const hadDist = await rename(distPath, distBackup).then(
+      () => true,
+      () => false
+    );
+
+    try {
+      await execFile("npm", ["link"], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          NPM_CONFIG_PREFIX: prefix
+        }
+      });
+
+      const { stdout } = await execFile(binPath, ["help"], { cwd: repoRoot });
+
+      expect(stdout).toContain("Usage: symphonika");
+      expect(stdout).toContain("Commands:");
+      expect(stdout).toContain("doctor");
+      expect(stdout).toContain("workflow");
+      expect(stdout).toContain("show-run");
+    } finally {
+      await rm(distPath, { force: true, recursive: true });
+      if (hadDist) {
+        await rename(distBackup, distPath);
       }
-    });
-
-    const { stdout } = await execFile(binPath, ["help"], { cwd: repoRoot });
-
-    expect(stdout).toContain("Usage: symphonika");
-    expect(stdout).toContain("Commands:");
-    expect(stdout).toContain("doctor");
-    expect(stdout).toContain("workflow");
-    expect(stdout).toContain("show-run");
+    }
   });
 
   it("prints top-level help when invoked through an npm-style bin symlink", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -42,6 +42,29 @@ afterEach(async () => {
 });
 
 describe("CLI", () => {
+  it("builds a missing dist bin during npm link so the linked executable shows help", async () => {
+    const root = await makeTempRoot();
+    const prefix = path.join(root, "prefix");
+    const binPath = path.join(prefix, "bin", "symphonika");
+    await rm(path.join(repoRoot, "dist"), { force: true, recursive: true });
+
+    await execFile("npm", ["link"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        NPM_CONFIG_PREFIX: prefix
+      }
+    });
+
+    const { stdout } = await execFile(binPath, ["help"], { cwd: repoRoot });
+
+    expect(stdout).toContain("Usage: symphonika");
+    expect(stdout).toContain("Commands:");
+    expect(stdout).toContain("doctor");
+    expect(stdout).toContain("workflow");
+    expect(stdout).toContain("show-run");
+  });
+
   it("prints top-level help when invoked through an npm-style bin symlink", async () => {
     const root = await makeTempRoot();
     const binPath = path.join(root, "symphonika");


### PR DESCRIPTION
Summary:
- Add a prepare lifecycle so npm link builds dist/cli.js before npm exposes the bin.
- Cover clean-checkout npm link help through the linked symphonika executable.

Validation:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #167