### PR TITLE
fix: mark daemon-orphaned runs stale on startup

### DIFF
--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -1515,10 +1515,23 @@ export class RunStore {
       projectName: row.project_name,
       runId: row.id
     }));
-    for (const entry of swept) {
-      this.recordTerminalReason(entry.runId, reason);
-      this.updateRunState(entry.runId, "stale");
-    }
+    const update = this.database.prepare(
+      [
+        "update runs set",
+        "state = 'stale',",
+        "terminal_reason = ?,",
+        "updated_at = ?",
+        "where id = ?"
+      ].join(" ")
+    );
+    const apply = this.database.transaction(() => {
+      for (const entry of swept) {
+        const updatedAt = timestamp();
+        update.run(reason, updatedAt, entry.runId);
+        this.recordRunTransition(entry.runId, "stale", updatedAt);
+      }
+    });
+    apply();
     return swept;
   }
 


### PR DESCRIPTION
## Summary
- mark provider-owned `queued`, `preparing_workspace`, and `running` rows from a previous daemon as `stale` with `terminal_reason = "daemon_orphaned"`
- cover startup reconciliation through the daemon runs API
- document stale-vs-failed/cancelled semantics and why `waiting` rows remain durable

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test -- tests/daemon.test.ts`
- `npm test -- tests/run-store-lifecycle.test.ts`
- `npm test -- --no-file-parallelism`
- `npm run build`

Note: exact parallel `npm test` was run twice and hit existing suite-load races/timeouts in unrelated dispatch/CLI tests; the failing files passed in isolation and the full serialized suite passed.

Closes #175