### PR TITLE
Fix transient retry before FSM fallback advance

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -698,6 +698,14 @@ Default continuation cap: `3`.
 
 Retry only transient infrastructure or provider failures.
 
+For raw FSM workflows, retryable transient failures consume the retry budget before non-terminal
+FSM transitions matching the failure signals are allowed to advance or park the workflow. The retry
+re-enters the same FSM state and preserves the state-advance label-immunity bit when the failed run
+was already mid-walk. Terminal `failure` / `blocked` transitions remain workflow-authored
+deterministic verdicts and pre-empt retry. After the retry budget is exhausted, the final attempt's
+signals are evaluated normally by the FSM; if no workflow transition handles them, the run follows
+the exhausted-retry failure path below.
+
 Default retry policy:
 
 - retry cap: `3`

--- a/docs/adr/0020-retry-transient-failures-only.md
+++ b/docs/adr/0020-retry-transient-failures-only.md
@@ -1,3 +1,5 @@
 # Retry transient failures only
 
 Symphonika will retry transient infrastructure and provider failures with exponential backoff, defaulting to three retries with delays around 10 seconds, 30 seconds, and 2 minutes capped at 5 minutes. Deterministic failures such as prompt rendering errors, invalid config, input-required signals, continuation caps, and workspace conflicts will not be retried automatically; they become operator-visible failures with logs and workspace state preserved.
+
+For raw FSM workflows, retryable transient failures take priority over non-terminal transitions whose predicates match the failure signals. The retry re-enters the same FSM state until the retry budget is spent. Terminal `failure` / `blocked` transitions still represent workflow-authored deterministic verdicts and are not retried; after retry exhaustion, non-terminal failure transitions are evaluated normally by the FSM.

--- a/docs/adr/0046-state-advance-vs-continuation.md
+++ b/docs/adr/0046-state-advance-vs-continuation.md
@@ -12,11 +12,20 @@ workflow rather than the length of a single workflow walk.
 Symphonika models state advancement as a distinct dispatch kind, `state_advance`, scheduled by
 `RunController.executeStateAdvance` whenever the FSM predicate engine advanced the workflow to a
 non-terminal next state for a `workflow.source.kind=raw_fsm` run. The per-state
-`ClassifiedTerminal` does **not** gate the advance: a step that exits `provider_success: true`
+`ClassifiedTerminal` does **not** gate ordinary advances: a step that exits `provider_success: true`
 without committing (a deterministic `no_workspace_changes` outcome) still advances when a
 transition matches on `provider_success: true` alone, because the state machine — not the
-classification of the per-state result — owns the "what runs next" decision. The same rule
-applies to `wait_park`. Two concrete consequences:
+classification of the per-state result — owns the "what runs next" decision.
+
+Transient provider/infrastructure failures are the narrow exception while retry budget remains. If
+a `failed` / `transient` outcome still has retry budget, Symphonika defers non-terminal FSM effects
+that match the failure signals (`state_advance` and `wait_park`) and retries the same state first.
+Terminal `failure` / `blocked` transitions still take effect immediately and synthesize a
+deterministic `workflow_terminal_*` outcome, because the workflow author has explicitly declared a
+terminal verdict. Once the retry budget is exhausted, the final attempt's signals are evaluated by
+the FSM normally, so a matching non-terminal fallback may advance the walk.
+
+The same rule applies to `wait_park`. Two concrete consequences:
 
 - `scheduleNext` evaluates the `stateAdvance` / `waitPark` branches before the failed-deterministic
   early-return. Otherwise a planning step that legitimately advances on `provider_success: true`
@@ -30,6 +39,9 @@ applies to `wait_park`. Two concrete consequences:
 State advance:
 
 - skips the continuation cap entirely (the FSM bounds the walk via terminal states);
+- yields to transient retry only while retry budget remains; the retry re-enters the same FSM state
+  and carries the same mid-walk label-immunity bit when the failed state was itself reached via
+  state advance;
 - skips the `labels_all` / `labels_none` re-check (the FSM, not the issue label set, decides the
   next state). Only the issue's open/closed state is re-verified to avoid acting on a closed issue.
   `reconcileActiveRuns` honors the same rule for in-flight state-advance runs, and `executeRetry`

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -2162,12 +2162,21 @@ export class RunController {
         advancedToTerminal: false,
         blocked: false
       };
