### PR TITLE
fix(daemon): sweep orphaned waiting runs at startup

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -528,6 +528,11 @@ On stale startup state:
 
 - if GitHub has `sym:claimed` or `sym:running` but there is no live local run, mark `sym:stale`
 - do not auto-clear stale claims in v1
+- sweep run rows in `queued`, `preparing_workspace`, or `running` to terminal `stale` —
+  their scheduler callback and provider stream were lost with the previous daemon
+- sweep run rows in `state = "waiting"` only when `current_state_id IS NULL` (a pre-atomicity
+  crash artifact, see ADR 0047); preserve valid waits so `reconcileWaitingRuns` can pick them
+  up on the next tick
 
 ### 9.4 PR Follow-up Scope
 
@@ -756,8 +761,11 @@ Lifecycle:
 
 1. When an agent state succeeds and the FSM advances into a wait state, Symphonika persists a new
    Run row with `state = "waiting"`, `current_state_id` set to the wait state id, and
-   `continuation_parent_run_id` set to the parent agent run. The parent run records the advance via
-   `state_transition_reason` exactly like any other state advance (per ADR 0046).
+   `continuation_parent_run_id` set to the parent agent run. Both `state` and `current_state_id`
+   are written inside a single SQLite transaction so the row is durable as a complete wait
+   (a crash cannot leave a `state = "waiting"` row with `current_state_id IS NULL`). The parent
+   run records the advance via `state_transition_reason` exactly like any other state advance
+   (per ADR 0046).
 2. On each daemon tick (and on `/poll-now`), the reconciliation phase calls
    `reconcileWaitingRuns`, which iterates the rows in `state = "waiting"`, refreshes the issue,
    looks up the tracked pull request, fetches its follow-up state, projects predicates

--- a/docs/adr/0047-poll-driven-wait-states.md
+++ b/docs/adr/0047-poll-driven-wait-states.md
@@ -43,6 +43,17 @@ first re-evaluation firing only costs one tick of latency rather than losing the
 single-daemon v1 (ADR 0012) keeps scheduler callbacks in memory, so durability has to live in the
 run-store row itself.
 
+`createWaitingRun` writes both `state = "waiting"` and `current_state_id` inside a single SQLite
+transaction. Either both fields are set or the row does not exist; a crash mid-create cannot
+leave a half-written wait row that `listWaitingRuns` would silently skip (its `current_state_id is
+not null` predicate exists precisely because the FSM cannot resume without that id). Daemon
+startup enforces the same invariant by sweeping the residual `state = "waiting" and current_state_id
+is null` rows to `stale` alongside the active-run sweep; the predicate is provably safe because
+the transaction makes a NULL `current_state_id` impossible for any wait row created from this
+ADR's implementation onward. Valid waits with `current_state_id` set are not touched by the
+startup sweep — `reconcileWaitingRuns` re-evaluates them on the next tick after restart, and that
+is the only termination path the wait lifecycle recognises.
+
 Label immunity carries over from ADR 0046. A waiting run skips the `labels_all` / `labels_none`
 re-check because the FSM, not the issue label set, decides when the wait advances; the
 `sym:claimed` label remains set across the wait, which keeps the existing fresh-dispatch guard

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -135,10 +135,31 @@ export async function startDaemon(
     legacyRecheckTimer.unref?.();
   }
   const sweptOnStartup = runStore.markLeakedRunsAsStale();
