### PR TITLE
feat(systemd): user-service template + slice for daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ journalctl --user -u symphonika -f
 What the template gives you:
 
 - **`symphonika.slice`** owns the daemon and every process it spawns. `MemoryHigh=` / `MemoryMax=` cap the whole tree so a runaway tool is killed *inside* the slice instead of triggering a global OOM.
-- **`GITHUB_TOKEN`** is populated from `gh auth token` at each (re)start, so the daemon picks up rotated tokens automatically. The service fails closed (won't start) if `gh` is logged out.
+- The daemon's **GitHub auth token** is populated from `gh auth token` at each (re)start, so it picks up rotated tokens automatically. The service fails closed (won't start) if `gh` is logged out.
 - `Restart=on-failure` brings the daemon back, and `After=graphical-session.target` keeps the ordering right so `gh` can read your keyring.
 
 If you need the daemon to keep running after logout, `loginctl enable-linger $USER`.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ npm run dev -- status --config symphonika.example.yml --watch
 
 The `symphony/` directory in the tree is a git submodule of an unrelated upstream project (`openai/symphony`) used as a reference — it is not a launcher for Symphonika.
 
+### Running as a systemd user service (Linux)
+
+For long-lived installations, run the daemon under `systemd --user` so it doesn't share a cgroup with your terminal. Otherwise an OOM-kill of a spawned tool (compiler, verifier, etc.) can mark the whole terminal scope as failed and `systemd` will tear down the terminal — and the daemon — along with it.
+
+Template units live in [`systemd/`](systemd/):
+
+```sh
+mkdir -p ~/.config/systemd/user
+cp systemd/symphonika.service systemd/symphonika.slice ~/.config/systemd/user/
+# Adjust ExecStart (if you didn't install via `npm install -g`) and the
+# memory caps in the slice to match your host.
+systemctl --user daemon-reload
+systemctl --user enable --now symphonika.service
+journalctl --user -u symphonika -f
+```
+
+What the template gives you:
+
+- **`symphonika.slice`** owns the daemon and every process it spawns. `MemoryHigh=` / `MemoryMax=` cap the whole tree so a runaway tool is killed *inside* the slice instead of triggering a global OOM.
+- **`GITHUB_TOKEN`** is populated from `gh auth token` at each (re)start, so the daemon picks up rotated tokens automatically. The service fails closed (won't start) if `gh` is logged out.
+- `Restart=on-failure` brings the daemon back, and `After=graphical-session.target` keeps the ordering right so `gh` can read your keyring.
+
+If you need the daemon to keep running after logout, `loginctl enable-linger $USER`.
+
 ### Built-in workflow templates
 
 Raw-FSM workflows can reference built-in templates by prefix without authoring local YAML, for example:

--- a/systemd/symphonika.service
+++ b/systemd/symphonika.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Symphonika orchestrator daemon
+After=graphical-session.target network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h
+Restart=on-failure
+RestartSec=5s
+
+# Inherit a sane PATH so spawned providers (claude, codex) and tools
+# (gh, esbmc, cargo, ...) resolve under user-systemd.
+Environment=PATH=%h/.npm-global/bin:%h/.cargo/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+# Resolve GITHUB_TOKEN from `gh auth token` at each (re)start so this
+# survives token rotation. Fails closed if gh returns empty so the
+# daemon never starts without a token. `exec` replaces the shell so
+# the node process becomes the service's Main PID.
+#
+# Customise the ExecStart path to match your install:
+#   * npm global       -> %h/.npm-global/bin/symphonika daemon
+#   * source checkout  -> /usr/bin/node /path/to/symphonika/dist/cli.js daemon
+ExecStart=/bin/sh -c 't=$(gh auth token); [ -n "$t" ] || { echo "ERROR: gh auth token returned empty"; exit 1; }; export GITHUB_TOKEN="$t"; exec %h/.npm-global/bin/symphonika daemon'
+
+# Keep the daemon and everything it spawns in its own cgroup slice.
+# A scope-wide OOM in a spawned tool (compiler, verifier, ...) no
+# longer tears down whichever terminal scope you happened to launch
+# the daemon from.
+Slice=symphonika.slice
+
+# Journald sees stdout/stderr. View with:
+#   journalctl --user -u symphonika -f
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/symphonika.slice
+++ b/systemd/symphonika.slice
@@ -1,0 +1,12 @@
+[Unit]
+Description=Symphonika slice (daemon + spawned providers and verifiers)
+
+[Slice]
+# Cap the whole daemon tree. Tune to match the host you run on; these
+# defaults assume a workstation with >= 64 GB of RAM. A runaway tool
+# (e.g. an ESBMC verification) will be killed inside this slice
+# instead of triggering a global OOM that tears down terminals or
+# other unrelated cgroups.
+MemoryHigh=24G
+MemoryMax=32G
+TasksMax=4096


### PR DESCRIPTION
## Summary

Adds opt-in systemd user-service templates so the daemon can run as a managed service in its own cgroup slice, plus a README section documenting installation.

- `systemd/symphonika.service` — Type=simple user unit with `Restart=on-failure`, an explicit `PATH`, and an inline `ExecStart` wrapper that resolves `GITHUB_TOKEN` from `gh auth token` at every (re)start (fails closed if `gh` is logged out).
- `systemd/symphonika.slice` — owns the daemon and every process it spawns, with `MemoryHigh=24G` / `MemoryMax=32G` / `TasksMax=4096` as a starting point.
- README — new `### Running as a systemd user service (Linux)` subsection under "Running the daemon" with copy-paste install steps.

## Why

Running `symphonika daemon` directly from a terminal puts it in the terminal's `systemd --user` app scope (e.g. `app-niri-ghostty-<PID>.scope`). If anything the daemon spawns OOMs (real-world trigger: ESBMC verifications under the vow workflow each consuming 27–33 GB RSS), the kernel kills the offending process and `systemd` marks the entire scope as failed with `Result: oom-kill` — taking the terminal *and* the daemon down with it.

Putting the daemon in its own slice fixes that two ways:

1. Memory caps are enforced *in-slice*, so a runaway tool is killed before triggering global OOM.
2. Even if a kill happens, only the symphonika slice is affected; unrelated terminal scopes are untouched.

`GITHUB_TOKEN` from `gh auth token` removes the chore of exporting and re-exporting the token across rotations.

## Notes for reviewers

- Files are templates, not auto-installed — users opt in by copying into `~/.config/systemd/user/`.
- `ExecStart` uses `%h/.npm-global/bin/symphonika` as the default since the rest of the README assumes a global npm install; a comment lists the alternate `node dist/cli.js` form for source checkouts.
- The README explicitly notes that the slice memory caps and the `ExecStart` path may need tuning per host.
- No code changes; no behaviour change for users who don't opt in.

## Test plan

- [x] Installed both files to `~/.config/systemd/user/`, `systemctl --user daemon-reload`, `systemctl --user enable --now symphonika.service` — daemon comes up healthy.
- [x] Verified the running daemon is in cgroup `…/symphonika.slice/symphonika.service` (not a ghostty scope).
- [x] Verified `GITHUB_TOKEN` is present in the daemon process environment (`/proc/<pid>/environ`) and that issue polling no longer reports "unset environment variable".
- [x] `systemd-analyze --user verify symphonika.service` is clean.
- [ ] Confirm `Restart=on-failure` refreshes the token: rotate `gh` token, then `systemctl --user restart symphonika`, re-check `/proc/<pid>/environ`.