+      // Retryable transient failures get first claim on the failed state. We
+      // still evaluate terminal workflow transitions below, because a raw FSM
+      // may intentionally map provider_success=false to terminal blocked/failure,
+      // but non-terminal advances are deferred until the retry budget is spent.
+      const deferRetryableTransientAdvance =
+        terminal.kind === "failed" &&
+        terminal.classification === "transient" &&
+        this.runStore.runRetryCount(input.runId) < this.lifecyclePolicy.retry.cap;
       // loadedWorkflow can be undefined if this.loadWorkflow itself threw
       // before currentState was set; in that case we run the bare
       // classifyFailure outcome without an FSM-driven overlay.
       if (currentState !== undefined && loadedWorkflow !== undefined) {
         workflowOutcome = this.applyWorkflowOutcome({
           currentState,
+          deferRetryableTransientAdvance,
           issue: input.issue,
           project: input.project,
           runId: input.runId,
@@ -2394,6 +2403,7 @@ export class RunController {
 
   private applyWorkflowOutcome(input: {
     currentState: ExpandedWorkflowState;
+    deferRetryableTransientAdvance?: boolean;
     issue: IssueSnapshot;
     project: RunControllerProjectConfig;
     runId: string;
@@ -2420,6 +2430,13 @@ export class RunController {
           advancedToTerminal: true,
           blocked: false,
           ...(terminalLabel === undefined ? {} : { terminalLabel })
+        };
+      }
+      if (input.deferRetryableTransientAdvance === true) {
+        return {
+          advancedToState: null,
+          advancedToTerminal: false,
+          blocked: false
         };
       }
       this.runStore.recordWorkflowStateAdvance(input.runId, {
@@ -2757,15 +2774,16 @@ export class RunController {
     }
 
     // Raw FSM mid-walk: the workflow predicate engine — not the per-state
-    // ClassifiedTerminal — decides what runs next. A step that exits
-    // provider_success=true without committing yields a deterministic
-    // `no_workspace_changes` outcome, but applyWorkflowOutcome may still have
-    // advanced the FSM (e.g. plan -> implement gated only on
-    // provider_success). Fire the FSM continuation before the failed branch
-    // so the next state runs even when the source state's per-state result
-    // classifies as failed. State advance also skips the continuation cap
-    // and the labels_all / labels_none re-check; only require that the
-    // issue is still open. See ADR 0046.
+    // ClassifiedTerminal — decides what runs next, except that retryable
+    // transient failures defer non-terminal advances before this method ever
+    // receives stateAdvance. A step that exits provider_success=true without
+    // committing still yields a deterministic `no_workspace_changes` outcome,
+    // but applyWorkflowOutcome may have advanced the FSM (e.g. plan ->
+    // implement gated only on provider_success). Fire the FSM continuation
+    // before the failed branch so the next state runs even when the source
+    // state's per-state result classifies as failed. State advance also skips
+    // the continuation cap and the labels_all / labels_none re-check; only
+    // require that the issue is still open. See ADR 0046.
     if (input.stateAdvance != null) {
       const stateAdvance = input.stateAdvance;
       const refreshedForAdvance = await this.refreshIssue({
@@ -2836,6 +2854,7 @@ export class RunController {
     // from the daemon tick's reconcileWaitingRuns pass. Sits above the failed
     // branch for the same reason as state advance: the FSM may legitimately
     // park even when the source state's per-state result classifies as failed.
+    // Retryable transient failures defer this park before waitPark is created.
     if (input.waitPark != null) {
       this.logger?.info(
         {

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1668,15 +1668,123 @@ describe("daemon dispatch", () => {
     }
   });
 
+  it("retries a transient failure before taking a non-terminal failure transition", async () => {
+    const root = await makeTempRoot();
+    await writeTransientFailureFallbackRawFsmProject(root);
+
+    const issue = issueFixture({
+      labels: ["agent-ready"],
+      number: 8,
+      title: "Dispatch an end-to-end run through a test provider"
+    });
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(issue),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([issue])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const renderedPrompts: string[] = [];
+    let providerAttempts = 0;
+    const codexProvider: AgentProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (
+        input: ProviderRunInput
+      ): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        providerAttempts += 1;
+        renderedPrompts.push(await readFile(input.promptPath, "utf8"));
+        yield {
+          normalized: {
+            exitCode: providerAttempts === 1 ? 1 : 0,
+            type: "process_exit"
+          },
+          raw: {
+            code: providerAttempts === 1 ? 1 : 0,
+            kind: "exit"
+          }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    };
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => `run-fsm-transient-retry-first-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 1, delaysMs: [5], maxBackoffMs: 10 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      await waitForSettledAttemptCount(root, 2);
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const rows = database
+          .prepare(
+            [
+              "select id, state, is_continuation, current_state_id,",
+              "terminal_state_id, retry_count from runs order by created_at"
+            ].join(" ")
+          )
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+          id: "run-fsm-transient-retry-first-1",
+          state: "succeeded",
+          is_continuation: 0,
+          current_state_id: null,
+          terminal_state_id: "done",
+          retry_count: 1
+        });
+
+        const attempts = database
+          .prepare(
+            "select run_id, attempt_number from attempts order by created_at"
+          )
+          .all() as Array<Record<string, unknown>>;
+        expect(attempts).toMatchObject([
+          { run_id: "run-fsm-transient-retry-first-1", attempt_number: 1 },
+          { run_id: "run-fsm-transient-retry-first-1", attempt_number: 2 }
+        ]);
+      } finally {
+        database.close();
+      }
+
+      expect(renderedPrompts).toHaveLength(2);
+      expect(renderedPrompts[0]).toContain("Draft a plan");
+      expect(renderedPrompts[1]).toContain("Draft a plan");
+      expect(renderedPrompts[0]).not.toContain("Recover");
+      expect(renderedPrompts[1]).not.toContain("Recover");
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   // Regression: when a transient per-state failure has retry budget
   // (`willRetry === true`), `applyTerminalLabels` does NOT add `sym:failed`
-  // — the retry path is supposed to handle the run. If the `stateAdvance`
-  // branch then bails on `refreshIssue`, the rollback must NOT add
-  // `sym:failed` (no suppression happened to undo) and must let control
-  // fall through so the failed-transient branch can schedule the retry.
-  // Without this distinction the bail-out path would over-mark the issue
-  // failed AND swallow the retry, breaking the transient-failure contract.
-  it("does not add sym:failed and lets the retry fire when state-advance bails on willRetry=true", async () => {
+  // — the retry path is supposed to handle the run. Even if the failure's
+  // signals match a non-terminal fallback transition, that advance is deferred
+  // until the retry budget is spent, so the issue must not be marked failed
+  // while the retry is still pending.
+  it("does not add sym:failed while a retryable transient fallback waits for retry", async () => {
     const root = await makeTempRoot();
     // Reuse the input_required-fallback workflow: planning's only fallback
     // is `to: error_handler` (no `when:`), so a transient failure with
@@ -1757,20 +1865,13 @@ describe("daemon dispatch", () => {
         }
         await new Promise((resolve) => setTimeout(resolve, 20));
       }
-      // Give the bail-path's markIssueFailed (if any) and the
-      // scheduleNext fall-through to the failed branch (which schedules
-      // a retry) time to settle.
+      // Give the deferred-advance path and retry scheduling time to settle.
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // The attempt ran exactly once because executeRetry's refreshIssue
       // also throws (same mock), so the retry was scheduled but dropped.
-      // The fact that a retry was scheduled at all is what this test
-      // verifies indirectly: with willRetry=true, the stateAdvance bail
-      // path must NOT add `sym:failed` (applyTerminalLabels already
-      // skipped it on the same `!willRetry` short-circuit) and must let
-      // control fall through to the failed-transient branch. Without the
-      // gate this assertion would be `1` (the bail-out wrongly added
-      // sym:failed even though the run is supposed to retry).
+      // The lack of `sym:failed` verifies that the non-terminal fallback did
+      // not convert the retryable transient into a visible issue failure.
       expect(attempts).toBeGreaterThanOrEqual(1);
       const failedLabelAdds = githubIssuesApi.addLabelsToIssue.mock.calls.filter(
         (call: unknown[]) => {
@@ -3558,6 +3659,58 @@ async function writeInputRequiredFallbackRawFsmProject(
   );
 }
 
+async function writeTransientFailureFallbackRawFsmProject(
+  root: string
+): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: transient_failure_fallback",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      transitions:",
+      "        - to: done",
+      "          when:",
+      "            provider_success: true",
+      "        - to: error_handler",
+      "          when:",
+      "            provider_success: false",
+      "    error_handler:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: error-prompt.md",
+      "      transitions:",
+      "        - to: recovered",
+      "          when:",
+      "            provider_success: true",
+      "        - to: failed",
+      "    done:",
+      "      terminal: success",
+      "    recovered:",
+      "      terminal: success",
+      "    failed:",
+      "      terminal: blocked",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Draft a plan for #{{issue.number}}: {{issue.title}}.\n"
+  );
+  await writeFile(
+    path.join(root, "error-prompt.md"),
+    "Recover #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
 async function writePerStateProviderRawFsmProject(root: string): Promise<void> {
   await writeRawFsmProjectConfig(root);
   await writeProviderRoutingWorkflow(root, "claude");
@@ -3878,6 +4031,48 @@ async function waitForStoredRunState(
   }
 
   throw new Error(`run did not reach state ${state}`);
+}
+
+async function waitForSettledAttemptCount(
+  root: string,
+  expectedAttempts: number,
+  options: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const intervalMs = options.intervalMs ?? 20;
+  const deadline = Date.now() + timeoutMs;
+  const databaseFile = path.join(root, ".symphonika", "symphonika.db");
+
+  while (Date.now() < deadline) {
+    try {
+      const database = new Database(databaseFile, { readonly: true });
+      try {
+        const row = database
+          .prepare(
+            [
+              "select count(*) as attempts,",
+              "sum(case when state = 'running' then 1 else 0 end) as running",
+              "from attempts"
+            ].join(" ")
+          )
+          .get() as { attempts: number; running: number | null };
+        if (
+          row.attempts >= expectedAttempts &&
+          (row.running === null || row.running === 0)
+        ) {
+          return;
+        }
+      } finally {
+        database.close();
+      }
+    } catch {
+      // The daemon may still be starting and creating its SQLite store.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`expected ${expectedAttempts} settled attempts before timeout`);
 }
 
 async function waitForStatusError(


### PR DESCRIPTION
Summary:
- defer non-terminal raw-FSM advances and wait parks while a transient provider failure still has retry budget
- preserve immediate workflow terminal failure/blocked handling and document the retry-vs-FSM contract
- add a daemon-level regression for provider_success:false fallback transitions retrying the same state first

Validation:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #184