### PR TITLE
fix(cli): re-run doctor each tick in status --watch

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -421,14 +421,12 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
       }) => {
         const printOnce = async (
           dashboard: boolean,
-          cachedReport?: DoctorReport,
           redrawState?: { previousLineCount: number }
         ): Promise<void> => {
           const stateRoot = resolveStateRoot(withConfigPath(options.config)).stateRoot;
           const store = openRunStore({ stateRoot });
           try {
-            const report =
-              cachedReport ?? (await doctor(withConfigPath(options.config)));
+            const report = await doctor(withConfigPath(options.config));
             const daemonUrl = resolveDaemonUrl(stateRoot, options.daemonUrl);
             const daemonStatus =
               daemonUrl === undefined
@@ -539,10 +537,9 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         };
 
         if (options.watch === true) {
-          const report = await doctor(withConfigPath(options.config));
           const redrawState = { previousLineCount: 0 };
           for (;;) {
-            await printOnce(true, report, redrawState);
+            await printOnce(true, redrawState);
             await sleep(options.intervalMs);
           }
         }

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -395,7 +395,7 @@ describe("CLI run commands", () => {
     expect(output.stdout).not.toContain("approval prompt");
   });
 
-  it("status --watch reuses project validation across refresh ticks", async () => {
+  it("status --watch re-runs doctor on each refresh tick", async () => {
     const stateRoot = await makeTempRoot();
     const resolvedStateRoot = path.join(stateRoot, ".symphonika");
     let doctorCalls = 0;
@@ -458,7 +458,7 @@ describe("CLI run commands", () => {
 
     expect(statusRequests).toBeGreaterThan(1);
     expect(openStoreCalls).toBeGreaterThan(2);
-    expect(doctorCalls).toBe(1);
+    expect(doctorCalls).toBeGreaterThan(1);
     expect(output.stdout).not.toContain("\x1b[2J");
     expect(output.stdout).toContain("\x1b[H");
     expect(output.stdout).toContain("\x1b[K");


### PR DESCRIPTION
## Summary

- `symphonika status --watch` cached the `DoctorReport` once at startup and reused it forever, so env/config/repo changes were invisible until the watch was restarted.
- This produced a confusing split: a fresh `symphonika doctor` (e.g. in a shell that exports `GITHUB_TOKEN`) reports `3 projects valid`, while a long-running watch (started in a shell that lacked `GITHUB_TOKEN`) keeps rendering `Projects: 0 valid / 3 invalid`.
- Drop the cached-report short-circuit in `src/cli.ts` so each refresh tick re-validates via `doctor()`. Flip the test that previously pinned the stale behavior.

## Repro before the fix

```
# shell A (no GITHUB_TOKEN exported)
symphonika status --watch
# → Projects: 0 valid / 3 invalid (forever)

# shell B
GITHUB_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN symphonika doctor
# → doctor ok: 3 projects valid
```

## Test plan

- [x] `npx vitest run tests/cli-runs.test.ts -t "status --watch re-runs doctor"`
- [x] Full suite: `npx vitest run --exclude tests/property-invariants.test.ts` (503 passing). The `property-invariants` file is pre-broken on `main` (missing `fast-check` dep) and unrelated to this change.
- [ ] Manual: start `symphonika status --watch` without `GITHUB_TOKEN`, then export the token in the same shell once — next tick should flip to `3 valid / 0 invalid`.