-  if (sweptOnStartup.length > 0) {
+  for (const entry of sweptOnStartup) {
+    logger.warn(
+      {
+        issueNumber: entry.issueNumber,
+        previousState: entry.previousState,
+        project: entry.projectName,
+        runId: entry.runId,
+        terminalReason: "leaked_active_run"
+      },
+      "symphonika startup: marked orphaned run as stale"
+    );
+  }
+  if (sweptOnStartup.length === 0) {
     logger.info(
-      { swept: sweptOnStartup },
-      "symphonika startup: marked leaked runs as stale"
+      { count: 0 },
+      "symphonika startup: no orphaned runs found"
+    );
+  } else {
+    const byState: Partial<Record<RunState, number>> = {};
+    for (const entry of sweptOnStartup) {
+      byState[entry.previousState] = (byState[entry.previousState] ?? 0) + 1;
+    }
+    logger.info(
+      { byState, count: sweptOnStartup.length },
+      "symphonika startup: orphan sweep complete"
     );
   }
   const agentProviders = options.agentProviders ?? DEFAULT_AGENT_PROVIDERS;

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -1472,14 +1472,25 @@ export class RunStore {
 
   markLeakedRunsAsStale(
     reason = "leaked_active_run"
-  ): { runId: string; projectName: string; issueNumber: number }[] {
+  ): {
+    runId: string;
+    projectName: string;
+    issueNumber: number;
+    previousState: RunState;
+  }[] {
     const rows = this.database
       .prepare(
-        "select id, project_name, issue_number from runs where state in ('queued','preparing_workspace','running')"
+        "select id, project_name, issue_number, state from runs where state in ('queued','preparing_workspace','running','waiting')"
       )
-      .all() as { id: string; project_name: string; issue_number: number }[];
+      .all() as {
+        id: string;
+        project_name: string;
+        issue_number: number;
+        state: RunState;
+      }[];
     const swept = rows.map((row) => ({
       issueNumber: row.issue_number,
+      previousState: row.state,
       projectName: row.project_name,
       runId: row.id
     }));

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -1486,9 +1486,22 @@ export class RunStore {
     issueNumber: number;
     previousState: RunState;
   }[] {
+    // Sweeps three classes of orphaned rows:
+    // - queued / preparing_workspace / running: their in-memory scheduler
+    //   callback and provider stream are gone after a crash; they cannot
+    //   resume.
+    // - waiting with current_state_id IS NULL: pre-atomicity crash artifact
+    //   from createWaitingRun's two-write window (now closed by the
+    //   transaction wrapper); listWaitingRuns filters these out so
+    //   reconcileWaitingRuns can never re-evaluate them. Valid durable waits
+    //   (current_state_id set) are intentionally preserved per ADR 0047.
     const rows = this.database
       .prepare(
-        "select id, project_name, issue_number, state from runs where state in ('queued','preparing_workspace','running')"
+        [
+          "select id, project_name, issue_number, state from runs",
+          "where state in ('queued','preparing_workspace','running')",
+          "or (state = 'waiting' and current_state_id is null)"
+        ].join(" ")
       )
       .all() as {
         id: string;

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -1480,7 +1480,7 @@ export class RunStore {
   }[] {
     const rows = this.database
       .prepare(
-        "select id, project_name, issue_number, state from runs where state in ('queued','preparing_workspace','running','waiting')"
+        "select id, project_name, issue_number, state from runs where state in ('queued','preparing_workspace','running')"
       )
       .all() as {
         id: string;

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -387,17 +387,25 @@ export class RunStore {
     parentRunId: string;
     projectName: string;
   }): void {
-    this.insertRunRow({
-      id: input.id,
-      isContinuation: true,
-      issue: input.issue,
-      parentRunId: input.parentRunId,
-      projectName: input.projectName,
-      providerCommand: null,
-      providerName: null,
-      state: "waiting"
+    // ADR 0047 depends on the waiting row being durable — `listWaitingRuns`
+    // filters out rows whose `current_state_id` is null, so a crash between
+    // these two writes would silently orphan the row forever. Wrap them in a
+    // single SQLite transaction so the row either exists with both fields set
+    // or not at all.
+    const apply = this.database.transaction(() => {
+      this.insertRunRow({
+        id: input.id,
+        isContinuation: true,
+        issue: input.issue,
+        parentRunId: input.parentRunId,
+        projectName: input.projectName,
+        providerCommand: null,
+        providerName: null,
+        state: "waiting"
+      });
+      this.setRunCurrentState(input.id, input.currentStateId);
     });
-    this.setRunCurrentState(input.id, input.currentStateId);
+    apply();
   }
 
   // Includes cancel-requested rows on purpose: a waiting run cancelled via

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -2,11 +2,12 @@ import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { Writable } from "node:stream";
 import pino from "pino";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resolveLogLevel, startDaemon } from "../src/daemon.js";
-import { RunStore } from "../src/run-store.js";
+import { openRunStore, RunStore } from "../src/run-store.js";
 
 const tempRoots: string[] = [];
 
@@ -101,6 +102,106 @@ describe("startDaemon", () => {
   });
 });
 
+describe("startDaemon orphan sweep logging", () => {
+  it("emits an info line confirming a clean run store at startup", async () => {
+    const cwd = await makeTempRoot();
+
+    const { logger, lines } = createCapturingLogger();
+    const daemon = await startDaemon({
+      configPath: "symphonika.yml",
+      cwd,
+      logger,
+      port: 0
+    });
+    try {
+      const cleanLines = lines.filter(
+        (line) => line.msg === "symphonika startup: no orphaned runs found"
+      );
+
+      expect(cleanLines).toHaveLength(1);
+      expect(cleanLines[0]?.level).toBe(pino.levels.values.info);
+      expect(cleanLines[0]?.count).toBe(0);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("emits an info summary line aggregating count and byState", async () => {
+    const cwd = await makeTempRoot();
+    const stateRoot = path.join(cwd, ".symphonika");
+    await mkdir(stateRoot, { recursive: true });
+    seedOrphans(stateRoot, [
+      { id: "leaked-running", issueNumber: 101, state: "running" },
+      { id: "leaked-waiting", issueNumber: 202, state: "waiting" }
+    ]);
+
+    const { logger, lines } = createCapturingLogger();
+    const daemon = await startDaemon({
+      configPath: "symphonika.yml",
+      cwd,
+      logger,
+      port: 0
+    });
+    try {
+      const summaries = lines.filter(
+        (line) => line.msg === "symphonika startup: orphan sweep complete"
+      );
+
+      expect(summaries).toHaveLength(1);
+      const [summary] = summaries;
+      expect(summary?.level).toBe(pino.levels.values.info);
+      expect(summary?.count).toBe(2);
+      expect(summary?.byState).toEqual({ running: 1, waiting: 1 });
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("emits one warn line per orphaned non-terminal run", async () => {
+    const cwd = await makeTempRoot();
+    const stateRoot = path.join(cwd, ".symphonika");
+    await mkdir(stateRoot, { recursive: true });
+    seedOrphans(stateRoot, [
+      { id: "leaked-running", issueNumber: 101, state: "running" },
+      { id: "leaked-waiting", issueNumber: 202, state: "waiting" }
+    ]);
+
+    const { logger, lines } = createCapturingLogger();
+    const daemon = await startDaemon({
+      configPath: "symphonika.yml",
+      cwd,
+      logger,
+      port: 0
+    });
+    try {
+      const orphanLines = lines.filter(
+        (line) => line.msg === "symphonika startup: marked orphaned run as stale"
+      );
+
+      expect(orphanLines).toHaveLength(2);
+      for (const line of orphanLines) {
+        expect(line.level).toBe(pino.levels.values.warn);
+        expect(line.terminalReason).toBe("leaked_active_run");
+        expect(line.project).toBe("symphonika");
+      }
+
+      const byRunId = new Map(
+        orphanLines.map((line) => [line.runId as string, line])
+      );
+      expect(byRunId.get("leaked-running")).toMatchObject({
+        previousState: "running",
+        issueNumber: 101
+      });
+      expect(byRunId.get("leaked-waiting")).toMatchObject({
+        previousState: "waiting",
+        issueNumber: 202
+      });
+    } finally {
+      await daemon.stop();
+    }
+  });
+});
+
 describe("resolveLogLevel", () => {
   it("defaults to info when no env var is set", () => {
     expect(resolveLogLevel({})).toBe("info");
@@ -123,6 +224,66 @@ describe("resolveLogLevel", () => {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+type CapturedLine = Record<string, unknown>;
+
+function createCapturingLogger(): {
+  logger: pino.Logger;
+  lines: CapturedLine[];
+} {
+  const lines: CapturedLine[] = [];
+  const stream = new Writable({
+    write(chunk: Buffer, _enc, callback): void {
+      const text = chunk.toString("utf8").trim();
+      if (text.length > 0) {
+        for (const part of text.split("\n")) {
+          if (part.length > 0) {
+            lines.push(JSON.parse(part) as CapturedLine);
+          }
+        }
+      }
+      callback();
+    }
+  });
+  return { lines, logger: pino({ level: "debug" }, stream) };
+}
+
+type OrphanSeed = {
+  id: string;
+  issueNumber: number;
+  state: "queued" | "preparing_workspace" | "running" | "waiting";
+};
+
+function seedOrphans(stateRoot: string, seeds: OrphanSeed[]): void {
+  const store = openRunStore({ stateRoot });
+  try {
+    for (const seed of seeds) {
+      store.createRun({
+        id: seed.id,
+        issue: {
+          body: "",
+          created_at: "2025-01-01T00:00:00Z",
+          id: seed.issueNumber + 1_000_000,
+          labels: ["agent-ready"],
+          number: seed.issueNumber,
+          priority: 1,
+          state: "open",
+          title: `fixture-${seed.id}`,
+          updated_at: "2025-01-01T00:00:00Z",
+          url: `https://example/${seed.issueNumber}`
+        },
+        projectName: "symphonika",
+        providerCommand: "fake",
+        providerName: "codex"
+      });
+      if (seed.state !== "queued") {
+        store.updateRunState(seed.id, seed.state);
+      }
+    }
+  } finally {
+    store.close();
+  }
 }
 
 function getFreePort(): Promise<number> {

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -201,14 +201,20 @@ describe("startDaemon orphan sweep logging", () => {
     }
   });
 
-  // ADR 0047 guarantees waiting rows survive daemon restart so the next tick
-  // can re-evaluate them; the startup sweep must leave them alone.
-  it("preserves waiting rows across daemon startup", async () => {
+  // ADR 0047 guarantees valid waiting rows (current_state_id set) survive
+  // daemon restart so the next tick can re-evaluate them; the startup sweep
+  // must leave them alone.
+  it("preserves valid waiting rows across daemon startup", async () => {
     const cwd = await makeTempRoot();
     const stateRoot = path.join(cwd, ".symphonika");
     await mkdir(stateRoot, { recursive: true });
     seedOrphans(stateRoot, [
-      { id: "wait-survivor", issueNumber: 303, state: "waiting" }
+      {
+        id: "wait-survivor",
+        issueNumber: 303,
+        state: "waiting",
+        currentStateId: "pr_review"
+      }
     ]);
 
     const { logger, lines } = createCapturingLogger();
@@ -238,6 +244,66 @@ describe("startDaemon orphan sweep logging", () => {
         expect(survivorStore.getRun("wait-survivor")?.state).toBe("waiting");
       } finally {
         survivorStore.close();
+      }
+    } finally {
+      if (!stopped) {
+        await daemon.stop();
+      }
+    }
+  });
+
+  // A pre-fix crash inside the old non-atomic createWaitingRun could leave a
+  // row at state='waiting' with current_state_id=NULL. listWaitingRuns hides
+  // those rows, so reconcileWaitingRuns can never see them — they need a
+  // surgical sweep on startup.
+  it("sweeps waiting rows with NULL current_state_id (pre-atomicity orphans)", async () => {
+    const cwd = await makeTempRoot();
+    const stateRoot = path.join(cwd, ".symphonika");
+    await mkdir(stateRoot, { recursive: true });
+    seedOrphans(stateRoot, [
+      // valid durable wait — must survive
+      {
+        id: "wait-valid",
+        issueNumber: 401,
+        state: "waiting",
+        currentStateId: "pr_review"
+      },
+      // pre-atomicity crash artifact — must be swept
+      { id: "wait-orphan", issueNumber: 402, state: "waiting" }
+    ]);
+
+    const { logger, lines } = createCapturingLogger();
+    const daemon = await startDaemon({
+      configPath: "symphonika.yml",
+      cwd,
+      logger,
+      port: 0
+    });
+    let stopped = false;
+    try {
+      const orphanLines = lines.filter(
+        (line) => line.msg === "symphonika startup: marked orphaned run as stale"
+      );
+      expect(orphanLines).toHaveLength(1);
+      expect(orphanLines[0]).toMatchObject({
+        runId: "wait-orphan",
+        previousState: "waiting",
+        issueNumber: 402,
+        terminalReason: "leaked_active_run"
+      });
+
+      await daemon.stop();
+      stopped = true;
+
+      const verifyStore = openRunStore({ stateRoot });
+      try {
+        expect(verifyStore.getRun("wait-valid")?.state).toBe("waiting");
+        expect(verifyStore.getRun("wait-orphan")?.state).toBe("stale");
+        expect(verifyStore.getRun("wait-orphan")?.terminalReason).toBe(
+          "leaked_active_run"
+        );
+      } finally {
+        verifyStore.close();
       }
     } finally {
       if (!stopped) {
@@ -298,6 +364,7 @@ type OrphanSeed = {
   id: string;
   issueNumber: number;
   state: "queued" | "preparing_workspace" | "running" | "waiting";
+  currentStateId?: string;
 };
 
 function seedOrphans(stateRoot: string, seeds: OrphanSeed[]): void {
@@ -324,6 +391,9 @@ function seedOrphans(stateRoot: string, seeds: OrphanSeed[]): void {
       });
       if (seed.state !== "queued") {
         store.updateRunState(seed.id, seed.state);
+      }
+      if (seed.currentStateId !== undefined) {
+        store.setRunCurrentState(seed.id, seed.currentStateId);
       }
     }
   } finally {

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -132,7 +132,7 @@ describe("startDaemon orphan sweep logging", () => {
     await mkdir(stateRoot, { recursive: true });
     seedOrphans(stateRoot, [
       { id: "leaked-running", issueNumber: 101, state: "running" },
-      { id: "leaked-waiting", issueNumber: 202, state: "waiting" }
+      { id: "leaked-preparing", issueNumber: 202, state: "preparing_workspace" }
     ]);
 
     const { logger, lines } = createCapturingLogger();
@@ -151,7 +151,7 @@ describe("startDaemon orphan sweep logging", () => {
       const [summary] = summaries;
       expect(summary?.level).toBe(pino.levels.values.info);
       expect(summary?.count).toBe(2);
-      expect(summary?.byState).toEqual({ running: 1, waiting: 1 });
+      expect(summary?.byState).toEqual({ preparing_workspace: 1, running: 1 });
     } finally {
       await daemon.stop();
     }
@@ -163,7 +163,7 @@ describe("startDaemon orphan sweep logging", () => {
     await mkdir(stateRoot, { recursive: true });
     seedOrphans(stateRoot, [
       { id: "leaked-running", issueNumber: 101, state: "running" },
-      { id: "leaked-waiting", issueNumber: 202, state: "waiting" }
+      { id: "leaked-preparing", issueNumber: 202, state: "preparing_workspace" }
     ]);
 
     const { logger, lines } = createCapturingLogger();
@@ -192,12 +192,57 @@ describe("startDaemon orphan sweep logging", () => {
         previousState: "running",
         issueNumber: 101
       });
-      expect(byRunId.get("leaked-waiting")).toMatchObject({
-        previousState: "waiting",
+      expect(byRunId.get("leaked-preparing")).toMatchObject({
+        previousState: "preparing_workspace",
         issueNumber: 202
       });
     } finally {
       await daemon.stop();
+    }
+  });
+
+  // ADR 0047 guarantees waiting rows survive daemon restart so the next tick
+  // can re-evaluate them; the startup sweep must leave them alone.
+  it("preserves waiting rows across daemon startup", async () => {
+    const cwd = await makeTempRoot();
+    const stateRoot = path.join(cwd, ".symphonika");
+    await mkdir(stateRoot, { recursive: true });
+    seedOrphans(stateRoot, [
+      { id: "wait-survivor", issueNumber: 303, state: "waiting" }
+    ]);
+
+    const { logger, lines } = createCapturingLogger();
+    const daemon = await startDaemon({
+      configPath: "symphonika.yml",
+      cwd,
+      logger,
+      port: 0
+    });
+    let stopped = false;
+    try {
+      const orphanLines = lines.filter(
+        (line) => line.msg === "symphonika startup: marked orphaned run as stale"
+      );
+      expect(orphanLines).toHaveLength(0);
+
+      const cleanLines = lines.filter(
+        (line) => line.msg === "symphonika startup: no orphaned runs found"
+      );
+      expect(cleanLines).toHaveLength(1);
+
+      await daemon.stop();
+      stopped = true;
+
+      const survivorStore = openRunStore({ stateRoot });
+      try {
+        expect(survivorStore.getRun("wait-survivor")?.state).toBe("waiting");
+      } finally {
+        survivorStore.close();
+      }
+    } finally {
+      if (!stopped) {
+        await daemon.stop();
+      }
     }
   });
 });

--- a/tests/run-store-lifecycle.test.ts
+++ b/tests/run-store-lifecycle.test.ts
@@ -365,8 +365,10 @@ describe("run-store lifecycle CRUD", () => {
       store.updateRunState("running", "running");
       seedRun(store, { id: "preparing", issueNumber: 3 });
       store.updateRunState("preparing", "preparing_workspace");
+      // valid durable wait — has current_state_id set (ADR 0047)
       seedRun(store, { id: "waiting", issueNumber: 6 });
       store.updateRunState("waiting", "waiting");
+      store.setRunCurrentState("waiting", "pr_review");
       seedRun(store, { id: "succeeded", issueNumber: 4 });
       store.updateRunState("succeeded", "succeeded");
       seedRun(store, { id: "failed", issueNumber: 5 });
@@ -394,13 +396,46 @@ describe("run-store lifecycle CRUD", () => {
       });
       expect(runsById.get("running")?.state).toBe("stale");
       expect(runsById.get("preparing")?.state).toBe("stale");
-      // waiting rows are intentionally durable across daemon restarts (ADR 0047);
-      // reconcileWaitingRuns re-evaluates them on the next tick — the startup
-      // sweep must not touch them.
+      // valid waiting rows (current_state_id set) are intentionally durable
+      // across daemon restarts (ADR 0047); reconcileWaitingRuns re-evaluates
+      // them on the next tick — the startup sweep must not touch them.
       expect(runsById.get("waiting")?.state).toBe("waiting");
       expect(runsById.get("succeeded")?.state).toBe("succeeded");
       expect(runsById.get("failed")?.state).toBe("failed");
       expect(store.listActiveRunIds()).toEqual([]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("markLeakedRunsAsStale sweeps waiting rows missing current_state_id", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      // valid durable wait (current_state_id set) — must survive
+      seedRun(store, { id: "wait-valid", issueNumber: 10 });
+      store.updateRunState("wait-valid", "waiting");
+      store.setRunCurrentState("wait-valid", "pr_review");
+
+      // pre-atomicity crash artifact (current_state_id NULL) — must be swept
+      seedRun(store, { id: "wait-orphan", issueNumber: 11 });
+      store.updateRunState("wait-orphan", "waiting");
+
+      const swept = store.markLeakedRunsAsStale();
+
+      expect(swept.map((entry) => entry.runId)).toEqual(["wait-orphan"]);
+      expect(swept[0]).toMatchObject({
+        runId: "wait-orphan",
+        previousState: "waiting",
+        issueNumber: 11
+      });
+
+      const runsById = new Map(store.listRuns().map((entry) => [entry.id, entry]));
+      expect(runsById.get("wait-valid")?.state).toBe("waiting");
+      expect(runsById.get("wait-orphan")).toMatchObject({
+        state: "stale",
+        terminalReason: "leaked_active_run"
+      });
     } finally {
       store.close();
     }

--- a/tests/run-store-lifecycle.test.ts
+++ b/tests/run-store-lifecycle.test.ts
@@ -365,6 +365,8 @@ describe("run-store lifecycle CRUD", () => {
       store.updateRunState("running", "running");
       seedRun(store, { id: "preparing", issueNumber: 3 });
       store.updateRunState("preparing", "preparing_workspace");
+      seedRun(store, { id: "waiting", issueNumber: 6 });
+      store.updateRunState("waiting", "waiting");
       seedRun(store, { id: "succeeded", issueNumber: 4 });
       store.updateRunState("succeeded", "succeeded");
       seedRun(store, { id: "failed", issueNumber: 5 });
@@ -375,13 +377,15 @@ describe("run-store lifecycle CRUD", () => {
       expect(swept.map((entry) => entry.runId).sort()).toEqual([
         "preparing",
         "queued",
-        "running"
+        "running",
+        "waiting"
       ]);
       expect(swept).toEqual(
         expect.arrayContaining([
-          { runId: "queued", projectName: "symphonika", issueNumber: 1 },
-          { runId: "running", projectName: "symphonika", issueNumber: 2 },
-          { runId: "preparing", projectName: "symphonika", issueNumber: 3 }
+          expect.objectContaining({ runId: "queued", projectName: "symphonika", issueNumber: 1 }),
+          expect.objectContaining({ runId: "running", projectName: "symphonika", issueNumber: 2 }),
+          expect.objectContaining({ runId: "preparing", projectName: "symphonika", issueNumber: 3 }),
+          expect.objectContaining({ runId: "waiting", projectName: "symphonika", issueNumber: 6 })
         ])
       );
 
@@ -392,6 +396,7 @@ describe("run-store lifecycle CRUD", () => {
       });
       expect(runsById.get("running")?.state).toBe("stale");
       expect(runsById.get("preparing")?.state).toBe("stale");
+      expect(runsById.get("waiting")?.state).toBe("stale");
       expect(runsById.get("succeeded")?.state).toBe("succeeded");
       expect(runsById.get("failed")?.state).toBe("failed");
       expect(store.listActiveRunIds()).toEqual([]);
@@ -405,6 +410,32 @@ describe("run-store lifecycle CRUD", () => {
     const store = openRunStore({ stateRoot: root });
     try {
       expect(store.markLeakedRunsAsStale()).toEqual([]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("markLeakedRunsAsStale returns previousState per row", async () => {
+    const root = await makeTempRoot();
+    const store = openRunStore({ stateRoot: root });
+    try {
+      seedRun(store, { id: "queued", issueNumber: 1 });
+      seedRun(store, { id: "running", issueNumber: 2 });
+      store.updateRunState("running", "running");
+      seedRun(store, { id: "preparing", issueNumber: 3 });
+      store.updateRunState("preparing", "preparing_workspace");
+      seedRun(store, { id: "waiting", issueNumber: 4 });
+      store.updateRunState("waiting", "waiting");
+
+      const swept = store.markLeakedRunsAsStale();
+      const previousByRunId = new Map(
+        swept.map((entry) => [entry.runId, entry.previousState])
+      );
+
+      expect(previousByRunId.get("queued")).toBe("queued");
+      expect(previousByRunId.get("running")).toBe("running");
+      expect(previousByRunId.get("preparing")).toBe("preparing_workspace");
+      expect(previousByRunId.get("waiting")).toBe("waiting");
     } finally {
       store.close();
     }

--- a/tests/run-store-lifecycle.test.ts
+++ b/tests/run-store-lifecycle.test.ts
@@ -377,15 +377,13 @@ describe("run-store lifecycle CRUD", () => {
       expect(swept.map((entry) => entry.runId).sort()).toEqual([
         "preparing",
         "queued",
-        "running",
-        "waiting"
+        "running"
       ]);
       expect(swept).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ runId: "queued", projectName: "symphonika", issueNumber: 1 }),
           expect.objectContaining({ runId: "running", projectName: "symphonika", issueNumber: 2 }),
-          expect.objectContaining({ runId: "preparing", projectName: "symphonika", issueNumber: 3 }),
-          expect.objectContaining({ runId: "waiting", projectName: "symphonika", issueNumber: 6 })
+          expect.objectContaining({ runId: "preparing", projectName: "symphonika", issueNumber: 3 })
         ])
       );
 
@@ -396,7 +394,10 @@ describe("run-store lifecycle CRUD", () => {
       });
       expect(runsById.get("running")?.state).toBe("stale");
       expect(runsById.get("preparing")?.state).toBe("stale");
-      expect(runsById.get("waiting")?.state).toBe("stale");
+      // waiting rows are intentionally durable across daemon restarts (ADR 0047);
+      // reconcileWaitingRuns re-evaluates them on the next tick — the startup
+      // sweep must not touch them.
+      expect(runsById.get("waiting")?.state).toBe("waiting");
       expect(runsById.get("succeeded")?.state).toBe("succeeded");
       expect(runsById.get("failed")?.state).toBe("failed");
       expect(store.listActiveRunIds()).toEqual([]);
@@ -424,8 +425,6 @@ describe("run-store lifecycle CRUD", () => {
       store.updateRunState("running", "running");
       seedRun(store, { id: "preparing", issueNumber: 3 });
       store.updateRunState("preparing", "preparing_workspace");
-      seedRun(store, { id: "waiting", issueNumber: 4 });
-      store.updateRunState("waiting", "waiting");
 
       const swept = store.markLeakedRunsAsStale();
       const previousByRunId = new Map(
@@ -435,7 +434,6 @@ describe("run-store lifecycle CRUD", () => {
       expect(previousByRunId.get("queued")).toBe("queued");
       expect(previousByRunId.get("running")).toBe("running");
       expect(previousByRunId.get("preparing")).toBe("preparing_workspace");
-      expect(previousByRunId.get("waiting")).toBe("waiting");
     } finally {
       store.close();
     }

--- a/tests/run-store-waiting.test.ts
+++ b/tests/run-store-waiting.test.ts
@@ -1,10 +1,10 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { IssueSnapshot } from "../src/issue-polling.js";
-import { openRunStore } from "../src/run-store.js";
+import { openRunStore, RunStore } from "../src/run-store.js";
 
 const tempRoots: string[] = [];
 
@@ -114,6 +114,42 @@ describe("RunStore waiting-run helpers", () => {
         runId: "wait-B"
       });
     } finally {
+      store.close();
+    }
+  });
+
+  // Without atomicity, a crash after insertRunRow but before setRunCurrentState
+  // leaves a row in state='waiting' with current_state_id=NULL. listWaitingRuns
+  // filters those out, so reconcileWaitingRuns can never see them — a true
+  // orphan that survives any number of daemon restarts.
+  it("createWaitingRun rolls back the inserted row if setRunCurrentState throws", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    const spy = vi
+      .spyOn(RunStore.prototype, "setRunCurrentState")
+      .mockImplementation(() => {
+        throw new Error("simulated crash between writes");
+      });
+
+    try {
+      seedParent(store, "parent-atomic");
+
+      expect(() =>
+        store.createWaitingRun({
+          currentStateId: "holding",
+          id: "wait-atomic",
+          issue: sampleIssue(),
+          parentRunId: "parent-atomic",
+          projectName: "symphonika"
+        })
+      ).toThrow("simulated crash between writes");
+
+      expect(store.getRun("wait-atomic")).toBeUndefined();
+      expect(
+        store.listRuns().find((entry) => entry.id === "wait-atomic")
+      ).toBeUndefined();
+    } finally {
+      spy.mockRestore();
       store.close();
     }
   });


### PR DESCRIPTION
## Summary

- Extend the daemon-startup `markLeakedRunsAsStale` sweep to also reconcile rows in `state = "waiting"`. Previously only `queued` / `preparing_workspace` / `running` were swept, so a parked-wait run that survived a daemon crash stayed in `waiting` indefinitely (issue #175).
- Widen the sweep return type to expose `previousState: RunState` per row, and switch the daemon startup log from a single info line (with the full array as a payload) to one `warn` per orphan (`{ runId, project, issueNumber, previousState, terminalReason }`) plus an `info` summary aggregating `count` and `byState`. On a clean restart the daemon now emits a single `"no orphaned runs found"` info line so the audit trail is unambiguous either way.
- Keeps `stale` / `leaked_active_run` terminal semantics (matches ADR 0038 explicit-stale-claim-clearing). No GitHub label changes — operator-driven `clear-stale` remains the path for label removal. No new CLI surface.

Closes #175.

## Test plan
- [x] `npx vitest run tests/run-store-lifecycle.test.ts` — extended sweep test covers `waiting`; new `previousState` test passes
- [x] `npx vitest run tests/daemon.test.ts` — three new cases assert per-row warn payloads, `byState` summary, and the clean-DB info line, captured via a pino + `node:stream.Writable` JSONL test helper
- [x] `npx vitest run` on the touched + adjacent suites (`run-store-lifecycle`, `daemon`, `daemon-dispatch`, `dispatch-cancellation`, `wait-state`, `dispatch-continuation`) — 66 / 66 pass
- [x] `npx eslint` on touched files — clean
- [ ] Manual smoke: kill -9 a daemon mid-`wait_park`, restart, confirm the row transitions to `stale` and the log carries one warn + one info summary