### PR TITLE
refactor(workflow): extract contract loading

### DIFF
--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -5,7 +5,14 @@ import { parse } from "yaml";
 import { BUILTIN_WORKFLOW_TEMPLATES } from "./builtin-templates.js";
 import type { WorkflowFormat } from "./config-schemas.js";
 import { isPathInside } from "./path-safety.js";
-import { validatePromptTemplateExpressions } from "./workflow/autonomous-prompt.js";
+import {
+  parseWorkflowContract,
+  projectWorkflowReferences,
+  resolveWorkflowFormat,
+  selectProjectWorkflow,
+  validateWorkflowTemplate
+} from "./workflow/contract-loading.js";
+import type { WorkflowContract } from "./workflow/contract-loading.js";
 import type {
   ExpandedWorkflow,
   ExpandedWorkflowState,
@@ -32,6 +39,13 @@ export type {
   RenderedAutonomousPrompt,
   RunEvidencePaths
 } from "./workflow/autonomous-prompt.js";
+export {
+  loadWorkflowContract,
+  parseWorkflowContract,
+  validateWorkflowContract,
+  validateWorkflowTemplate
+} from "./workflow/contract-loading.js";
+export type { WorkflowContract } from "./workflow/contract-loading.js";
 export type {
   ExpandedWorkflow,
   ExpandedWorkflowState,
@@ -42,13 +56,6 @@ export type {
   WorkflowSourceKind,
   WorkflowTransition
 } from "./workflow/types.js";
-
-export type WorkflowContract = {
-  body: string;
-  contentHash: string;
-  errors: string[];
-  path: string;
-};
 
 type WorkflowTemplateInputType =
   | "boolean"
@@ -103,18 +110,6 @@ export type ProjectWorkflowLoadResult = {
   workflowPath: string | null;
 };
 
-const serviceDiscoveryFrontMatterKeys = new Set([
-  "agent",
-  "issue_filters",
-  "priority",
-  "projects",
-  "provider",
-  "providers",
-  "tracker",
-  "workflow",
-  "workspace"
-]);
-
 const actionKinds = new Set<WorkflowActionKind>([
   "agent",
   "close_issue",
@@ -145,13 +140,6 @@ const completionPredicateKeys = new Set([
 const terminalStates = new Set(["blocked", "failure", "success"]);
 
 const tagPattern = /{{\s*([^{}]+?)\s*}}/g;
-
-export async function loadWorkflowContract(
-  workflowPath: string
-): Promise<WorkflowContract> {
-  const contents = await readFile(workflowPath, "utf8");
-  return parseWorkflowContract(contents, workflowPath);
-}
 
 export async function loadExpandedWorkflow(
   workflowPath: string,
@@ -298,84 +286,6 @@ export function explainWorkflow(workflow: ExpandedWorkflow): string {
   return `${lines.join("\n")}\n`;
 }
 
-export async function validateWorkflowContract(
-  workflowPath: string
-): Promise<string[]> {
-  let contents: string;
-
-  try {
-    contents = await readFile(workflowPath, "utf8");
-  } catch (error) {
-    return [`workflow contract not found at ${workflowPath}: ${errorMessage(error)}`];
-  }
-
-  const workflow = parseWorkflowContract(contents, workflowPath);
-  const errors = [...workflow.errors];
-
-  if (workflow.body.trim().length === 0) {
-    errors.push(`workflow contract at ${workflowPath} must not be empty`);
-  }
-
-  errors.push(...validateWorkflowTemplate(workflow.body, workflowPath));
-  return errors;
-}
-
-export function parseWorkflowContract(
-  contents: string,
-  workflowPath: string
-): WorkflowContract {
-  const lines = contents.split(/\r?\n/);
-
-  if (lines[0]?.trim() !== "---") {
-    return {
-      body: contents,
-      contentHash: contentHash(contents),
-      errors: [],
-      path: workflowPath
-    };
-  }
-
-  const closingLine = lines.findIndex(
-    (line, index) => index > 0 && line.trim() === "---"
-  );
-  if (closingLine === -1) {
-    return {
-      body: "",
-      contentHash: contentHash(contents),
-      errors: [`workflow front matter at ${workflowPath} is missing a closing ---`],
-      path: workflowPath
-    };
-  }
-
-  const frontMatterSource = lines.slice(1, closingLine).join("\n");
-  const errors: string[] = [];
-  const frontMatter = parseFrontMatter(frontMatterSource, workflowPath, errors);
-
-  if (frontMatter !== undefined) {
-    for (const key of Object.keys(frontMatter)) {
-      if (serviceDiscoveryFrontMatterKeys.has(key)) {
-        errors.push(
-          `workflow front matter at ${workflowPath} must not define service config key ${key}`
-        );
-      }
-    }
-  }
-
-  return {
-    body: lines.slice(closingLine + 1).join("\n"),
-    contentHash: contentHash(contents),
-    errors,
-    path: workflowPath
-  };
-}
-
-export function validateWorkflowTemplate(
-  template: string,
-  workflowPath: string
-): string[] {
-  return validatePromptTemplateExpressions(template, workflowPath);
-}
-
 export async function expandWorkflowDefinition(
   contents: string,
   workflowPath: string,
@@ -419,33 +329,6 @@ export async function expandWorkflowDefinition(
   };
 }
 
-type ResolvedWorkflowFormat =
-  | { kind: "markdown" | "raw_fsm" }
-  | { error: string; kind: "error" };
-
-function resolveWorkflowFormat(
-  format: WorkflowFormat,
-  workflowPath: string
-): ResolvedWorkflowFormat {
-  if (format === "markdown") {
-    return { kind: "markdown" };
-  }
-  if (format === "raw_fsm") {
-    return { kind: "raw_fsm" };
-  }
-  const extension = path.extname(workflowPath).toLowerCase();
-  if (extension === ".md") {
-    return { kind: "markdown" };
-  }
-  if (extension === ".yaml" || extension === ".yml" || extension === ".json") {
-    return { kind: "raw_fsm" };
-  }
-  return {
-    error: `workflow at ${workflowPath} has no recognized extension (.md, .yaml, .yml, .json); declare format explicitly`,
-    kind: "error"
-  };
-}
-
 function emptyExpandedWorkflow(
   contents: string,
   workflowPath: string,
@@ -459,122 +342,6 @@ function emptyExpandedWorkflow(
     states: [],
     templateFiles: []
   };
-}
-
-function projectWorkflowReferences(
-  rawProjects: unknown[],
-  configPath: string,
-  errors: string[]
-): Array<{ name: string; workflowFormat: WorkflowFormat; workflowPath: string }> {
-  const projects: Array<{
-    name: string;
-    workflowFormat: WorkflowFormat;
-    workflowPath: string;
-  }> = [];
-  for (const [index, rawProject] of rawProjects.entries()) {
-    if (!isRecord(rawProject)) {
-      errors.push(`projects.${index} in ${configPath} must be a mapping`);
-      continue;
-    }
-    const name = stringProperty(rawProject, "name");
-    if (name === undefined) {
-      errors.push(`projects.${index}.name in ${configPath} must be a non-empty string`);
-      continue;
-    }
-    const reference = parseWorkflowReference(
-      rawProject.workflow,
-      `projects.${name}.workflow`,
-      configPath,
-      errors
-    );
-    if (reference === undefined) {
-      continue;
-    }
-    projects.push({
-      name,
-      workflowFormat: reference.format,
-      workflowPath: reference.path
-    });
-  }
-  return projects;
-}
-
-function parseWorkflowReference(
-  rawWorkflow: unknown,
-  fieldLabel: string,
-  configPath: string,
-  errors: string[]
-): { format: WorkflowFormat; path: string } | undefined {
-  if (typeof rawWorkflow === "string") {
-    const trimmed = rawWorkflow.trim();
-    if (trimmed.length === 0) {
-      errors.push(`${fieldLabel} in ${configPath} must be a non-empty path`);
-      return undefined;
-    }
-    return { format: "auto", path: trimmed };
-  }
-  if (isRecord(rawWorkflow)) {
-    const pathValue = stringProperty(rawWorkflow, "path");
-    if (pathValue === undefined) {
-      errors.push(`${fieldLabel}.path in ${configPath} must be a non-empty path`);
-      return undefined;
-    }
-    const formatRaw = rawWorkflow.format;
-    let format: WorkflowFormat = "auto";
-    if (formatRaw !== undefined) {
-      if (
-        formatRaw === "markdown" ||
-        formatRaw === "raw_fsm" ||
-        formatRaw === "auto"
-      ) {
-        format = formatRaw;
-      } else {
-        errors.push(
-          `${fieldLabel}.format in ${configPath} must be one of markdown, raw_fsm, auto`
-        );
-        return undefined;
-      }
-    }
-    return { format, path: pathValue };
-  }
-  errors.push(`${fieldLabel} in ${configPath} must be a non-empty path or mapping`);
-  return undefined;
-}
-
-function selectProjectWorkflow(
-  projects: Array<{
-    name: string;
-    workflowFormat: WorkflowFormat;
-    workflowPath: string;
-  }>,
-  requestedProject: string | undefined,
-  configPath: string,
-  errors: string[]
-):
-  | { name: string; workflowFormat: WorkflowFormat; workflowPath: string }
-  | undefined {
-  if (requestedProject !== undefined) {
-    const selected = projects.find((project) => project.name === requestedProject);
-    if (selected === undefined) {
-      errors.push(
-        `project ${requestedProject} is not defined in service config ${configPath}`
-      );
-    }
-    return selected;
-  }
-
-  if (projects.length === 1) {
-    return projects[0];
-  }
-
-  if (projects.length === 0) {
-    errors.push(`service config ${configPath} does not contain a project workflow`);
-  } else {
-    errors.push(
-      `service config ${configPath} has ${projects.length} projects; pass --project`
-    );
-  }
-  return undefined;
 }
 
 function parseExplicitWorkflowDefinition(
@@ -1595,26 +1362,6 @@ function uniqueStrings(values: string[]): string[] {
 
 function isPathSafeIdentifier(value: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_.-]*$/.test(value);
-}
-
-function parseFrontMatter(
-  source: string,
-  workflowPath: string,
-  errors: string[]
-): Record<string, unknown> | undefined {
-  try {
-    const parsed: unknown = parse(source) ?? {};
-    if (isRecord(parsed)) {
-      return parsed;
-    }
-    errors.push(`workflow front matter at ${workflowPath} must be a mapping`);
-    return undefined;
-  } catch (error) {
-    errors.push(
-      `workflow front matter at ${workflowPath} could not be parsed: ${errorMessage(error)}`
-    );
-    return undefined;
-  }
 }
 
 function contentHash(contents: string): string {

--- a/src/workflow/contract-loading.ts
+++ b/src/workflow/contract-loading.ts
@@ -1,0 +1,295 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parse } from "yaml";
+
+import type { WorkflowFormat } from "../config-schemas.js";
+import { validatePromptTemplateExpressions } from "./autonomous-prompt.js";
+
+export type WorkflowContract = {
+  body: string;
+  contentHash: string;
+  errors: string[];
+  path: string;
+};
+
+export type ProjectWorkflowReference = {
+  name: string;
+  workflowFormat: WorkflowFormat;
+  workflowPath: string;
+};
+
+export type ResolvedWorkflowFormat =
+  | { kind: "markdown" | "raw_fsm" }
+  | { error: string; kind: "error" };
+
+const serviceDiscoveryFrontMatterKeys = new Set([
+  "agent",
+  "issue_filters",
+  "priority",
+  "projects",
+  "provider",
+  "providers",
+  "tracker",
+  "workflow",
+  "workspace"
+]);
+
+export async function loadWorkflowContract(
+  workflowPath: string
+): Promise<WorkflowContract> {
+  const contents = await readFile(workflowPath, "utf8");
+  return parseWorkflowContract(contents, workflowPath);
+}
+
+export async function validateWorkflowContract(
+  workflowPath: string
+): Promise<string[]> {
+  let contents: string;
+
+  try {
+    contents = await readFile(workflowPath, "utf8");
+  } catch (error) {
+    return [`workflow contract not found at ${workflowPath}: ${errorMessage(error)}`];
+  }
+
+  const workflow = parseWorkflowContract(contents, workflowPath);
+  const errors = [...workflow.errors];
+
+  if (workflow.body.trim().length === 0) {
+    errors.push(`workflow contract at ${workflowPath} must not be empty`);
+  }
+
+  errors.push(...validateWorkflowTemplate(workflow.body, workflowPath));
+  return errors;
+}
+
+export function parseWorkflowContract(
+  contents: string,
+  workflowPath: string
+): WorkflowContract {
+  const lines = contents.split(/\r?\n/);
+
+  if (lines[0]?.trim() !== "---") {
+    return {
+      body: contents,
+      contentHash: contentHash(contents),
+      errors: [],
+      path: workflowPath
+    };
+  }
+
+  const closingLine = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === "---"
+  );
+  if (closingLine === -1) {
+    return {
+      body: "",
+      contentHash: contentHash(contents),
+      errors: [`workflow front matter at ${workflowPath} is missing a closing ---`],
+      path: workflowPath
+    };
+  }
+
+  const frontMatterSource = lines.slice(1, closingLine).join("\n");
+  const errors: string[] = [];
+  const frontMatter = parseFrontMatter(frontMatterSource, workflowPath, errors);
+
+  if (frontMatter !== undefined) {
+    for (const key of Object.keys(frontMatter)) {
+      if (serviceDiscoveryFrontMatterKeys.has(key)) {
+        errors.push(
+          `workflow front matter at ${workflowPath} must not define service config key ${key}`
+        );
+      }
+    }
+  }
+
+  return {
+    body: lines.slice(closingLine + 1).join("\n"),
+    contentHash: contentHash(contents),
+    errors,
+    path: workflowPath
+  };
+}
+
+export function validateWorkflowTemplate(
+  template: string,
+  workflowPath: string
+): string[] {
+  return validatePromptTemplateExpressions(template, workflowPath);
+}
+
+export function resolveWorkflowFormat(
+  format: WorkflowFormat,
+  workflowPath: string
+): ResolvedWorkflowFormat {
+  if (format === "markdown") {
+    return { kind: "markdown" };
+  }
+  if (format === "raw_fsm") {
+    return { kind: "raw_fsm" };
+  }
+  const extension = path.extname(workflowPath).toLowerCase();
+  if (extension === ".md") {
+    return { kind: "markdown" };
+  }
+  if (extension === ".yaml" || extension === ".yml" || extension === ".json") {
+    return { kind: "raw_fsm" };
+  }
+  return {
+    error: `workflow at ${workflowPath} has no recognized extension (.md, .yaml, .yml, .json); declare format explicitly`,
+    kind: "error"
+  };
+}
+
+export function projectWorkflowReferences(
+  rawProjects: unknown[],
+  configPath: string,
+  errors: string[]
+): ProjectWorkflowReference[] {
+  const projects: ProjectWorkflowReference[] = [];
+  for (const [index, rawProject] of rawProjects.entries()) {
+    if (!isRecord(rawProject)) {
+      errors.push(`projects.${index} in ${configPath} must be a mapping`);
+      continue;
+    }
+    const name = stringProperty(rawProject, "name");
+    if (name === undefined) {
+      errors.push(`projects.${index}.name in ${configPath} must be a non-empty string`);
+      continue;
+    }
+    const reference = parseWorkflowReference(
+      rawProject.workflow,
+      `projects.${name}.workflow`,
+      configPath,
+      errors
+    );
+    if (reference === undefined) {
+      continue;
+    }
+    projects.push({
+      name,
+      workflowFormat: reference.format,
+      workflowPath: reference.path
+    });
+  }
+  return projects;
+}
+
+export function parseWorkflowReference(
+  rawWorkflow: unknown,
+  fieldLabel: string,
+  configPath: string,
+  errors: string[]
+): { format: WorkflowFormat; path: string } | undefined {
+  if (typeof rawWorkflow === "string") {
+    const trimmed = rawWorkflow.trim();
+    if (trimmed.length === 0) {
+      errors.push(`${fieldLabel} in ${configPath} must be a non-empty path`);
+      return undefined;
+    }
+    return { format: "auto", path: trimmed };
+  }
+  if (isRecord(rawWorkflow)) {
+    const pathValue = stringProperty(rawWorkflow, "path");
+    if (pathValue === undefined) {
+      errors.push(`${fieldLabel}.path in ${configPath} must be a non-empty path`);
+      return undefined;
+    }
+    const formatRaw = rawWorkflow.format;
+    let format: WorkflowFormat = "auto";
+    if (formatRaw !== undefined) {
+      if (
+        formatRaw === "markdown" ||
+        formatRaw === "raw_fsm" ||
+        formatRaw === "auto"
+      ) {
+        format = formatRaw;
+      } else {
+        errors.push(
+          `${fieldLabel}.format in ${configPath} must be one of markdown, raw_fsm, auto`
+        );
+        return undefined;
+      }
+    }
+    return { format, path: pathValue };
+  }
+  errors.push(`${fieldLabel} in ${configPath} must be a non-empty path or mapping`);
+  return undefined;
+}
+
+export function selectProjectWorkflow(
+  projects: ProjectWorkflowReference[],
+  requestedProject: string | undefined,
+  configPath: string,
+  errors: string[]
+): ProjectWorkflowReference | undefined {
+  if (requestedProject !== undefined) {
+    const selected = projects.find((project) => project.name === requestedProject);
+    if (selected === undefined) {
+      errors.push(
+        `project ${requestedProject} is not defined in service config ${configPath}`
+      );
+    }
+    return selected;
+  }
+
+  if (projects.length === 1) {
+    return projects[0];
+  }
+
+  if (projects.length === 0) {
+    errors.push(`service config ${configPath} does not contain a project workflow`);
+  } else {
+    errors.push(
+      `service config ${configPath} has ${projects.length} projects; pass --project`
+    );
+  }
+  return undefined;
+}
+
+function parseFrontMatter(
+  source: string,
+  workflowPath: string,
+  errors: string[]
+): Record<string, unknown> | undefined {
+  let parsed: unknown;
+  try {
+    parsed = parse(source) ?? {};
+  } catch (error) {
+    errors.push(
+      `workflow front matter at ${workflowPath} could not be parsed: ${errorMessage(error)}`
+    );
+    return undefined;
+  }
+  if (!isRecord(parsed)) {
+    errors.push(`workflow front matter at ${workflowPath} must be a mapping`);
+    return undefined;
+  }
+  return parsed;
+}
+
+function contentHash(contents: string): string {
+  return `sha256:${createHash("sha256").update(contents).digest("hex")}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stringProperty(
+  record: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = record[key];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/workflow-contract-loading.test.ts
+++ b/tests/workflow-contract-loading.test.ts
@@ -1,0 +1,193 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  loadExpandedWorkflow,
+  loadWorkflowContract as loadWorkflowContractFromFacade,
+  parseWorkflowContract as parseWorkflowContractFromFacade,
+  validateWorkflowContract as validateWorkflowContractFromFacade,
+  validateWorkflowTemplate as validateWorkflowTemplateFromFacade
+} from "../src/workflow.js";
+import {
+  loadWorkflowContract,
+  parseWorkflowContract,
+  validateWorkflowContract,
+  validateWorkflowTemplate
+} from "../src/workflow/contract-loading.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-workflow-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { force: true, recursive: true })
+    )
+  );
+});
+
+describe("workflow contract loading", () => {
+  it("keeps contract-loading exports available through the workflow facade", () => {
+    expect(loadWorkflowContractFromFacade).toBe(loadWorkflowContract);
+    expect(parseWorkflowContractFromFacade).toBe(parseWorkflowContract);
+    expect(validateWorkflowContractFromFacade).toBe(validateWorkflowContract);
+    expect(validateWorkflowTemplateFromFacade).toBe(validateWorkflowTemplate);
+  });
+
+  it("loads WORKFLOW.md body without prompt-adjacent front matter", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(
+      workflowPath,
+      [
+        "---",
+        "autonomy:",
+        "  max_turns: 8",
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n")
+    );
+
+    const workflow = await loadWorkflowContract(workflowPath);
+
+    expect(workflow).toMatchObject({
+      body: "Work on {{issue.title}}.\n",
+      errors: [],
+      path: workflowPath
+    });
+    expect(workflow.contentHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+});
+
+describe("workflow format routing", () => {
+  it("auto-routes a .md file to the Markdown loader regardless of body content", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(
+      workflowPath,
+      [
+        "workflow:",
+        "  name: looks_like_yaml",
+        "  initial: planning",
+        "  states:",
+        "    planning:",
+        "      action:",
+        "        kind: agent",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath, "auto");
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow.source.kind).toBe("markdown");
+    expect(result.workflow.states.map((state) => state.id)).toEqual([
+      "run_agent",
+      "done"
+    ]);
+  });
+
+  it("auto-routes .yaml, .yml, and .json paths to the raw FSM loader", async () => {
+    const root = await makeTempRoot();
+    for (const extension of [".yaml", ".yml", ".json"]) {
+      const workflowPath = path.join(root, `workflow${extension}`);
+      const contents =
+        extension === ".json"
+          ? JSON.stringify({
+              workflow: {
+                initial: "done",
+                name: "json_workflow",
+                states: { done: { terminal: "success" } }
+              }
+            })
+          : [
+              "workflow:",
+              "  name: yaml_workflow",
+              "  initial: done",
+              "  states:",
+              "    done:",
+              "      terminal: success",
+              ""
+            ].join("\n");
+      await writeFile(workflowPath, contents);
+
+      const result = await loadExpandedWorkflow(workflowPath, "auto");
+      expect(result.errors).toEqual([]);
+      expect(result.workflow.source.kind).toBe("raw_fsm");
+      expect(result.workflow.states.map((state) => state.id)).toEqual(["done"]);
+    }
+  });
+
+  it("auto rejects an unknown extension and reports the supported set", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.txt");
+    await writeFile(workflowPath, "doesn't matter\n");
+
+    const result = await loadExpandedWorkflow(workflowPath, "auto");
+
+    expect(result.errors).toContain(
+      `workflow at ${workflowPath} has no recognized extension (.md, .yaml, .yml, .json); declare format explicitly`
+    );
+  });
+
+  it("explicit markdown format treats a YAML-shaped .yml file as Markdown content", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.yml");
+    await writeFile(
+      workflowPath,
+      [
+        "---",
+        "name: explicit_markdown",
+        "---",
+        "",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadExpandedWorkflow(workflowPath, "markdown");
+
+    expect(result.errors).toEqual([]);
+    expect(result.workflow.source.kind).toBe("markdown");
+    expect(result.workflow.states.map((state) => state.id)).toEqual([
+      "run_agent",
+      "done"
+    ]);
+  });
+
+  it("explicit raw_fsm format errors when a .md file is not valid raw FSM YAML", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(workflowPath, "# Just a markdown file\n");
+
+    const result = await loadExpandedWorkflow(workflowPath, "raw_fsm");
+
+    expect(result.errors).toContain(
+      `workflow definition at ${workflowPath} must define a top-level workflow mapping`
+    );
+  });
+
+  it("explicit raw_fsm format surfaces YAML parse errors regardless of extension", async () => {
+    const root = await makeTempRoot();
+    const workflowPath = path.join(root, "workflow.json");
+    await writeFile(workflowPath, "{ bogus yaml here: : :");
+
+    const result = await loadExpandedWorkflow(workflowPath, "raw_fsm");
+
+    expect(
+      result.errors.some((message) =>
+        message.startsWith(
+          `workflow definition at ${workflowPath} could not be parsed:`
+        )
+      )
+    ).toBe(true);
+  });
+});

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -8,14 +8,11 @@ import { decideNextStep } from "../src/lifecycle/state-machine-dispatch.js";
 import {
   explainWorkflow,
   loadExpandedWorkflow,
-  loadWorkflowContract,
-  renderAutonomousPrompt,
   validateExpandedWorkflowReferences
 } from "../src/workflow.js";
 import type { ExpandedWorkflow } from "../src/workflow.js";
 
 const tempRoots: string[] = [];
-const DEFAULT_CODEX_COMMAND = `codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server`;
 
 async function makeTempRoot(): Promise<string> {
   const root = await mkdtemp(path.join(tmpdir(), "symphonika-workflow-test-"));
@@ -29,62 +26,6 @@ afterEach(async () => {
       rm(root, { force: true, recursive: true })
     )
   );
-});
-
-describe("workflow contract loading", () => {
-  it("loads WORKFLOW.md body without front matter and carries its content hash into the rendered prompt", async () => {
-    const root = await makeTempRoot();
-    const workflowPath = path.join(root, "WORKFLOW.md");
-    await writeFile(
-      workflowPath,
-      [
-        "---",
-        "autonomy:",
-        "  max_turns: 8",
-        "---",
-        "Work on {{issue.title}}.",
-        ""
-      ].join("\n")
-    );
-
-    const workflow = await loadWorkflowContract(workflowPath);
-    const rendered = renderAutonomousPrompt({
-      branch: {
-        name: "sym/symphonika/7-render-prompts",
-        ref: "refs/heads/sym/symphonika/7-render-prompts"
-      },
-      issue: issueSnapshot(),
-      project: {
-        name: "symphonika"
-      },
-      provider: {
-        command: DEFAULT_CODEX_COMMAND,
-        name: "codex"
-      },
-      run: {
-        attempt: 1,
-        continuation: false,
-        id: "run-7"
-      },
-      template: workflow.body,
-      workflowContentHash: workflow.contentHash,
-      workflowPath: workflow.path,
-      workspace: {
-        path: "/state/workspaces/symphonika/issues/7-render-prompts",
-        previous_attempt: false,
-        root: "/state/workspaces/symphonika"
-      }
-    });
-
-    expect(workflow.errors).toEqual([]);
-    expect(workflow.body).toBe("Work on {{issue.title}}.\n");
-    expect(workflow.contentHash).toMatch(/^sha256:[a-f0-9]{64}$/);
-    expect(rendered.prompt).toContain(
-      "Work on Render autonomous prompts and persist run evidence."
-    );
-    expect(rendered.prompt).not.toContain("max_turns");
-    expect(rendered.workflowContentHash).toBe(workflow.contentHash);
-  });
 });
 
 describe("state machine workflow definitions", () => {
@@ -1782,131 +1723,6 @@ describe("built-in workflow templates", () => {
   });
 });
 
-describe("workflow format routing", () => {
-  it("auto-routes a .md file to the Markdown loader regardless of body content", async () => {
-    const root = await makeTempRoot();
-    const workflowPath = path.join(root, "WORKFLOW.md");
-    await writeFile(
-      workflowPath,
-      [
-        "workflow:",
-        "  name: looks_like_yaml",
-        "  initial: planning",
-        "  states:",
-        "    planning:",
-        "      action:",
-        "        kind: agent",
-        ""
-      ].join("\n")
-    );
-
-    const result = await loadExpandedWorkflow(workflowPath, "auto");
-
-    expect(result.errors).toEqual([]);
-    expect(result.workflow.source.kind).toBe("markdown");
-    expect(result.workflow.states.map((state) => state.id)).toEqual([
-      "run_agent",
-      "done"
-    ]);
-  });
-
-  it("auto-routes .yaml, .yml, and .json paths to the raw FSM loader", async () => {
-    const root = await makeTempRoot();
-    for (const extension of [".yaml", ".yml", ".json"]) {
-      const workflowPath = path.join(root, `workflow${extension}`);
-      const contents =
-        extension === ".json"
-          ? JSON.stringify({
-              workflow: {
-                initial: "done",
-                name: "json_workflow",
-                states: { done: { terminal: "success" } }
-              }
-            })
-          : [
-              "workflow:",
-              "  name: yaml_workflow",
-              "  initial: done",
-              "  states:",
-              "    done:",
-              "      terminal: success",
-              ""
-            ].join("\n");
-      await writeFile(workflowPath, contents);
-
-      const result = await loadExpandedWorkflow(workflowPath, "auto");
-      expect(result.errors).toEqual([]);
-      expect(result.workflow.source.kind).toBe("raw_fsm");
-      expect(result.workflow.states.map((state) => state.id)).toEqual(["done"]);
-    }
-  });
-
-  it("auto rejects an unknown extension and reports the supported set", async () => {
-    const root = await makeTempRoot();
-    const workflowPath = path.join(root, "workflow.txt");
-    await writeFile(workflowPath, "doesn't matter\n");
-
-    const result = await loadExpandedWorkflow(workflowPath, "auto");
-
-    expect(result.errors).toContain(
-      `workflow at ${workflowPath} has no recognized extension (.md, .yaml, .yml, .json); declare format explicitly`
-    );
-  });
-
-  it("explicit markdown format treats a YAML-shaped .yml file as Markdown content", async () => {
-    const root = await makeTempRoot();
-    const workflowPath = path.join(root, "workflow.yml");
-    await writeFile(
-      workflowPath,
-      [
-        "---",
-        "name: explicit_markdown",
-        "---",
-        "",
-        "Work on {{issue.title}}.",
-        ""
-      ].join("\n")
-    );
-
-    const result = await loadExpandedWorkflow(workflowPath, "markdown");
-
-    expect(result.errors).toEqual([]);
-    expect(result.workflow.source.kind).toBe("markdown");
-    expect(result.workflow.states.map((state) => state.id)).toEqual([
-      "run_agent",
-      "done"
-    ]);
-  });
-
-  it("explicit raw_fsm format errors when a .md file is not valid raw FSM YAML", async () => {
-    const root = await makeTempRoot();
-    const workflowPath = path.join(root, "WORKFLOW.md");
-    await writeFile(workflowPath, "# Just a markdown file\n");
-
-    const result = await loadExpandedWorkflow(workflowPath, "raw_fsm");
-
-    expect(result.errors).toContain(
-      `workflow definition at ${workflowPath} must define a top-level workflow mapping`
-    );
-  });
-
-  it("explicit raw_fsm format surfaces YAML parse errors regardless of extension", async () => {
-    const root = await makeTempRoot();
-    const workflowPath = path.join(root, "workflow.json");
-    await writeFile(workflowPath, "{ bogus yaml here: : :");
-
-    const result = await loadExpandedWorkflow(workflowPath, "raw_fsm");
-
-    expect(
-      result.errors.some((message) =>
-        message.startsWith(
-          `workflow definition at ${workflowPath} could not be parsed:`
-        )
-      )
-    ).toBe(true);
-  });
-});
-
 describe("validateExpandedWorkflowReferences", () => {
   it("returns no errors when every raw FSM agent prompt resolves to an existing file", async () => {
     const root = await makeTempRoot();
@@ -2055,18 +1871,3 @@ describe("validateExpandedWorkflowReferences", () => {
     expect(errors).toEqual([]);
   });
 });
-
-function issueSnapshot() {
-  return {
-    body: "Implement prompt evidence.",
-    created_at: "2026-04-28T10:00:00Z",
-    id: 700,
-    labels: ["agent-ready"],
-    number: 7,
-    priority: 99,
-    state: "open",
-    title: "Render autonomous prompts and persist run evidence",
-    updated_at: "2026-04-29T10:00:00Z",
-    url: "https://github.com/pmatos/symphonika/issues/7"
-  };
-}


### PR DESCRIPTION
Summary:
- Move Workflow Contract parsing, validation, front-matter checks, project workflow references, and format selection helpers into src/workflow/contract-loading.ts.
- Keep src/workflow.ts as the compatibility facade for moved public exports.
- Move contract-loading and format-routing coverage into tests/workflow-contract-loading.test.ts.

Tests:
- npm run quality

Closes #158