### PR TITLE
refactor: split issue reservation registries

### DIFF
--- a/src/lifecycle/active-runs.ts
+++ b/src/lifecycle/active-runs.ts
@@ -1,5 +1,30 @@
-import type { AgentProvider } from "../provider.js";
 import type { CancelReason } from "../run-store.js";
+
+import {
+  InFlightRunRegistry,
+  type InFlightRunEntry,
+  type RegisterRunInput
+} from "./in-flight-runs.js";
+import {
+  IssueReservationRegistry,
+  type IssueReservationKey
+} from "./issue-reservations.js";
+import {
+  ScheduledWorkRegistry,
+  type ScheduledWorkInput,
+  type ScheduledWorkSnapshot
+} from "./scheduled-work.js";
+
+export { InFlightRunRegistry } from "./in-flight-runs.js";
+export type { InFlightRunEntry, RegisterRunInput } from "./in-flight-runs.js";
+export { IssueReservationRegistry } from "./issue-reservations.js";
+export type { IssueReservationKey } from "./issue-reservations.js";
+export { ScheduledWorkRegistry } from "./scheduled-work.js";
+export type {
+  ScheduledWorkInput,
+  ScheduledWorkKind,
+  ScheduledWorkSnapshot
+} from "./scheduled-work.js";
 
 export const CANCEL_REASONS = {
   CLOSED_ISSUE: "closed_issue",
@@ -42,166 +67,72 @@ export function computeRetryDelayMs(
   return Math.min(slot, policy.retry.maxBackoffMs);
 }
 
-export type ActiveRunEntry = {
-  cancel: () => Promise<void>;
-  cancelReason?: CancelReason;
-  cancelRequested: boolean;
-  issueNumber: number;
-  projectName: string;
-  provider?: AgentProvider;
-  // When false, this run is part of an FSM walk where the state machine — not
-  // the issue label set — decides whether to keep running. Reconcile uses this
-  // to skip the labels_all / labels_none re-check while still honoring
-  // CLOSED_ISSUE. See ADR 0046.
-  respectsIssueLabels: boolean;
-  runId: string;
-};
-
-export type RegisterInput = {
-  cancel: () => Promise<void>;
-  issueNumber: number;
-  projectName: string;
-  provider?: AgentProvider;
-  respectsIssueLabels?: boolean;
-  runId: string;
-};
-
-export type ScheduledWorkKind =
-  | "retry"
-  | "continuation"
-  | "state_advance"
-  | "wait_park";
-
-export type ScheduledWorkInput = {
-  delayMs: number;
-  fire: () => Promise<void>;
-  issueNumber: number;
-  kind: ScheduledWorkKind;
-  projectName: string;
-  runId: string;
-};
-
-type ScheduledItem = {
-  dueAt: number;
-  issueNumber: number;
-  kind: ScheduledWorkKind;
-  projectName: string;
-  runId: string;
-  timeout: ReturnType<typeof setTimeout>;
-};
+export type ActiveRunEntry = InFlightRunEntry;
+export type RegisterInput = RegisterRunInput;
 
 export class ActiveRunRegistry {
-  private readonly entries = new Map<string, ActiveRunEntry>();
-  private readonly issueLocks = new Set<string>();
-  private readonly scheduled = new Set<ScheduledItem>();
+  private readonly inFlightRuns: InFlightRunRegistry;
+  private readonly issueReservations: IssueReservationRegistry;
+  private readonly scheduledWork: ScheduledWorkRegistry;
+
+  constructor() {
+    this.inFlightRuns = new InFlightRunRegistry();
+    this.scheduledWork = new ScheduledWorkRegistry();
+    this.issueReservations = new IssueReservationRegistry({
+      inFlightRuns: this.inFlightRuns,
+      scheduledWork: this.scheduledWork
+    });
+  }
 
   register(input: RegisterInput): void {
-    const entry: ActiveRunEntry = {
-      cancel: input.cancel,
-      cancelRequested: false,
-      issueNumber: input.issueNumber,
-      projectName: input.projectName,
-      respectsIssueLabels: input.respectsIssueLabels ?? true,
-      runId: input.runId
-    };
-    if (input.provider !== undefined) {
-      entry.provider = input.provider;
-    }
-    this.entries.set(input.runId, entry);
-    this.issueLocks.add(issueLockKey(input.projectName, input.issueNumber));
+    this.inFlightRuns.register(input);
   }
 
   unregister(runId: string): ActiveRunEntry | undefined {
-    const entry = this.entries.get(runId);
-    if (entry === undefined) {
-      return undefined;
-    }
-    this.entries.delete(runId);
-    this.issueLocks.delete(issueLockKey(entry.projectName, entry.issueNumber));
-    return entry;
+    return this.inFlightRuns.unregister(runId);
   }
 
   get(runId: string): ActiveRunEntry | undefined {
-    return this.entries.get(runId);
+    return this.inFlightRuns.get(runId);
   }
 
   list(): ActiveRunEntry[] {
-    return Array.from(this.entries.values());
+    return this.inFlightRuns.list();
   }
 
   isIssueInFlight(projectName: string, issueNumber: number): boolean {
-    return this.issueLocks.has(issueLockKey(projectName, issueNumber));
+    return this.inFlightRuns.isIssueInFlight(projectName, issueNumber);
   }
 
-  // Companion to `isIssueInFlight`: returns true when there is scheduled work
-  // (a delayed retry / continuation / state_advance / wait_park) pending for
-  // the issue. Dispatchers that gate on liveness should check both — a
-  // scheduled state_advance is not yet "in flight" but the issue is reserved
-  // for it. Mirrors the liveness precedent in stale-claims `collectLiveKeys`.
   isIssueScheduled(projectName: string, issueNumber: number): boolean {
-    for (const item of this.scheduled) {
-      if (
-        item.projectName === projectName &&
-        item.issueNumber === issueNumber
-      ) {
-        return true;
-      }
-    }
-    return false;
+    return this.scheduledWork.isIssueScheduled(projectName, issueNumber);
+  }
+
+  isIssueReserved(projectName: string, issueNumber: number): boolean {
+    return this.issueReservations.isIssueReserved(projectName, issueNumber);
+  }
+
+  issueKeys(): IssueReservationKey[] {
+    return this.issueReservations.issueKeys();
   }
 
   async requestCancel(runId: string, reason: CancelReason): Promise<void> {
-    const entry = this.entries.get(runId);
-    if (entry === undefined || entry.cancelRequested) {
-      return;
-    }
-    entry.cancelRequested = true;
-    entry.cancelReason = reason;
-    await entry.cancel();
+    await this.inFlightRuns.requestCancel(runId, reason);
   }
 
   scheduleDelayed(input: ScheduledWorkInput): void {
-    const dueAt = Date.now() + input.delayMs;
-    const item: ScheduledItem = {
-      dueAt,
-      issueNumber: input.issueNumber,
-      kind: input.kind,
-      projectName: input.projectName,
-      runId: input.runId,
-      timeout: setTimeout(() => {
-        this.scheduled.delete(item);
-        input.fire().catch(() => {
-          /* caller is responsible for surfacing scheduled-work failures */
-        });
-      }, input.delayMs)
-    };
-    item.timeout.unref?.();
-    this.scheduled.add(item);
+    this.scheduledWork.scheduleDelayed(input);
   }
 
-  peekDelayed(): { runId: string; kind: ScheduledWorkKind; dueAt: number }[] {
-    return Array.from(this.scheduled, (item) => ({
-      dueAt: item.dueAt,
-      kind: item.kind,
-      runId: item.runId
-    }));
+  peekDelayed(): ScheduledWorkSnapshot[] {
+    return this.scheduledWork.peekDelayed();
   }
 
   scheduledIssueKeys(): { issueNumber: number; projectName: string }[] {
-    return Array.from(this.scheduled, (item) => ({
-      issueNumber: item.issueNumber,
-      projectName: item.projectName
-    }));
+    return this.scheduledWork.issueKeys();
   }
 
   cancelAll(): void {
-    for (const item of this.scheduled) {
-      clearTimeout(item.timeout);
-    }
-    this.scheduled.clear();
+    this.scheduledWork.cancelAll();
   }
-}
-
-function issueLockKey(projectName: string, issueNumber: number): string {
-  return `${projectName}#${issueNumber}`;
 }

--- a/src/lifecycle/in-flight-runs.ts
+++ b/src/lifecycle/in-flight-runs.ts
@@ -1,0 +1,98 @@
+import type { AgentProvider } from "../provider.js";
+import type { CancelReason } from "../run-store.js";
+
+export type InFlightRunEntry = {
+  cancel: () => Promise<void>;
+  cancelReason?: CancelReason;
+  cancelRequested: boolean;
+  issueNumber: number;
+  projectName: string;
+  provider?: AgentProvider;
+  // When false, this run is part of an FSM walk where the state machine, not
+  // the issue label set, decides whether to keep running. Reconcile uses this
+  // to skip the labels_all / labels_none re-check while still honoring
+  // CLOSED_ISSUE. See ADR 0046.
+  respectsIssueLabels: boolean;
+  runId: string;
+};
+
+export type RegisterRunInput = {
+  cancel: () => Promise<void>;
+  issueNumber: number;
+  projectName: string;
+  provider?: AgentProvider;
+  respectsIssueLabels?: boolean;
+  runId: string;
+};
+
+export class InFlightRunRegistry {
+  private readonly entries = new Map<string, InFlightRunEntry>();
+  private readonly issueLocks = new Set<string>();
+
+  register(input: RegisterRunInput): void {
+    if (this.entries.has(input.runId)) {
+      throw new Error(`in-flight run already exists for run ${input.runId}`);
+    }
+    const key = issueKey(input.projectName, input.issueNumber);
+    if (this.issueLocks.has(key)) {
+      throw new Error(`in-flight run already exists for issue ${key}`);
+    }
+
+    const entry: InFlightRunEntry = {
+      cancel: input.cancel,
+      cancelRequested: false,
+      issueNumber: input.issueNumber,
+      projectName: input.projectName,
+      respectsIssueLabels: input.respectsIssueLabels ?? true,
+      runId: input.runId
+    };
+    if (input.provider !== undefined) {
+      entry.provider = input.provider;
+    }
+    this.entries.set(input.runId, entry);
+    this.issueLocks.add(key);
+  }
+
+  unregister(runId: string): InFlightRunEntry | undefined {
+    const entry = this.entries.get(runId);
+    if (entry === undefined) {
+      return undefined;
+    }
+    this.entries.delete(runId);
+    this.issueLocks.delete(issueKey(entry.projectName, entry.issueNumber));
+    return entry;
+  }
+
+  get(runId: string): InFlightRunEntry | undefined {
+    return this.entries.get(runId);
+  }
+
+  list(): InFlightRunEntry[] {
+    return Array.from(this.entries.values());
+  }
+
+  isIssueInFlight(projectName: string, issueNumber: number): boolean {
+    return this.issueLocks.has(issueKey(projectName, issueNumber));
+  }
+
+  issueKeys(): { issueNumber: number; projectName: string }[] {
+    return Array.from(this.entries.values(), (entry) => ({
+      issueNumber: entry.issueNumber,
+      projectName: entry.projectName
+    }));
+  }
+
+  async requestCancel(runId: string, reason: CancelReason): Promise<void> {
+    const entry = this.entries.get(runId);
+    if (entry === undefined || entry.cancelRequested) {
+      return;
+    }
+    entry.cancelRequested = true;
+    entry.cancelReason = reason;
+    await entry.cancel();
+  }
+}
+
+function issueKey(projectName: string, issueNumber: number): string {
+  return `${projectName}#${issueNumber}`;
+}

--- a/src/lifecycle/issue-reservations.ts
+++ b/src/lifecycle/issue-reservations.ts
@@ -1,0 +1,42 @@
+import type { InFlightRunRegistry } from "./in-flight-runs.js";
+import type { ScheduledWorkRegistry } from "./scheduled-work.js";
+
+export type IssueReservationKey = {
+  issueNumber: number;
+  projectName: string;
+};
+
+export class IssueReservationRegistry {
+  private readonly inFlightRuns: InFlightRunRegistry;
+  private readonly scheduledWork: ScheduledWorkRegistry;
+
+  constructor(input: {
+    inFlightRuns: InFlightRunRegistry;
+    scheduledWork: ScheduledWorkRegistry;
+  }) {
+    this.inFlightRuns = input.inFlightRuns;
+    this.scheduledWork = input.scheduledWork;
+  }
+
+  isIssueReserved(projectName: string, issueNumber: number): boolean {
+    return (
+      this.inFlightRuns.isIssueInFlight(projectName, issueNumber) ||
+      this.scheduledWork.isIssueScheduled(projectName, issueNumber)
+    );
+  }
+
+  issueKeys(): IssueReservationKey[] {
+    const keys = new Map<string, IssueReservationKey>();
+    for (const entry of this.inFlightRuns.issueKeys()) {
+      keys.set(issueKey(entry.projectName, entry.issueNumber), entry);
+    }
+    for (const entry of this.scheduledWork.issueKeys()) {
+      keys.set(issueKey(entry.projectName, entry.issueNumber), entry);
+    }
+    return Array.from(keys.values());
+  }
+}
+
+function issueKey(projectName: string, issueNumber: number): string {
+  return `${projectName}#${issueNumber}`;
+}

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -1369,22 +1369,10 @@ export class RunController {
       };
     }
 
-    if (this.activeRuns.isIssueInFlight(input.projectName, input.issueNumber)) {
+    if (this.activeRuns.isIssueReserved(input.projectName, input.issueNumber)) {
       return {
         dispatched: false,
-        reason: "issue already has an active run"
-      };
-    }
-
-    // Don't race a scheduled state_advance: a wait→agent transition may have
-    // just enqueued an autofix state for this issue in the same tick. The
-    // scheduled item is not yet in `activeRuns.entries`, so `isIssueInFlight`
-    // misses it. Consult `isIssueScheduled` to avoid dispatching a duplicate
-    // review-followup run on the same issue/branch.
-    if (this.activeRuns.isIssueScheduled(input.projectName, input.issueNumber)) {
-      return {
-        dispatched: false,
-        reason: "issue has scheduled work pending"
+        reason: "issue already has an active or scheduled run"
       };
     }
 
@@ -1496,7 +1484,7 @@ export class RunController {
         .sort(compareCandidateIssues)
         .find(
           (entry) =>
-            !this.activeRuns.isIssueInFlight(entry.project, entry.issue.number)
+            !this.activeRuns.isIssueReserved(entry.project, entry.issue.number)
         );
       if (candidate === undefined) {
         continue;

--- a/src/lifecycle/scheduled-work.ts
+++ b/src/lifecycle/scheduled-work.ts
@@ -1,0 +1,91 @@
+export type ScheduledWorkKind =
+  | "retry"
+  | "continuation"
+  | "state_advance"
+  | "wait_park";
+
+export type ScheduledWorkInput = {
+  delayMs: number;
+  fire: () => Promise<void>;
+  issueNumber: number;
+  kind: ScheduledWorkKind;
+  projectName: string;
+  runId: string;
+};
+
+export type ScheduledWorkSnapshot = {
+  dueAt: number;
+  issueNumber: number;
+  kind: ScheduledWorkKind;
+  projectName: string;
+  runId: string;
+};
+
+type ScheduledItem = ScheduledWorkSnapshot & {
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+export class ScheduledWorkRegistry {
+  private readonly scheduled = new Map<string, ScheduledItem>();
+
+  scheduleDelayed(input: ScheduledWorkInput): void {
+    const key = issueKey(input.projectName, input.issueNumber);
+    if (this.scheduled.has(key)) {
+      throw new Error(`scheduled work already exists for issue ${key}`);
+    }
+
+    const dueAt = Date.now() + input.delayMs;
+    const timeout = setTimeout(() => {
+      const current = this.scheduled.get(key);
+      if (current?.timeout === timeout) {
+        this.scheduled.delete(key);
+      }
+      input.fire().catch(() => {
+        /* caller is responsible for surfacing scheduled-work failures */
+      });
+    }, input.delayMs);
+
+    const item: ScheduledItem = {
+      dueAt,
+      issueNumber: input.issueNumber,
+      kind: input.kind,
+      projectName: input.projectName,
+      runId: input.runId,
+      timeout
+    };
+    timeout.unref?.();
+    this.scheduled.set(key, item);
+  }
+
+  peekDelayed(): ScheduledWorkSnapshot[] {
+    return Array.from(this.scheduled.values(), (item) => ({
+      dueAt: item.dueAt,
+      issueNumber: item.issueNumber,
+      kind: item.kind,
+      projectName: item.projectName,
+      runId: item.runId
+    }));
+  }
+
+  isIssueScheduled(projectName: string, issueNumber: number): boolean {
+    return this.scheduled.has(issueKey(projectName, issueNumber));
+  }
+
+  issueKeys(): { issueNumber: number; projectName: string }[] {
+    return Array.from(this.scheduled.values(), (item) => ({
+      issueNumber: item.issueNumber,
+      projectName: item.projectName
+    }));
+  }
+
+  cancelAll(): void {
+    for (const item of this.scheduled.values()) {
+      clearTimeout(item.timeout);
+    }
+    this.scheduled.clear();
+  }
+}
+
+function issueKey(projectName: string, issueNumber: number): string {
+  return `${projectName}#${issueNumber}`;
+}

--- a/src/lifecycle/stale-claims.ts
+++ b/src/lifecycle/stale-claims.ts
@@ -100,10 +100,7 @@ export async function detectStaleClaims(
 
 function collectLiveKeys(input: DetectStaleClaimsInput): Set<string> {
   const keys = new Set<string>();
-  for (const entry of input.activeRuns.list()) {
-    keys.add(issueKey(entry.projectName, entry.issueNumber));
-  }
-  for (const entry of input.activeRuns.scheduledIssueKeys()) {
+  for (const entry of input.activeRuns.issueKeys()) {
     keys.add(issueKey(entry.projectName, entry.issueNumber));
   }
   for (const entry of input.runStore.listActiveRunIds()) {

--- a/tests/in-flight-runs.test.ts
+++ b/tests/in-flight-runs.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { InFlightRunRegistry } from "../src/lifecycle/in-flight-runs.js";
+
+describe("InFlightRunRegistry", () => {
+  it("rejects a second in-flight run for the same project issue", () => {
+    const registry = new InFlightRunRegistry();
+    registry.register({
+      cancel: () => Promise.resolve(),
+      issueNumber: 7,
+      projectName: "symphonika",
+      runId: "run-a"
+    });
+
+    expect(() =>
+      registry.register({
+        cancel: () => Promise.resolve(),
+        issueNumber: 7,
+        projectName: "symphonika",
+        runId: "run-b"
+      })
+    ).toThrow(/in-flight run already exists/);
+  });
+});

--- a/tests/issue-reservations.test.ts
+++ b/tests/issue-reservations.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { InFlightRunRegistry } from "../src/lifecycle/in-flight-runs.js";
+import { IssueReservationRegistry } from "../src/lifecycle/issue-reservations.js";
+import { ScheduledWorkRegistry } from "../src/lifecycle/scheduled-work.js";
+
+function createRegistries(): {
+  inFlightRuns: InFlightRunRegistry;
+  reservations: IssueReservationRegistry;
+  scheduledWork: ScheduledWorkRegistry;
+} {
+  const inFlightRuns = new InFlightRunRegistry();
+  const scheduledWork = new ScheduledWorkRegistry();
+  const reservations = new IssueReservationRegistry({
+    inFlightRuns,
+    scheduledWork
+  });
+  return { inFlightRuns, reservations, scheduledWork };
+}
+
+describe("IssueReservationRegistry", () => {
+  it("reports reservations for either in-flight runs or scheduled work", () => {
+    vi.useFakeTimers();
+    try {
+      const { inFlightRuns, reservations, scheduledWork } = createRegistries();
+
+      expect(reservations.isIssueReserved("symphonika", 7)).toBe(false);
+
+      inFlightRuns.register({
+        cancel: () => Promise.resolve(),
+        issueNumber: 7,
+        projectName: "symphonika",
+        runId: "run-a"
+      });
+      expect(reservations.isIssueReserved("symphonika", 7)).toBe(true);
+
+      inFlightRuns.unregister("run-a");
+      expect(reservations.isIssueReserved("symphonika", 7)).toBe(false);
+
+      scheduledWork.scheduleDelayed({
+        delayMs: 1_000,
+        fire: () => Promise.resolve(),
+        issueNumber: 7,
+        kind: "retry",
+        projectName: "symphonika",
+        runId: "run-b"
+      });
+      expect(reservations.isIssueReserved("symphonika", 7)).toBe(true);
+
+      scheduledWork.cancelAll();
+      expect(reservations.isIssueReserved("symphonika", 7)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns one issue key when a project issue is both in-flight and scheduled", () => {
+    vi.useFakeTimers();
+    try {
+      const { inFlightRuns, reservations, scheduledWork } = createRegistries();
+      inFlightRuns.register({
+        cancel: () => Promise.resolve(),
+        issueNumber: 7,
+        projectName: "symphonika",
+        runId: "run-a"
+      });
+      scheduledWork.scheduleDelayed({
+        delayMs: 1_000,
+        fire: () => Promise.resolve(),
+        issueNumber: 7,
+        kind: "state_advance",
+        projectName: "symphonika",
+        runId: "run-b"
+      });
+
+      expect(reservations.issueKeys()).toEqual([
+        { issueNumber: 7, projectName: "symphonika" }
+      ]);
+
+      scheduledWork.cancelAll();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/pull-request-followup.test.ts
+++ b/tests/pull-request-followup.test.ts
@@ -329,8 +329,8 @@ describe("pull request follow-up", () => {
 
       // Use a controller whose schedule handler actually goes through
       // ActiveRunRegistry.scheduleDelayed so the scheduled state_advance is
-      // visible to isIssueScheduled. Keep the timeouts long enough that the
-      // fire() never runs during the test.
+      // visible to the issue-reservation facade. Keep the timeouts long enough
+      // that the fire() never runs during the test.
       const activeRuns = new ActiveRunRegistry();
       let nextRun = 0;
       const controller = new RunController({

--- a/tests/scheduled-work.test.ts
+++ b/tests/scheduled-work.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ScheduledWorkRegistry } from "../src/lifecycle/scheduled-work.js";
+
+describe("ScheduledWorkRegistry", () => {
+  it("rejects a second scheduled item for the same project issue", () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new ScheduledWorkRegistry();
+      registry.scheduleDelayed({
+        delayMs: 1_000,
+        fire: () => Promise.resolve(),
+        issueNumber: 7,
+        kind: "retry",
+        projectName: "symphonika",
+        runId: "run-a"
+      });
+
+      expect(() =>
+        registry.scheduleDelayed({
+          delayMs: 1_000,
+          fire: () => Promise.resolve(),
+          issueNumber: 7,
+          kind: "continuation",
+          projectName: "symphonika",
+          runId: "run-b"
+        })
+      ).toThrow(/scheduled work already exists/);
+      expect(registry.peekDelayed()).toHaveLength(1);
+
+      registry.cancelAll();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- split ActiveRunRegistry internals into InFlightRunRegistry and ScheduledWorkRegistry
- add IssueReservationRegistry as the single in-flight-or-scheduled facade
- move dispatch and stale-claim liveness callers to the reservation facade
- enforce one scheduled item per project issue and one in-flight run per project issue

## Validation
- npm run lint && npm run typecheck && npm test && npm run build

Closes #145