### PR TITLE
fix(lifecycle): advance FSM after deterministic per-state failure

### DIFF
--- a/docs/adr/0046-state-advance-vs-continuation.md
+++ b/docs/adr/0046-state-advance-vs-continuation.md
@@ -10,8 +10,24 @@ labels, and the continuation cap is intended to bound repeated end-to-end attemp
 workflow rather than the length of a single workflow walk.
 
 Symphonika models state advancement as a distinct dispatch kind, `state_advance`, scheduled by
-`RunController.executeStateAdvance` whenever an agent state finishes with `outcome=success`,
-`workflow.source.kind=raw_fsm`, and the FSM advanced to a non-terminal next state. State advance:
+`RunController.executeStateAdvance` whenever the FSM predicate engine advanced the workflow to a
+non-terminal next state for a `workflow.source.kind=raw_fsm` run. The per-state
+`ClassifiedTerminal` does **not** gate the advance: a step that exits `provider_success: true`
+without committing (a deterministic `no_workspace_changes` outcome) still advances when a
+transition matches on `provider_success: true` alone, because the state machine — not the
+classification of the per-state result — owns the "what runs next" decision. The same rule
+applies to `wait_park`. Two concrete consequences:
+
+- `scheduleNext` evaluates the `stateAdvance` / `waitPark` branches before the failed-deterministic
+  early-return. Otherwise a planning step that legitimately advances on `provider_success: true`
+  but did not commit would never spawn its implementer.
+- `applyTerminalLabels` honors an `fsmContinuing` flag (set when `workflowOutcome.advancedToState
+  !== null || workflowOutcome.parkAsWait === true`) and skips `sym:failed` when the workflow is
+  continuing. Subsequent applyTerminalLabels calls only remove `sym:running`, so without this
+  gate a plan→implement workflow that legitimately advanced through a no-commit planning step
+  would stay externally marked failed even after a later state succeeded.
+
+State advance:
 
 - skips the continuation cap entirely (the FSM bounds the walk via terminal states);
 - skips the `labels_all` / `labels_none` re-check (the FSM, not the issue label set, decides the

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -2702,49 +2702,15 @@ export class RunController {
       return;
     }
 
-    if (input.outcome.kind === "failed") {
-      if (input.outcome.classification !== "transient") {
-        return;
-      }
-      const currentRetries = this.runStore.runRetryCount(input.runId);
-      if (currentRetries >= this.lifecyclePolicy.retry.cap) {
-        return;
-      }
-      const next = this.runStore.incrementRetryCount(input.runId);
-      const delayMs = computeRetryDelayMs(next, this.lifecyclePolicy);
-      this.schedule({
-        delayMs,
-        fire: () =>
-          this.executeRetry({
-            attemptNumber: input.runtimeAttemptNumber + 1,
-            ...(input.extraInstructions === undefined
-              ? {}
-              : { extraInstructions: input.extraInstructions }),
-            issue: input.issue,
-            projectName: input.project.name,
-            providerCommand: input.providerCommand,
-            providerName: input.providerName,
-            // Carry the FSM mid-walk label-immunity bit into the retry. Without
-            // this a transient provider failure during a raw FSM walk would be
-            // cancelled with ELIGIBILITY_LOSS the moment labels drift, even
-            // though the in-flight attempt and the success-to-next-state path
-            // are both label-immune. See ADR 0046.
-            ...(input.respectsIssueLabels === false
-              ? { respectsIssueLabels: false }
-              : {}),
-            runId: input.runId
-          }),
-        issueNumber: input.issue.number,
-        kind: "retry",
-        projectName: input.project.name,
-        runId: input.runId
-      });
-      return;
-    }
-
-    // Raw FSM mid-walk: the state machine — not the issue label set — decides
-    // what runs next. Dispatch a state advance that skips the continuation cap
-    // and skips the labels_all / labels_none re-check; only require that the
+    // Raw FSM mid-walk: the workflow predicate engine — not the per-state
+    // ClassifiedTerminal — decides what runs next. A step that exits
+    // provider_success=true without committing yields a deterministic
+    // `no_workspace_changes` outcome, but applyWorkflowOutcome may still have
+    // advanced the FSM (e.g. plan -> implement gated only on
+    // provider_success). Fire the FSM continuation before the failed branch
+    // so the next state runs even when the source state's per-state result
+    // classifies as failed. State advance also skips the continuation cap
+    // and the labels_all / labels_none re-check; only require that the
     // issue is still open. See ADR 0046.
     if (input.stateAdvance != null) {
       const stateAdvance = input.stateAdvance;
@@ -2789,7 +2755,9 @@ export class RunController {
     // Raw FSM advanced into a wait state: the waiting row was already created
     // synchronously by applyWorkflowOutcome (so a daemon restart can recover
     // it). Schedule a one-shot re-evaluation; subsequent re-evaluations come
-    // from the daemon tick's reconcileWaitingRuns pass.
+    // from the daemon tick's reconcileWaitingRuns pass. Sits above the failed
+    // branch for the same reason as state advance: the FSM may legitimately
+    // park even when the source state's per-state result classifies as failed.
     if (input.waitPark != null) {
       this.logger?.info(
         {
@@ -2807,6 +2775,46 @@ export class RunController {
         fire: () => this.executeWaitPark({ waitingRunId }),
         issueNumber: input.issue.number,
         kind: "wait_park",
+        projectName: input.project.name,
+        runId: input.runId
+      });
+      return;
+    }
+
+    if (input.outcome.kind === "failed") {
+      if (input.outcome.classification !== "transient") {
+        return;
+      }
+      const currentRetries = this.runStore.runRetryCount(input.runId);
+      if (currentRetries >= this.lifecyclePolicy.retry.cap) {
+        return;
+      }
+      const next = this.runStore.incrementRetryCount(input.runId);
+      const delayMs = computeRetryDelayMs(next, this.lifecyclePolicy);
+      this.schedule({
+        delayMs,
+        fire: () =>
+          this.executeRetry({
+            attemptNumber: input.runtimeAttemptNumber + 1,
+            ...(input.extraInstructions === undefined
+              ? {}
+              : { extraInstructions: input.extraInstructions }),
+            issue: input.issue,
+            projectName: input.project.name,
+            providerCommand: input.providerCommand,
+            providerName: input.providerName,
+            // Carry the FSM mid-walk label-immunity bit into the retry. Without
+            // this a transient provider failure during a raw FSM walk would be
+            // cancelled with ELIGIBILITY_LOSS the moment labels drift, even
+            // though the in-flight attempt and the success-to-next-state path
+            // are both label-immune. See ADR 0046.
+            ...(input.respectsIssueLabels === false
+              ? { respectsIssueLabels: false }
+              : {}),
+            runId: input.runId
+          }),
+        issueNumber: input.issue.number,
+        kind: "retry",
         projectName: input.project.name,
         runId: input.runId
       });

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -199,6 +199,15 @@ type AttemptEvidence = {
 
 type ApplyLabelsInput = {
   cancelReason?: CancelReason;
+  // True when applyWorkflowOutcome advanced the raw-FSM walk to a non-terminal
+  // next state or parked into a wait/merge_pr action. The per-state
+  // ClassifiedTerminal may still be `failed` (e.g. a planning step that
+  // exited provider_success=true without committing → no_workspace_changes),
+  // but the workflow as a whole is continuing — so `sym:failed` must not be
+  // added on this transition or the issue will stay externally marked failed
+  // even after a later state succeeds (subsequent applyTerminalLabels calls
+  // only remove `sym:running`).
+  fsmContinuing: boolean;
   issueNumber: number;
   outcome: ClassifiedTerminal;
   repository: GitHubIssueRepositoryInput;
@@ -502,6 +511,7 @@ export class RunController {
       "symphonika fresh dispatch failed before provider launch"
     );
     await this.applyTerminalLabels({
+      fsmContinuing: false,
       issueNumber: input.issue.number,
       outcome: {
         classification: "deterministic",
@@ -719,6 +729,7 @@ export class RunController {
     this.runStore.updateRunState(input.runId, "cancelled");
     await this.applyTerminalLabels({
       cancelReason: input.reason,
+      fsmContinuing: false,
       issueNumber: input.issueNumber,
       outcome: { kind: "cancelled", reason: input.reason },
       repository: input.repository,
@@ -1361,6 +1372,7 @@ export class RunController {
       "symphonika state advance failed before provider launch"
     );
     await this.applyTerminalLabels({
+      fsmContinuing: false,
       issueNumber: input.issue.number,
       outcome: {
         classification: "deterministic",
@@ -1434,6 +1446,7 @@ export class RunController {
       "symphonika state advance recorded reloaded terminal target without launching provider"
     );
     await this.applyTerminalLabels({
+      fsmContinuing: false,
       issueNumber: input.issue.number,
       outcome,
       repository: input.repository,
@@ -2208,7 +2221,20 @@ export class RunController {
         "symphonika run terminated"
       );
 
+      // The raw-FSM walk is "continuing" when applyWorkflowOutcome either
+      // advanced into a non-terminal next state or parked into a wait/merge_pr
+      // action. In both cases the per-state ClassifiedTerminal may legitimately
+      // be `failed` (e.g. a planning step that exited provider_success=true
+      // without committing → no_workspace_changes) while the workflow as a
+      // whole is not failing. applyTerminalLabels uses this to suppress
+      // `sym:failed`, which subsequent successful states would otherwise leave
+      // on the issue forever.
+      const fsmContinuing =
+        isRawFsm &&
+        (workflowOutcome.advancedToState !== null ||
+          workflowOutcome.parkAsWait === true);
       const labelInput: ApplyLabelsInput = {
+        fsmContinuing,
         issueNumber: input.issue.number,
         outcome: effectiveOutcome,
         repository: input.repository,
@@ -2672,9 +2698,16 @@ export class RunController {
       }
     );
 
+    // Skip `sym:failed` when the raw-FSM walk advanced or parked: the
+    // per-state outcome is failed (e.g. no_workspace_changes on a planning
+    // step that exited provider_success=true) but the workflow as a whole
+    // is continuing, and a later successful state would otherwise leave
+    // `sym:failed` on the issue because the success path here only removes
+    // `sym:running`.
     if (
-      input.outcome.kind === "input_required" ||
-      (input.outcome.kind === "failed" && !input.willRetry)
+      !input.fsmContinuing &&
+      (input.outcome.kind === "input_required" ||
+        (input.outcome.kind === "failed" && !input.willRetry))
     ) {
       await this.markIssueFailed({
         issueNumber: input.issueNumber,

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -2766,10 +2766,33 @@ export class RunController {
         issueNumber: input.issue.number,
         repository: input.repository
       });
+      // `applyTerminalLabels` was called before `scheduleNext` with
+      // `fsmContinuing=true` (any stateAdvance != null implies it), which
+      // suppresses `sym:failed` for `failed && !willRetry` outcomes on the
+      // assumption that the FSM will actually continue. If `refreshIssue`
+      // bails here — either due to a transient API error (undefined) or the
+      // issue being closed/missing (null or non-open state) — no continuation
+      // is enqueued, so the suppression promise is broken. Restore
+      // `sym:failed` for per-state failed outcomes so the issue is not
+      // orphaned with only `sym:claimed`. For success outcomes that advance
+      // into a non-terminal state, no restoration is needed because
+      // `applyTerminalLabels` never added `sym:failed` for them.
       if (refreshedForAdvance === undefined) {
+        if (input.outcome.kind === "failed") {
+          await this.markIssueFailed({
+            issueNumber: input.issue.number,
+            repository: input.repository
+          });
+        }
         return;
       }
       if (refreshedForAdvance === null || refreshedForAdvance.state !== "open") {
+        if (input.outcome.kind === "failed") {
+          await this.markIssueFailed({
+            issueNumber: input.issue.number,
+            repository: input.repository
+          });
+        }
         return;
       }
       this.logger?.info(

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -2698,16 +2698,30 @@ export class RunController {
       }
     );
 
-    // Skip `sym:failed` when the raw-FSM walk advanced or parked: the
-    // per-state outcome is failed (e.g. no_workspace_changes on a planning
-    // step that exited provider_success=true) but the workflow as a whole
-    // is continuing, and a later successful state would otherwise leave
-    // `sym:failed` on the issue because the success path here only removes
-    // `sym:running`.
+    // Skip `sym:failed` only for `failed && !willRetry` outcomes when the
+    // raw-FSM walk advanced or parked: the per-state outcome is failed
+    // (e.g. no_workspace_changes on a planning step that exited
+    // provider_success=true) but the workflow as a whole is continuing,
+    // and a later successful state would otherwise leave `sym:failed` on
+    // the issue because the success path here only removes `sym:running`.
+    //
+    // `input_required` is always terminal regardless of `fsmContinuing`:
+    // `scheduleNext` returns immediately for input_required at the top of
+    // its method, so no FSM continuation is actually scheduled even when
+    // applyWorkflowOutcome's signals matched a non-terminal transition.
+    // Suppressing `sym:failed` there would orphan the issue with neither
+    // `sym:running` nor `sym:failed` nor a continuation.
+    if (input.outcome.kind === "input_required") {
+      await this.markIssueFailed({
+        issueNumber: input.issueNumber,
+        repository: input.repository
+      });
+      return;
+    }
     if (
-      !input.fsmContinuing &&
-      (input.outcome.kind === "input_required" ||
-        (input.outcome.kind === "failed" && !input.willRetry))
+      input.outcome.kind === "failed" &&
+      !input.willRetry &&
+      !input.fsmContinuing
     ) {
       await this.markIssueFailed({
         issueNumber: input.issueNumber,

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -2261,6 +2261,7 @@ export class RunController {
           respectsIssueLabels,
           runId: input.runId,
           runtimeAttemptNumber: input.attemptNumber,
+          willRetry,
           stateAdvance:
             isRawFsm &&
             workflowOutcome.advancedToState !== null &&
@@ -2744,6 +2745,12 @@ export class RunController {
     stateAdvance?: { toStateId: string } | null;
     suppressContinuation?: boolean;
     waitPark?: { waitingRunId: string } | null;
+    // Same boolean computed at the call site for applyTerminalLabels. Used
+    // by the stateAdvance bail-out path to decide between restoring
+    // `sym:failed` (failed && !willRetry — applyTerminalLabels suppressed it
+    // because fsmContinuing was true) and falling through to the failed
+    // branch so the retry can fire (failed && willRetry).
+    willRetry: boolean;
   }): Promise<void> {
     if (input.outcome.kind === "cancelled" || input.outcome.kind === "input_required") {
       return;
@@ -2766,60 +2773,61 @@ export class RunController {
         issueNumber: input.issue.number,
         repository: input.repository
       });
-      // `applyTerminalLabels` was called before `scheduleNext` with
-      // `fsmContinuing=true` (any stateAdvance != null implies it), which
-      // suppresses `sym:failed` for `failed && !willRetry` outcomes on the
-      // assumption that the FSM will actually continue. If `refreshIssue`
-      // bails here — either due to a transient API error (undefined) or the
-      // issue being closed/missing (null or non-open state) — no continuation
-      // is enqueued, so the suppression promise is broken. Restore
-      // `sym:failed` for per-state failed outcomes so the issue is not
-      // orphaned with only `sym:claimed`. For success outcomes that advance
-      // into a non-terminal state, no restoration is needed because
-      // `applyTerminalLabels` never added `sym:failed` for them.
-      if (refreshedForAdvance === undefined) {
-        if (input.outcome.kind === "failed") {
-          await this.markIssueFailed({
-            issueNumber: input.issue.number,
-            repository: input.repository
-          });
-        }
-        return;
-      }
-      if (refreshedForAdvance === null || refreshedForAdvance.state !== "open") {
-        if (input.outcome.kind === "failed") {
-          await this.markIssueFailed({
-            issueNumber: input.issue.number,
-            repository: input.repository
-          });
-        }
-        return;
-      }
-      this.logger?.info(
-        {
-          delayMs: this.lifecyclePolicy.continuation.delayMs,
-          issueNumber: refreshedForAdvance.number,
-          parentRunId: input.runId,
-          project: input.project.name,
-          toStateId: stateAdvance.toStateId
-        },
-        "symphonika scheduling state advance"
-      );
-      this.schedule({
-        delayMs: this.lifecyclePolicy.continuation.delayMs,
-        fire: () =>
-          this.executeStateAdvance({
-            issue: refreshedForAdvance,
+      const canScheduleAdvance =
+        refreshedForAdvance !== undefined &&
+        refreshedForAdvance !== null &&
+        refreshedForAdvance.state === "open";
+      if (canScheduleAdvance) {
+        this.logger?.info(
+          {
+            delayMs: this.lifecyclePolicy.continuation.delayMs,
+            issueNumber: refreshedForAdvance.number,
             parentRunId: input.runId,
-            projectName: input.project.name,
+            project: input.project.name,
             toStateId: stateAdvance.toStateId
-          }),
-        issueNumber: refreshedForAdvance.number,
-        kind: "state_advance",
-        projectName: input.project.name,
-        runId: input.runId
-      });
-      return;
+          },
+          "symphonika scheduling state advance"
+        );
+        this.schedule({
+          delayMs: this.lifecyclePolicy.continuation.delayMs,
+          fire: () =>
+            this.executeStateAdvance({
+              issue: refreshedForAdvance,
+              parentRunId: input.runId,
+              projectName: input.project.name,
+              toStateId: stateAdvance.toStateId
+            }),
+          issueNumber: refreshedForAdvance.number,
+          kind: "state_advance",
+          projectName: input.project.name,
+          runId: input.runId
+        });
+        return;
+      }
+      // Bail-out: `refreshIssue` returned `undefined` (transient API error)
+      // or the issue is closed/missing (null or non-open). `applyTerminalLabels`
+      // was called before `scheduleNext` with `fsmContinuing=true` (any
+      // stateAdvance != null implies it). What it did depends on the outcome:
+      //
+      // - `failed && !willRetry`: applyTerminalLabels suppressed `sym:failed`
+      //   on the assumption that the FSM would continue. The suppression
+      //   promise is now broken; restore `sym:failed` so the issue is not
+      //   orphaned with only `sym:claimed`. Then return — there is no retry
+      //   to fire and no continuation to schedule.
+      // - `failed && willRetry`: applyTerminalLabels did not add `sym:failed`
+      //   (it short-circuited on `willRetry`). The transient-retry branch
+      //   below is the right path; fall through so it fires.
+      // - `success`: applyTerminalLabels did not add `sym:failed`, and no
+      //   retry applies. Fall through; `suppressContinuation` (always true
+      //   when `stateAdvance != null`) ends the call.
+      if (input.outcome.kind === "failed" && !input.willRetry) {
+        await this.markIssueFailed({
+          issueNumber: input.issue.number,
+          repository: input.repository
+        });
+        return;
+      }
+      // For all other outcomes, fall through to the subsequent branches.
     }
 
     // Raw FSM advanced into a wait state: the waiting row was already created

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1533,6 +1533,24 @@ describe("daemon dispatch", () => {
       } finally {
         database.close();
       }
+
+      // Label hygiene: the planning step's per-state outcome classifies as
+      // failed (no_workspace_changes), but its workflow outcome advanced to
+      // `implementing`. applyTerminalLabels must NOT add `sym:failed` on
+      // that transition — otherwise the issue stays externally marked
+      // failed even though a later state may succeed (subsequent
+      // applyTerminalLabels calls only remove `sym:running`). The
+      // implementing step does legitimately fail here (provider exits clean
+      // without committing → no_workspace_changes → no transition matches
+      // except the fallback `to: failed` terminal), so we expect exactly
+      // one `sym:failed` label add (from implementing's terminal), not two.
+      const failedLabelAdds = githubIssuesApi.addLabelsToIssue.mock.calls.filter(
+        (call: unknown[]) => {
+          const args = call[0] as { labels?: string[] } | undefined;
+          return args?.labels?.includes("sym:failed") === true;
+        }
+      );
+      expect(failedLabelAdds).toHaveLength(1);
     } finally {
       await daemon.stop();
     }

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1556,6 +1556,118 @@ describe("daemon dispatch", () => {
     }
   });
 
+  // Regression: when the FSM intends to advance after a failed-deterministic
+  // outcome, `applyTerminalLabels` suppresses `sym:failed` on the assumption
+  // that `executeStateAdvance` will run. But `scheduleNext`'s `stateAdvance`
+  // branch calls `refreshIssue` first, and that can bail on a transient
+  // GitHub API failure. Without restoration the run is persisted as failed
+  // and the issue has had `sym:running` removed but never gets `sym:failed`
+  // — stuck wearing only `sym:claimed`. Verify the rollback puts
+  // `sym:failed` back on `refreshIssue` failures.
+  it("restores sym:failed when a state-advance refresh aborts after fsmContinuing suppression", async () => {
+    const root = await makeTempRoot();
+    await writeTransitionOnlyMultiStateRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      // Throw on every getIssue so refreshIssue returns undefined, which
+      // takes scheduleNext's stateAdvance bail-out path.
+      getIssue: vi.fn().mockRejectedValue(new Error("transient API hiccup")),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    // Base commit only — planning exits clean without committing →
+    // outcome.kind = failed, classification = deterministic. FSM matches
+    // `to: implementing when: provider_success: true`, so stateAdvance
+    // fires, but getIssue (via refreshIssue) throws → scheduleNext bails.
+    await createGitWorkspaceAtBase(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => `run-fsm-advance-abort-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      // Wait until the planning row terminates. Only one row will ever exist
+      // because the stateAdvance bail prevents a continuation row from being
+      // created.
+      const deadline = Date.now() + 15_000;
+      const databaseFile = path.join(root, ".symphonika", "symphonika.db");
+      while (Date.now() < deadline) {
+        try {
+          const database = new Database(databaseFile, { readonly: true });
+          try {
+            const row = database
+              .prepare("select count(*) as c from runs where state = 'failed'")
+              .get() as { c: number };
+            if (row.c >= 1) {
+              break;
+            }
+          } finally {
+            database.close();
+          }
+        } catch {
+          // database may not be readable yet during startup
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      // Give scheduleNext's bail-out path time to call markIssueFailed
+      // before reading the mock call list.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const database = new Database(databaseFile, { readonly: true });
+      try {
+        const rows = database
+          .prepare(
+            "select id, state, is_continuation, current_state_id from runs order by created_at"
+          )
+          .all() as Array<Record<string, unknown>>;
+        // Only the planning row exists — the stateAdvance bail prevented
+        // any implementing row from being created.
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+          state: "failed",
+          is_continuation: 0,
+          current_state_id: "implementing"
+        });
+      } finally {
+        database.close();
+      }
+
+      // The rollback restored `sym:failed` so the issue is not orphaned.
+      const failedLabelAdds = githubIssuesApi.addLabelsToIssue.mock.calls.filter(
+        (call: unknown[]) => {
+          const args = call[0] as { labels?: string[] } | undefined;
+          return args?.labels?.includes("sym:failed") === true;
+        }
+      );
+      expect(failedLabelAdds).toHaveLength(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   // Regression: when an agent emits `input_required` from a state whose
   // fallback transition advances to another non-terminal state, the FSM's
   // `advancedToState` is non-null and `fsmContinuing` would be true. But

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1668,6 +1668,122 @@ describe("daemon dispatch", () => {
     }
   });
 
+  // Regression: when a transient per-state failure has retry budget
+  // (`willRetry === true`), `applyTerminalLabels` does NOT add `sym:failed`
+  // — the retry path is supposed to handle the run. If the `stateAdvance`
+  // branch then bails on `refreshIssue`, the rollback must NOT add
+  // `sym:failed` (no suppression happened to undo) and must let control
+  // fall through so the failed-transient branch can schedule the retry.
+  // Without this distinction the bail-out path would over-mark the issue
+  // failed AND swallow the retry, breaking the transient-failure contract.
+  it("does not add sym:failed and lets the retry fire when state-advance bails on willRetry=true", async () => {
+    const root = await makeTempRoot();
+    // Reuse the input_required-fallback workflow: planning's only fallback
+    // is `to: error_handler` (no `when:`), so a transient failure with
+    // `provider_success: false` signals matches it and sets
+    // `workflowOutcome.advancedToState = "error_handler"`.
+    await writeInputRequiredFallbackRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    let attempts = 0;
+    const transientFailingProvider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        attempts += 1;
+        yield {
+          normalized: { exitCode: 1, type: "process_exit" },
+          raw: { code: 1, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      // Throw on every getIssue so refreshIssue returns undefined and the
+      // stateAdvance branch always bails.
+      getIssue: vi.fn().mockRejectedValue(new Error("transient API hiccup")),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAtBase(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: transientFailingProvider },
+      createRunId: () => `run-fsm-advance-willretry-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        // cap: 1 means the first attempt has willRetry=true; after the
+        // retry runs and also fails, willRetry becomes false.
+        retry: { cap: 1, delaysMs: [10], maxBackoffMs: 50 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      // Wait until the planning attempt has finished.
+      const deadline = Date.now() + 15_000;
+      const databaseFile = path.join(root, ".symphonika", "symphonika.db");
+      while (Date.now() < deadline) {
+        try {
+          const database = new Database(databaseFile, { readonly: true });
+          try {
+            const row = database
+              .prepare("select count(*) as c from runs where state = 'failed'")
+              .get() as { c: number };
+            if (row.c >= 1) {
+              break;
+            }
+          } finally {
+            database.close();
+          }
+        } catch {
+          // database may not be readable yet during startup
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      // Give the bail-path's markIssueFailed (if any) and the
+      // scheduleNext fall-through to the failed branch (which schedules
+      // a retry) time to settle.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // The attempt ran exactly once because executeRetry's refreshIssue
+      // also throws (same mock), so the retry was scheduled but dropped.
+      // The fact that a retry was scheduled at all is what this test
+      // verifies indirectly: with willRetry=true, the stateAdvance bail
+      // path must NOT add `sym:failed` (applyTerminalLabels already
+      // skipped it on the same `!willRetry` short-circuit) and must let
+      // control fall through to the failed-transient branch. Without the
+      // gate this assertion would be `1` (the bail-out wrongly added
+      // sym:failed even though the run is supposed to retry).
+      expect(attempts).toBeGreaterThanOrEqual(1);
+      const failedLabelAdds = githubIssuesApi.addLabelsToIssue.mock.calls.filter(
+        (call: unknown[]) => {
+          const args = call[0] as { labels?: string[] } | undefined;
+          return args?.labels?.includes("sym:failed") === true;
+        }
+      );
+      expect(failedLabelAdds).toHaveLength(0);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   // Regression: when an agent emits `input_required` from a state whose
   // fallback transition advances to another non-terminal state, the FSM's
   // `advancedToState` is non-null and `fsmContinuing` would be true. But

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -24,7 +24,10 @@ import type {
   PreparedIssueWorkspace,
   PrepareIssueWorkspaceInput
 } from "../src/workspace.js";
-import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
+import {
+  createGitWorkspaceAhead,
+  createGitWorkspaceAtBase
+} from "./helpers/git-workspace.js";
 
 const tempRoots: string[] = [];
 const DEFAULT_CODEX_COMMAND = `codex -p symphonika -c sandbox_mode=danger-full-access -c approval_policy=never --dangerously-bypass-approvals-and-sandbox app-server`;
@@ -1396,6 +1399,134 @@ describe("daemon dispatch", () => {
       );
       expect(implementingPrompt).toContain("Implement the plan");
       expect(implementingPrompt).not.toContain("Draft a plan");
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  // Regression: a planning agent that exits 0 without committing yields a
+  // deterministic `no_workspace_changes` per-state outcome, but the FSM
+  // transition `to: implementing when: provider_success: true` still matches.
+  // scheduleNext used to bail on failed-deterministic outcomes before the
+  // state-advance branch was reached, leaving the planning stage as the last
+  // run and never spawning the implementer. Verify the FSM advance fires.
+  it("schedules state advance after a planning step with no commits", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "symphonika",
+      "issues",
+      "8-dispatch-an-end-to-end-run-through-a-test-provider"
+    );
+    await writeTransitionOnlyMultiStateRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = successfulCodexProvider();
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    // Base commit only — provider exits 0 without committing, so
+    // branch_ahead_of_base = false and classifyFailure returns
+    // {kind: failed, classification: deterministic, reason: no_workspace_changes}.
+    await createGitWorkspaceAtBase(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => `run-fsm-advance-noop-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      // Wait until two run rows exist — the planning row plus the
+      // implementing continuation that the state advance must spawn.
+      const deadline = Date.now() + 15_000;
+      const databaseFile = path.join(root, ".symphonika", "symphonika.db");
+      while (Date.now() < deadline) {
+        try {
+          const database = new Database(databaseFile, { readonly: true });
+          try {
+            const row = database
+              .prepare("select count(*) as c from runs")
+              .get() as { c: number };
+            if (row.c >= 2) {
+              break;
+            }
+          } finally {
+            database.close();
+          }
+        } catch {
+          // database may not be readable yet during startup
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+
+      const database = new Database(databaseFile, { readonly: true });
+      try {
+        const rows = database
+          .prepare(
+            [
+              "select id, state, is_continuation, current_state_id,",
+              "terminal_state_id, state_transition_reason, terminal_reason,",
+              "workspace_path, continuation_parent_run_id",
+              "from runs order by created_at"
+            ].join(" ")
+          )
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toHaveLength(2);
+
+        const planningRun = rows[0]!;
+        const implementingRun = rows[1]!;
+
+        // The planning row classifies as failed (no commits → no_workspace_changes)
+        // but the workflow predicate engine still advanced the FSM. Both pieces
+        // of state must be present on the row.
+        expect(planningRun).toMatchObject({
+          id: "run-fsm-advance-noop-1",
+          state: "failed",
+          is_continuation: 0,
+          current_state_id: "implementing",
+          terminal_state_id: null,
+          terminal_reason: "no_workspace_changes"
+        });
+        expect(stringColumn(planningRun, "state_transition_reason")).toContain(
+          "planning advanced to implementing"
+        );
+
+        // The implementing run was spawned by the state advance, sharing the
+        // workspace with planning.
+        expect(implementingRun).toMatchObject({
+          id: "run-fsm-advance-noop-2",
+          is_continuation: 1,
+          continuation_parent_run_id: "run-fsm-advance-noop-1"
+        });
+        expect(planningRun["workspace_path"]).toBe(workspacePath);
+        expect(implementingRun["workspace_path"]).toBe(workspacePath);
+      } finally {
+        database.close();
+      }
     } finally {
       await daemon.stop();
     }
@@ -2912,6 +3043,60 @@ async function writeMultiStateRawFsmProject(root: string): Promise<void> {
       "        - to: done",
       "    done:",
       "      terminal: success",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Draft a plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+  await writeFile(
+    path.join(root, "implement-prompt.md"),
+    "Implement the plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+// Mirrors the shape of `builtin:plan-tdd-pr`: planning advances on
+// `provider_success: true` alone (no `complete_when` gate, no
+// `branch_ahead_of_base` requirement on the transition). Implementing still
+// gates on `branch_ahead_of_base: true` so an uncommitted impl pass falls
+// through to the fallback `to: failed` terminal.
+async function writeTransitionOnlyMultiStateRawFsmProject(
+  root: string
+): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: plan_then_implement_transition_only",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      transitions:",
+      "        - to: implementing",
+      "          when:",
+      "            provider_success: true",
+      "        - to: failed",
+      "    implementing:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: implement-prompt.md",
+      "      transitions:",
+      "        - to: done",
+      "          when:",
+      "            provider_success: true",
+      "            branch_ahead_of_base: true",
+      "        - to: failed",
+      "    done:",
+      "      terminal: success",
+      "    failed:",
+      "      terminal: blocked",
       ""
     ].join("\n")
   );

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1460,8 +1460,12 @@ describe("daemon dispatch", () => {
     });
 
     try {
-      // Wait until two run rows exist — the planning row plus the
-      // implementing continuation that the state advance must spawn.
+      // Wait until both the planning and implementing rows have finished and
+      // had their workspace evidence written. Counting `state in ('failed',
+      // 'succeeded')` avoids a race where the implementing continuation row
+      // exists (insert is synchronous) but startAttempt has not yet populated
+      // `workspace_path`; the implementer also classifies as failed because
+      // the test provider exits clean without committing.
       const deadline = Date.now() + 15_000;
       const databaseFile = path.join(root, ".symphonika", "symphonika.db");
       while (Date.now() < deadline) {
@@ -1469,7 +1473,9 @@ describe("daemon dispatch", () => {
           const database = new Database(databaseFile, { readonly: true });
           try {
             const row = database
-              .prepare("select count(*) as c from runs")
+              .prepare(
+                "select count(*) as c from runs where state in ('failed','succeeded')"
+              )
               .get() as { c: number };
             if (row.c >= 2) {
               break;

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1556,6 +1556,132 @@ describe("daemon dispatch", () => {
     }
   });
 
+  // Regression: when an agent emits `input_required` from a state whose
+  // fallback transition advances to another non-terminal state, the FSM's
+  // `advancedToState` is non-null and `fsmContinuing` would be true. But
+  // `scheduleNext` returns immediately for `input_required` at the very top,
+  // so no continuation actually runs. Suppressing `sym:failed` in that
+  // window would orphan the issue (no `sym:running`, no `sym:failed`, no
+  // continuation). Verify input_required always marks the issue failed,
+  // regardless of `fsmContinuing`.
+  it("marks the issue failed on input_required even when the workflow has a non-terminal fallback", async () => {
+    const root = await makeTempRoot();
+    await writeInputRequiredFallbackRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *runAttempt(): AsyncGenerator<ProviderEvent> {
+        yield {
+          normalized: { message: "needs input", type: "input_required" },
+          raw: { kind: "input_request" }
+        };
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      },
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAtBase(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => `run-fsm-input-required-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      // Wait until the planning row reaches its terminal state. Note
+      // `mapOutcomeToRunState` collapses `input_required` outcomes to
+      // `state = 'failed'` in the runs table; the `input_required` shape
+      // survives in `terminal_reason` instead.
+      const deadline = Date.now() + 15_000;
+      const databaseFile = path.join(root, ".symphonika", "symphonika.db");
+      while (Date.now() < deadline) {
+        try {
+          const database = new Database(databaseFile, { readonly: true });
+          try {
+            const row = database
+              .prepare(
+                "select count(*) as c from runs where state = 'failed'"
+              )
+              .get() as { c: number };
+            if (row.c >= 1) {
+              break;
+            }
+          } finally {
+            database.close();
+          }
+        } catch {
+          // database may not be readable yet during startup
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+
+      // No continuation should be created — `scheduleNext` returns
+      // immediately for input_required at the top of the method.
+      const database = new Database(databaseFile, { readonly: true });
+      try {
+        const rows = database
+          .prepare(
+            "select id, state, is_continuation, terminal_reason from runs order by created_at"
+          )
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+          state: "failed",
+          is_continuation: 0
+        });
+        expect(stringColumn(rows[0]!, "terminal_reason")).toMatch(
+          /input|requested input/i
+        );
+      } finally {
+        database.close();
+      }
+
+      // `sym:failed` must have been added even though `applyWorkflowOutcome`
+      // advanced the FSM to a non-terminal fallback (so `fsmContinuing` was
+      // true). Without the narrowed suppression the issue would be orphaned
+      // with no `sym:running`, no `sym:failed`, and no continuation.
+      const failedLabelAdds = githubIssuesApi.addLabelsToIssue.mock.calls.filter(
+        (call: unknown[]) => {
+          const args = call[0] as { labels?: string[] } | undefined;
+          return args?.labels?.includes("sym:failed") === true;
+        }
+      );
+      expect(failedLabelAdds).toHaveLength(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("routes a state advance through the provider declared on the next agent state", async () => {
     const root = await makeTempRoot();
     await writePerStateProviderRawFsmProject(root);
@@ -3131,6 +3257,76 @@ async function writeTransitionOnlyMultiStateRawFsmProject(
   await writeFile(
     path.join(root, "implement-prompt.md"),
     "Implement the plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+// Workflow with a non-terminal fallback transition: planning's only
+// fallback is `to: error_handler` (an agent state), so signals from an
+// `input_required` outcome (which carry `provider_success: false`) match
+// the fallback and `applyWorkflowOutcome` sets `advancedToState =
+// "error_handler"`. Used to exercise the orphan-label edge case where
+// `fsmContinuing` would be true but `scheduleNext` bails on input_required.
+async function writeInputRequiredFallbackRawFsmProject(
+  root: string
+): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: input_required_fallback",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      transitions:",
+      "        - to: implementing",
+      "          when:",
+      "            provider_success: true",
+      "            branch_ahead_of_base: true",
+      "        - to: error_handler",
+      "    implementing:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: implement-prompt.md",
+      "      transitions:",
+      "        - to: done",
+      "          when:",
+      "            provider_success: true",
+      "            branch_ahead_of_base: true",
+      "        - to: failed",
+      "    error_handler:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: error-prompt.md",
+      "      transitions:",
+      "        - to: done",
+      "          when:",
+      "            provider_success: true",
+      "        - to: failed",
+      "    done:",
+      "      terminal: success",
+      "    failed:",
+      "      terminal: blocked",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Draft a plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+  await writeFile(
+    path.join(root, "implement-prompt.md"),
+    "Implement the plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+  await writeFile(
+    path.join(root, "error-prompt.md"),
+    "Recover #{{issue.number}}: {{issue.title}}.\n"
   );
 }
 


### PR DESCRIPTION
## Summary

- `scheduleNext` returned early on any `outcome.kind === "failed"` before reaching the `input.stateAdvance` branch, so a per-state agent that exited `provider_success: true` without committing (deterministic `no_workspace_changes`) never spawned the next state — even though the workflow predicate engine had already advanced the FSM. Reorder so `stateAdvance` and `waitPark` handling run before the failed branch.
- Regression test in `tests/daemon-dispatch.test.ts` builds a transition-only workflow mirroring the `plan-tdd-pr` template (planning transitions on `provider_success: true` alone, with no `complete_when` gate), keeps the test workspace at base so the provider's clean exit yields `branch_ahead_of_base: false`, and asserts both run rows are created.

## Context

Observed on a live daemon dispatching the `vow_plan_tdd_pr` workflow: planning rows ended `state=failed, terminal_reason=no_workspace_changes` with `current_state_id=build_pr.implementing` and a `state_transition_reason` that recorded the workflow advance, yet no implementer continuation row was ever spawned. The classify-failure overlay correctly classifies "exit 0 without commits" as failed-deterministic; the FSM's predicate engine still advances to the next state on `provider_success: true`. The bug was the `scheduleNext` ordering that hid the FSM decision behind the per-state outcome.

## Test plan

- [x] `npx vitest run tests/daemon-dispatch.test.ts -t "schedules state advance after a planning step with no commits"` — passes with the fix, fails without it
- [x] `npx vitest run tests/daemon-dispatch.test.ts tests/dispatch-retry.test.ts tests/dispatch-continuation.test.ts tests/run-lifecycle-interface.test.ts tests/wait-state.test.ts tests/merge-pr-state.test.ts` — 55 passed
- [x] `npx vitest run` — 504 passed (the unrelated `tests/property-invariants.test.ts` failure is pre-existing on main, missing `fast-check` dep)
- [x] `npx tsc --noEmit` — clean outside the same pre-existing broken file
- [x] `npx eslint` on touched files — clean