### PR TITLE
Throttle doctor checks in status watch

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -846,7 +846,7 @@ Bootstrap CLI commands:
 - `symphonika doctor [--config <path>]`
 - `symphonika init-project [--config <path>] --yes`
 - `symphonika daemon [--config <path>] [--port <port>]`
-- `symphonika status [--config <path>] [--dashboard] [--watch] [--interval-ms <ms>]`
+- `symphonika status [--config <path>] [--dashboard] [--watch] [--interval-ms <ms>] [--doctor-ttl-ms <ms>]`
 - `symphonika poll-now [--config <path>]`
 - `symphonika runs [--config <path>]`
 - `symphonika show-run <run-id> [--config <path>]`
@@ -873,7 +873,10 @@ labels only after explicit confirmation.
 
 `status --dashboard` renders a compact terminal status dashboard from the run store and daemon
 `/api/status` endpoint. `status --watch` refreshes that read-only dashboard in place; it must not
-dispatch work or mutate GitHub state.
+dispatch work or mutate GitHub state. Watch mode refreshes daemon status and run-store data every
+frame, but caches the full `doctor` validation path for 5000 ms by default so passive dashboards do
+not continuously re-run provider probes or GitHub validation reads. `--doctor-ttl-ms 0` disables that
+cache when an operator explicitly wants every frame to perform full validation.
 
 `clear-stale` removes `sym:stale`, `sym:claimed`, and `sym:running` only after explicit confirmation.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,6 +98,8 @@ type PollNowResponse = {
   state: "dispatching" | "idle";
 };
 
+const DEFAULT_STATUS_WATCH_DOCTOR_TTL_MS = 5000;
+
 export function buildCli(dependencies: CliDependencies = {}): Command {
   const doctor = dependencies.runDoctor ?? runDoctor;
   const init = dependencies.runInit ?? runInit;
@@ -411,14 +413,45 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .option("--dashboard", "render a compact terminal status dashboard")
     .option("--watch", "refresh the terminal dashboard until interrupted")
     .option("--interval-ms <n>", "watch refresh interval in milliseconds", parsePositiveInt, 1000)
+    .option(
+      "--doctor-ttl-ms <n>",
+      "minimum milliseconds between full doctor checks in watch mode; 0 checks every frame",
+      parseNonNegativeInt,
+      DEFAULT_STATUS_WATCH_DOCTOR_TTL_MS
+    )
     .action(
       async (options: {
         config?: string;
         daemonUrl?: string;
         dashboard?: boolean;
+        doctorTtlMs: number;
         intervalMs: number;
         watch?: boolean;
       }) => {
+        let watchDoctorCache:
+          | { expiresAtMs: number; report: DoctorReport }
+          | undefined;
+
+        const refreshDoctorReport = async (): Promise<DoctorReport> => {
+          if (options.watch !== true) {
+            return doctor(withConfigPath(options.config));
+          }
+          const now = Date.now();
+          if (
+            options.doctorTtlMs > 0 &&
+            watchDoctorCache !== undefined &&
+            now < watchDoctorCache.expiresAtMs
+          ) {
+            return watchDoctorCache.report;
+          }
+          const report = await doctor(withConfigPath(options.config));
+          watchDoctorCache = {
+            expiresAtMs: Date.now() + options.doctorTtlMs,
+            report
+          };
+          return report;
+        };
+
         const printOnce = async (
           dashboard: boolean,
           redrawState?: { previousLineCount: number }
@@ -426,7 +459,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
           const stateRoot = resolveStateRoot(withConfigPath(options.config)).stateRoot;
           const store = openRunStore({ stateRoot });
           try {
-            const report = await doctor(withConfigPath(options.config));
+            const report = await refreshDoctorReport();
             const daemonUrl = resolveDaemonUrl(stateRoot, options.daemonUrl);
             const daemonStatus =
               daemonUrl === undefined
@@ -1318,6 +1351,14 @@ function parsePositiveInt(value: string): number {
   const n = Number(value);
   if (!Number.isInteger(n) || n <= 0) {
     throw new InvalidArgumentError("must be a positive integer");
+  }
+  return n;
+}
+
+function parseNonNegativeInt(value: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new InvalidArgumentError("must be a non-negative integer");
   }
   return n;
 }

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -395,7 +395,7 @@ describe("CLI run commands", () => {
     expect(output.stdout).not.toContain("approval prompt");
   });
 
-  it("status --watch re-runs doctor on each refresh tick", async () => {
+  it("status --watch reuses doctor checks while refreshing daemon status", async () => {
     const stateRoot = await makeTempRoot();
     const resolvedStateRoot = path.join(stateRoot, ".symphonika");
     let doctorCalls = 0;
@@ -458,10 +458,74 @@ describe("CLI run commands", () => {
 
     expect(statusRequests).toBeGreaterThan(1);
     expect(openStoreCalls).toBeGreaterThan(2);
-    expect(doctorCalls).toBeGreaterThan(1);
+    expect(doctorCalls).toBe(1);
     expect(output.stdout).not.toContain("\x1b[2J");
     expect(output.stdout).toContain("\x1b[H");
     expect(output.stdout).toContain("\x1b[K");
+  });
+
+  it("status --watch can disable doctor caching with a zero TTL", async () => {
+    const stateRoot = await makeTempRoot();
+    const resolvedStateRoot = path.join(stateRoot, ".symphonika");
+    let doctorCalls = 0;
+    let openStoreCalls = 0;
+    const { program } = captureProgram(stateRoot, {
+      fetch: () =>
+        Promise.resolve(
+          Response.json({
+            issuePolling: {
+              errors: [],
+              projects: [{ fetchedIssues: 1, name: "alpha", ok: true }]
+            },
+            state: "idle",
+            stateRoot: resolvedStateRoot
+          })
+        ),
+      openRunStore: () => {
+        openStoreCalls += 1;
+        if (openStoreCalls > 2) {
+          throw new Error("stop watch");
+        }
+        return openRunStore({ stateRoot });
+      },
+      runDoctor: () => {
+        doctorCalls += 1;
+        return Promise.resolve({
+          configPath: "/tmp/symphonika.yml",
+          errors: [],
+          ok: true,
+          projects: [
+            {
+              missingOperationalLabels: [],
+              name: "alpha",
+              staleIssues: [],
+              validForDispatch: true,
+              workflowPath: "/tmp/WORKFLOW.md"
+            }
+          ]
+        } satisfies DoctorReport);
+      }
+    });
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "symphonika",
+        "status",
+        "--config",
+        path.join(stateRoot, "symphonika.yml"),
+        "--daemon-url",
+        "http://127.0.0.1:3030",
+        "--watch",
+        "--interval-ms",
+        "1",
+        "--doctor-ttl-ms",
+        "0"
+      ])
+    ).rejects.toThrow("stop watch");
+
+    expect(openStoreCalls).toBeGreaterThan(2);
+    expect(doctorCalls).toBeGreaterThan(1);
   });
 
   it("status discovers the local daemon endpoint descriptor", async () => {


### PR DESCRIPTION
Summary:
- cache full doctor validation in status --watch for 5000 ms by default while keeping daemon status and run-store refresh per frame
- add --doctor-ttl-ms with 0 as an explicit no-cache mode
- document the watch-mode cadence in SPEC.md

Tests:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #185