### PR TITLE
Add one-shot report routines

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,6 +117,15 @@ _Avoid_: event log when referring to scheduler state
 One orchestrator-managed execution lifecycle for one issue in one workspace.
 _Avoid_: issue when referring to execution status
 
+**Routine**:
+A project-owned scheduled prompt declaration that can launch a Coding Agent without a GitHub Issue.
+_Avoid_: workflow contract when referring to recurring or one-shot scheduled work
+
+**Routine Firing**:
+One durable execution attempt of a Routine, with its own workspace, provider logs, prompt evidence,
+and lifecycle state.
+_Avoid_: run when specifically referring to non-issue scheduled execution
+
 **Run Lifecycle**:
 The stateful progression of one Run from dispatch selection through provider execution, scheduling,
 waiting, cancellation, or terminal labels.
@@ -189,6 +198,8 @@ _Avoid_: chat session
 - A **Normalized Event Log** is derived from a **Provider Event Log**
 - A **Run Store** records durable orchestration state across process restarts
 - A **Run** can succeed even when its **Issue** remains open
+- A **Routine** belongs to one **Project** and may create zero or more **Routine Firings**
+- A **Routine Firing** consumes the same Project/global in-flight capacity as issue **Runs**
 - A **Run Lifecycle** consumes **Lifecycle Events** and chooses **Planned Steps**
 - A **Continuation** is capped so an eligible issue cannot loop forever
 - A **State Advance** is not capped by the continuation cap; the FSM bounds the walk via terminal states

--- a/SPEC.md
+++ b/SPEC.md
@@ -292,16 +292,6 @@ Agent Provider. If an agent state omits `action.provider`, Symphonika uses the P
 
 The daemon must not dispatch a Project when its workflow contract is missing or invalid.
 
-### 5.4 Routine Declarations
-
-Projects may define `routines: string[]` in `symphonika.yml`. Paths are resolved relative to the
-service config directory and are re-read on every daemon tick with the rest of the runtime snapshot.
-Invalid routine declarations are reported through the same reload-error surface as invalid workflow
-contracts, and the daemon keeps using the last known good snapshot.
-
-Slice 1 supports only one-shot `schedule.at` routines. Cron and any second schedule field are
-invalid in this slice.
-
 ### 5.3 Templating
 
 Workflow prompt rendering uses simple strict Mustache-style variables. Unknown variables fail prompt
@@ -340,6 +330,16 @@ The preamble tells the agent:
 - it should preserve evidence when blocked
 - it should use the prepared workspace and issue branch
 - it should operate on the assigned issue unless the workflow says otherwise
+
+### 5.4 Routine Declarations
+
+Projects may define `routines: string[]` in `symphonika.yml`. Paths are resolved relative to the
+service config directory and are re-read on every daemon tick with the rest of the runtime snapshot.
+Invalid routine declarations are reported through the same reload-error surface as invalid workflow
+contracts, and the daemon keeps using the last known good snapshot.
+
+Slice 1 supports only one-shot `schedule.at` routines. Cron and any second schedule field are
+invalid in this slice.
 
 ## 6. Credentials
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -166,6 +166,26 @@ Symphonika stores both:
 - Provider Event Log: raw provider protocol stream for the run
 - Normalized Event Log: provider-neutral events used by the orchestrator, UI, tests, and debugging
 
+### 4.12 Routine
+
+A Routine is a Project-owned scheduled prompt declaration. Slice 1 supports hand-authored Markdown
+routine files with YAML front matter:
+
+- `name`
+- `schedule.at`
+- `kind: report`
+- optional `provider`
+
+The Markdown body is the routine prompt template. `name` must be safe as a single workspace path
+segment because routine firing workspaces live under `<workspace.root>/routines/<name>/<firing-id>/`.
+
+### 4.13 Routine Firing
+
+A Routine Firing is one durable execution of a Routine. It records the Routine, Project, provider,
+workspace path, prompt evidence, provider logs, terminal reason, and lifecycle state. Slice 1
+supports one-shot `schedule.at` routines only; after the first firing is created, the Routine becomes
+`expired` and must not fire again on daemon restart.
+
 ## 5. Config Files
 
 ### 5.1 Service Config
@@ -244,6 +264,8 @@ projects:
     agent:
       provider: codex
     workflow: ./WORKFLOW.md
+    routines:
+      - ./daily-report.md
 ```
 
 The bootstrap slice must use this final multi-project shape even with one configured Project.
@@ -270,6 +292,16 @@ Agent Provider. If an agent state omits `action.provider`, Symphonika uses the P
 
 The daemon must not dispatch a Project when its workflow contract is missing or invalid.
 
+### 5.4 Routine Declarations
+
+Projects may define `routines: string[]` in `symphonika.yml`. Paths are resolved relative to the
+service config directory and are re-read on every daemon tick with the rest of the runtime snapshot.
+Invalid routine declarations are reported through the same reload-error surface as invalid workflow
+contracts, and the daemon keeps using the last known good snapshot.
+
+Slice 1 supports only one-shot `schedule.at` routines. Cron and any second schedule field are
+invalid in this slice.
+
 ### 5.3 Templating
 
 Workflow prompt rendering uses simple strict Mustache-style variables. Unknown variables fail prompt
@@ -285,6 +317,18 @@ Available top-level objects:
 - `provider`
 
 Symphonika prepends a standard autonomy preamble to every rendered workflow prompt.
+
+Routine prompt rendering uses the same strict templating rules and the same standard autonomy
+preamble. For `kind: report`, available top-level objects are:
+
+- `project`
+- `workspace`
+- `provider`
+- `routine`
+- `firing`
+
+`issue`, `run`, and `branch` are unavailable to routine prompts. Referencing any of them fails
+rendering with terminal reason `prompt_render_error`.
 
 The preamble tells the agent:
 
@@ -349,6 +393,8 @@ SQLite stores durable orchestration state:
 - workspace paths
 - normalized event metadata
 - raw log file paths
+- routines
+- routine firings
 
 The run store is not a replacement for GitHub as the canonical tracker. It is durable runtime
 evidence and restart state.
@@ -427,6 +473,7 @@ The daemon owns:
 - retries and continuations
 - PR follow-up polling for Symphonika-owned PRs
 - local UI/API
+- routine schedule evaluation and firing dispatch
 
 ### 8.2 Startup Sequence
 
@@ -468,6 +515,25 @@ Invalid Projects are disabled. Valid Projects may continue running.
 
 Existing runs continue by default. Removing a Project from service config marks it inactive rather
 than killing active full-permission agents. Operators can explicitly cancel runs.
+
+### 8.5 Routines
+
+On each daemon tick, Symphonika evaluates loaded active Routines. Slice 1's `ScheduleEvaluator`
+supports one-shot `schedule.at` only:
+
+- `wait_until` when `now < at`
+- `fire_now` when `now >= at` and the Routine has not fired
+- `expired` after a firing exists or the Routine state is `expired`
+
+When a Routine fires, Symphonika allocates a ULID firing id, prepares a workspace at
+`<workspace.root>/routines/<routine-name>/<firing-id>/` on the Project base branch, renders the
+routine prompt, runs the configured provider, records a `routine_firings` row, and marks the
+Routine `expired`. Routine Firings use states `queued`, `preparing_workspace`, `running`,
+`succeeded`, `failed`, and `cancelled`.
+
+Routine Firings consume the same per-Project and global `max_in_flight` slots as issue Runs. If a
+cap is already full when a Routine is due, the daemon skips that fire for this slice and logs the
+skip; no firing row is written.
 
 ## 9. GitHub Tracker Behavior
 
@@ -556,6 +622,9 @@ Recommended layout:
     repo.git
   issues/
     <issue-number>-<slug>/
+  routines/
+    <routine-name>/
+      <firing-id>/
 ```
 
 First attempt:
@@ -857,6 +926,7 @@ Bootstrap CLI commands:
 - `symphonika status [--config <path>] [--dashboard] [--watch] [--interval-ms <ms>] [--doctor-ttl-ms <ms>]`
 - `symphonika poll-now [--config <path>]`
 - `symphonika runs [--config <path>]`
+- `symphonika routines [--config <path>]`
 - `symphonika show-run <run-id> [--config <path>]`
 - `symphonika cancel <run-id> [--config <path>]`
 - `symphonika clear-stale <project> <issue-number> [--config <path>] --yes`
@@ -886,6 +956,8 @@ frame, but caches the full `doctor` validation path for 5000 ms by default so pa
 not continuously re-run provider probes or GitHub validation reads. `--doctor-ttl-ms 0` disables that
 cache when an operator explicitly wants every frame to perform full validation.
 
+`routines` lists routine status per Project with `state`, `next_fire_at`, and `last_fired_at`.
+
 `clear-stale` removes `sym:stale`, `sym:claimed`, and `sym:running` only after explicit confirmation.
 
 ## 14. Local Web UI and API
@@ -904,9 +976,13 @@ The UI is primarily read-only. It shows:
 - raw log links or content
 - rendered prompt links
 - retry and continuation state
+- routines with `state`, `next_fire_at`, and `last_fired_at`
 
 The v1 mutating web actions are explicit active-run cancellation and a manual poll-now trigger that
 uses the normal daemon scheduler path.
+
+The HTTP API exposes `GET /api/routines` with the same routine status shape as the CLI and
+dashboard.
 
 Label creation, stale-claim reset, and workspace cleanup remain CLI-only.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -487,6 +487,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
                 latestEvents: collectLatestDashboardEvents(store, all),
                 projects: report.projects,
                 reload: formatReloadOutcome(daemonStatus),
+                routines: store.listRoutines(),
                 runs: all,
                 stateRoot
               });
@@ -664,6 +665,40 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         }
       }
     );
+
+  program
+    .command("routines")
+    .description("list routines from the run store")
+    .option("--config <path>", "service config path")
+    .option("--project <project>", "filter by project name")
+    .action((options: { config?: string; project?: string }) => {
+      const stateRoot = resolveStateRoot(withConfigPath(options.config)).stateRoot;
+      const store = openRunStore({ stateRoot });
+      try {
+        const routines = store.listRoutines(
+          options.project === undefined ? {} : { project: options.project }
+        );
+        if (routines.length === 0) {
+          writeOut(program, "(no routines)\n");
+          return;
+        }
+        writeOut(program, "project  routine  state  next_fire_at  last_fired_at\n");
+        for (const routine of routines) {
+          writeOut(
+            program,
+            [
+              routine.projectName,
+              routine.name,
+              routine.state,
+              routine.nextFireAt ?? "-",
+              routine.lastFiredAt ?? "-"
+            ].join("  ") + "\n"
+          );
+        }
+      } finally {
+        store.close();
+      }
+    });
 
   program
     .command("show-run")

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -48,6 +48,11 @@ import {
   type RunState,
   type SyncProjectStateInput
 } from "./run-store.js";
+import { dispatchDueRoutines } from "./routines/dispatcher.js";
+import type {
+  PreparedRoutineWorkspace,
+  PrepareRoutineWorkspaceInput
+} from "./routines/workspace.js";
 import { resolveStateRoot } from "./state.js";
 import { buildStatusSnapshot } from "./status.js";
 import { VERSION } from "./version.js";
@@ -71,6 +76,10 @@ export type StartDaemonOptions = {
   prepareIssueWorkspace?: (
     input: PrepareIssueWorkspaceInput
   ) => Promise<PreparedIssueWorkspace>;
+  createRoutineFiringId?: () => string;
+  prepareRoutineWorkspace?: (
+    input: PrepareRoutineWorkspaceInput
+  ) => Promise<PreparedRoutineWorkspace>;
 };
 
 export type DaemonHandle = {
@@ -415,6 +424,30 @@ export async function startDaemon(
         }
         if (prResult.action === "review_dispatch" || prResult.action === "merged") {
           logger.info(prResult, "symphonika PR follow-up action completed");
+          return;
+        }
+        const routineResult = await dispatchDueRoutines({
+          activeRuns,
+          agentProviders,
+          configDir: state.configDir,
+          ...(options.createRoutineFiringId === undefined
+            ? {}
+            : { createFiringId: options.createRoutineFiringId }),
+          globalConcurrency: runtimeConfig.globalConcurrency(),
+          logger,
+          ...(options.prepareRoutineWorkspace === undefined
+            ? {}
+            : { prepareRoutineWorkspace: options.prepareRoutineWorkspace }),
+          projects: runtimeConfig.projectsByName(),
+          providersConfig: runtimeConfig.providersConfig(),
+          runStore,
+          stateRoot: state.stateRoot
+        });
+        if (routineResult.fired.length > 0) {
+          logger.info(
+            { fired: routineResult.fired.length },
+            "symphonika routine firing action completed"
+          );
           return;
         }
         const result = await runController.dispatchOneFresh(issuePollStatus);
@@ -819,4 +852,3 @@ const PR_FOLLOWUP_MIN_INTERVAL_MS = 1_000;
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -157,6 +157,7 @@ export function createHttpApp(options: HttpAppOptions): Hono {
       },
       projectStates: runStore?.listProjectStates() ?? [],
       reload: options.getReloadStatus?.() ?? emptyReloadStatus(),
+      routines: runStore?.listRoutines() ?? [],
       runs: getRuns(),
       scheduled: getScheduled(),
       service: "symphonika",
@@ -205,6 +206,15 @@ export function createHttpApp(options: HttpAppOptions): Hono {
         filter.limit = limit;
       }
       return context.json({ runs: runStore.listRuns(filter) });
+    });
+
+    app.get("/api/routines", (context) => {
+      const project = context.req.query("project");
+      return context.json({
+        routines: runStore.listRoutines(
+          project === undefined ? {} : { project }
+        )
+      });
     });
 
     app.get("/api/runs/:id", (context) => {

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -16,6 +16,7 @@ import type {
   RunStatus,
   RunStore
 } from "../run-store.js";
+import type { RoutineStatus } from "../routines/types.js";
 import type { StatusSnapshot } from "../status.js";
 import type { ExpandedWorkflow } from "../workflow.js";
 
@@ -55,6 +56,7 @@ export function registerPages(options: RegisterPagesOptions): void {
       [
         renderHeader(options.version, snapshot),
         renderProjectsCard(snapshot, options.issuePollStatus),
+        renderRoutinesTable(options.runStore.listRoutines()),
         renderStaleIssuesCard(options.issuePollStatus?.filteredIssues ?? []),
         renderRunsTable("Recent runs", recentRuns)
       ].join("")
@@ -265,6 +267,21 @@ function renderStaleIssuesCard(
     .join("");
   return `<section><h2>Stale issues</h2>
 <table><thead><tr><th>Project</th><th>Issue</th><th>Reason</th></tr></thead>
+<tbody>${rows}</tbody></table></section>`;
+}
+
+function renderRoutinesTable(routines: RoutineStatus[]): string {
+  if (routines.length === 0) {
+    return "";
+  }
+  const rows = routines
+    .map(
+      (routine) =>
+        `<tr><td>${escapeHtml(routine.projectName)}</td><td>${escapeHtml(routine.name)}</td><td>${escapeHtml(routine.state)}</td><td>${escapeHtml(routine.nextFireAt ?? "-")}</td><td>${escapeHtml(routine.lastFiredAt ?? "-")}</td></tr>`
+    )
+    .join("");
+  return `<section><h2>Routines</h2>
+<table><thead><tr><th>Project</th><th>Routine</th><th>State</th><th>next_fire_at</th><th>last_fired_at</th></tr></thead>
 <tbody>${rows}</tbody></table></section>`;
 }
 

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -42,6 +42,7 @@ import { prepareIssueWorkspace as defaultPrepareIssueWorkspace } from "../worksp
 import { readFile } from "node:fs/promises";
 
 import type { WorkflowReference } from "../config-schemas.js";
+import type { RoutineDeclaration } from "../routines/types.js";
 import {
   expandWorkflowDefinition,
   parseWorkflowContract,
@@ -89,6 +90,7 @@ type LoadedWorkflow = {
 };
 
 export type RunControllerProjectConfig = PollingProjectConfig & {
+  routines?: RoutineDeclaration[];
   workflow: WorkflowReference | WorkflowSnapshot;
   workspace: {
     git: {

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import type { WorkflowFormat } from "./config-schemas.js";
 import {
   projectWorkspaceSchema,
+  pathStringSchema,
   workflowReferenceSchema
 } from "./config-schemas.js";
 import type {
@@ -30,6 +31,8 @@ import {
   parseWorkflowContract,
   validateExpandedWorkflowReferences
 } from "./workflow.js";
+import { loadRoutineDeclaration } from "./routines/declaration-loader.js";
+import type { RoutineDeclaration } from "./routines/types.js";
 
 export type RuntimeConfigSnapshot = {
   configPath: string;
@@ -104,6 +107,7 @@ const pollingProjectSchema = z
 const runtimeProjectDetailSchema = z
   .object({
     name: z.string().trim().min(1),
+    routines: z.array(pathStringSchema).optional(),
     workspace: projectWorkspaceSchema,
     workflow: workflowReferenceSchema
   })
@@ -283,9 +287,20 @@ async function loadRuntimeConfigSnapshot(input: {
       continue;
     }
 
+    const routines = await readRoutineDeclarations(
+      (detail.data.routines ?? []).map((routinePath) =>
+        path.resolve(input.configDir, routinePath)
+      ),
+      errors
+    );
+    if (routines === undefined) {
+      return lastKnownGoodOrNothing(input.previous, errors);
+    }
+
     if (pollingProject.data.disabled === true) {
       dispatchProjects.push({
         ...pollingProject.data,
+        routines,
         workflow: detail.data.workflow,
         workspace: detail.data.workspace
       });
@@ -302,6 +317,7 @@ async function loadRuntimeConfigSnapshot(input: {
     }
     dispatchProjects.push({
       ...pollingProject.data,
+      routines,
       workflow,
       workspace: detail.data.workspace
     });
@@ -415,6 +431,23 @@ async function readWorkflowSnapshot(
     format,
     path: workflow.path
   };
+}
+
+async function readRoutineDeclarations(
+  routinePaths: string[],
+  errors: string[]
+): Promise<RoutineDeclaration[] | undefined> {
+  const routines: RoutineDeclaration[] = [];
+  const startingErrorCount = errors.length;
+  for (const routinePath of routinePaths) {
+    const result = await loadRoutineDeclaration(routinePath);
+    if (result.routine === null) {
+      errors.push(...result.errors);
+      continue;
+    }
+    routines.push(result.routine);
+  }
+  return errors.length > startingErrorCount ? undefined : routines;
 }
 
 function lastKnownGoodOrNothing(

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -287,6 +287,16 @@ async function loadRuntimeConfigSnapshot(input: {
       continue;
     }
 
+    if (pollingProject.data.disabled === true) {
+      dispatchProjects.push({
+        ...pollingProject.data,
+        routines: [],
+        workflow: detail.data.workflow,
+        workspace: detail.data.workspace
+      });
+      continue;
+    }
+
     const routines = await readRoutineDeclarations(
       (detail.data.routines ?? []).map((routinePath) =>
         path.resolve(input.configDir, routinePath)
@@ -295,16 +305,6 @@ async function loadRuntimeConfigSnapshot(input: {
     );
     if (routines === undefined) {
       return lastKnownGoodOrNothing(input.previous, errors);
-    }
-
-    if (pollingProject.data.disabled === true) {
-      dispatchProjects.push({
-        ...pollingProject.data,
-        routines,
-        workflow: detail.data.workflow,
-        workspace: detail.data.workspace
-      });
-      continue;
     }
 
     const workflow = await readWorkflowSnapshot(
@@ -439,12 +439,21 @@ async function readRoutineDeclarations(
 ): Promise<RoutineDeclaration[] | undefined> {
   const routines: RoutineDeclaration[] = [];
   const startingErrorCount = errors.length;
+  const seenNames = new Map<string, string>();
   for (const routinePath of routinePaths) {
     const result = await loadRoutineDeclaration(routinePath);
     if (result.routine === null) {
       errors.push(...result.errors);
       continue;
     }
+    const existing = seenNames.get(result.routine.name);
+    if (existing !== undefined) {
+      errors.push(
+        `duplicate routine name "${result.routine.name}" declared by ${existing} and ${result.routine.sourcePath}`
+      );
+      continue;
+    }
+    seenNames.set(result.routine.name, result.routine.sourcePath);
     routines.push(result.routine);
   }
   return errors.length > startingErrorCount ? undefined : routines;

--- a/src/routines/declaration-loader.ts
+++ b/src/routines/declaration-loader.ts
@@ -1,0 +1,195 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { parse } from "yaml";
+
+import type { AgentProviderName } from "../provider.js";
+import type { RoutineDeclaration, RoutineKind } from "./types.js";
+
+export type RoutineDeclarationLoadResult = {
+  errors: string[];
+  routine: RoutineDeclaration | null;
+};
+
+const providerNames = new Set(["codex", "claude"]);
+const routineKinds = new Set(["report"]);
+
+export async function loadRoutineDeclaration(
+  routinePath: string
+): Promise<RoutineDeclarationLoadResult> {
+  const absolutePath = path.resolve(routinePath);
+  let contents: string;
+  try {
+    contents = await readFile(absolutePath, "utf8");
+  } catch (error) {
+    return {
+      errors: [`routine declaration not found at ${absolutePath}: ${errorMessage(error)}`],
+      routine: null
+    };
+  }
+
+  return parseRoutineDeclaration(contents, absolutePath);
+}
+
+export function parseRoutineDeclaration(
+  contents: string,
+  routinePath: string
+): RoutineDeclarationLoadResult {
+  const lines = contents.split(/\r?\n/);
+  const errors: string[] = [];
+
+  if (lines[0]?.trim() !== "---") {
+    return {
+      errors: [`routine at ${routinePath} must start with YAML front matter`],
+      routine: null
+    };
+  }
+
+  const closingLine = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === "---"
+  );
+  if (closingLine === -1) {
+    return {
+      errors: [`routine front matter at ${routinePath} is missing a closing ---`],
+      routine: null
+    };
+  }
+
+  const frontMatter = parseFrontMatter(
+    lines.slice(1, closingLine).join("\n"),
+    routinePath,
+    errors
+  );
+  const prompt = lines.slice(closingLine + 1).join("\n");
+
+  if (frontMatter === null) {
+    return { errors, routine: null };
+  }
+
+  const name = stringField(frontMatter, "name");
+  if (name === undefined) {
+    errors.push(`routine at ${routinePath} name is required`);
+  } else if (!isPathSafeRoutineName(name)) {
+    errors.push(`routine at ${routinePath} name "${name}" is not path-safe`);
+  }
+
+  const kind = stringField(frontMatter, "kind");
+  if (kind === undefined) {
+    errors.push(`routine at ${routinePath} kind is required`);
+  } else if (!routineKinds.has(kind)) {
+    errors.push(`routine at ${routinePath} kind must be report`);
+  }
+
+  const providerValue = stringField(frontMatter, "provider");
+  let provider: AgentProviderName | null = null;
+  if (providerValue !== undefined) {
+    if (!providerNames.has(providerValue)) {
+      errors.push(`routine at ${routinePath} provider must be codex or claude`);
+    } else {
+      provider = providerValue as AgentProviderName;
+    }
+  }
+
+  const schedule = recordField(frontMatter, "schedule");
+  const at = schedule === undefined ? undefined : dateStringField(schedule, "at");
+  if (schedule === undefined || at === undefined) {
+    errors.push(`routine at ${routinePath} schedule.at is required`);
+  } else if (Number.isNaN(new Date(at).getTime())) {
+    errors.push(`routine at ${routinePath} schedule.at must be a valid ISO 8601 date`);
+  }
+  if (schedule !== undefined) {
+    const scheduleKeys = Object.keys(schedule);
+    if (scheduleKeys.length !== 1 || scheduleKeys[0] !== "at") {
+      errors.push(
+        `routine at ${routinePath} schedule must define only one schedule field; supported in this slice: at`
+      );
+    }
+  }
+
+  if (prompt.trim().length === 0) {
+    errors.push(`routine at ${routinePath} prompt body must not be empty`);
+  }
+
+  if (errors.length > 0) {
+    return { errors, routine: null };
+  }
+
+  return {
+    errors: [],
+    routine: {
+      kind: kind as RoutineKind,
+      name: name!,
+      prompt,
+      provider,
+      schedule: { at: at! },
+      sourcePath: routinePath
+    }
+  };
+}
+
+function parseFrontMatter(
+  source: string,
+  routinePath: string,
+  errors: string[]
+): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = parse(source) ?? {};
+  } catch (error) {
+    errors.push(
+      `routine front matter at ${routinePath} could not be parsed: ${errorMessage(error)}`
+    );
+    return null;
+  }
+  if (!isRecord(parsed)) {
+    errors.push(`routine front matter at ${routinePath} must be a mapping`);
+    return null;
+  }
+  return parsed;
+}
+
+function isPathSafeRoutineName(name: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(name) && name !== "." && name !== "..";
+}
+
+function recordField(
+  record: Record<string, unknown>,
+  key: string
+): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function stringField(
+  record: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function dateStringField(
+  record: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = record[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    const trimmed = value.trim();
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? trimmed : parsed.toISOString();
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? "" : value.toISOString();
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/routines/declaration-loader.ts
+++ b/src/routines/declaration-loader.ts
@@ -187,7 +187,7 @@ function dateStringField(
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function errorMessage(error: unknown): string {

--- a/src/routines/dispatcher.ts
+++ b/src/routines/dispatcher.ts
@@ -1,0 +1,467 @@
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { Logger } from "pino";
+
+import type { ActiveRunRegistry } from "../lifecycle/active-runs.js";
+import type {
+  AgentProviderName,
+  AgentProviderRegistry,
+  NormalizedProviderEvent,
+  ProviderEvent
+} from "../provider.js";
+import type {
+  RunControllerProjectConfig,
+  RunControllerProvidersConfig
+} from "../lifecycle/run-controller.js";
+import type { RunStore } from "../run-store.js";
+import { evaluateRoutineSchedule } from "./schedule.js";
+import {
+  renderRoutinePrompt,
+  RoutinePromptRenderError
+} from "./prompt-renderer.js";
+import type { RoutineStatus } from "./types.js";
+import { createUlid } from "./ulid.js";
+import {
+  prepareRoutineWorkspace as defaultPrepareRoutineWorkspace,
+  type PreparedRoutineWorkspace,
+  type PrepareRoutineWorkspaceInput
+} from "./workspace.js";
+
+export type DispatchDueRoutinesInput = {
+  activeRuns: ActiveRunRegistry;
+  agentProviders: AgentProviderRegistry;
+  configDir: string;
+  createFiringId?: () => string;
+  globalConcurrency: { maxInFlight: number | undefined };
+  logger?: Logger;
+  now?: Date;
+  prepareRoutineWorkspace?: (
+    input: PrepareRoutineWorkspaceInput
+  ) => Promise<PreparedRoutineWorkspace>;
+  projects: Map<string, RunControllerProjectConfig>;
+  providersConfig: RunControllerProvidersConfig;
+  runStore: RunStore;
+  stateRoot: string;
+};
+
+export type DispatchDueRoutinesResult = {
+  fired: string[];
+  skipped: Array<{ reason: string; routineName: string; projectName: string }>;
+};
+
+type RoutineTerminalOutcome =
+  | { kind: "cancelled"; reason: string }
+  | { kind: "failed"; reason: string }
+  | { kind: "succeeded"; reason: string };
+
+export async function dispatchDueRoutines(
+  input: DispatchDueRoutinesInput
+): Promise<DispatchDueRoutinesResult> {
+  const fired: string[] = [];
+  const skipped: DispatchDueRoutinesResult["skipped"] = [];
+  const now = input.now ?? new Date();
+  const prepareRoutineWorkspace =
+    input.prepareRoutineWorkspace ?? defaultPrepareRoutineWorkspace;
+  const createFiringId = input.createFiringId ?? (() => createUlid());
+
+  for (const project of input.projects.values()) {
+    input.runStore.syncRoutines(project.name, project.routines ?? []);
+    if (project.disabled === true) {
+      continue;
+    }
+    for (const routine of input.runStore.listRoutines({ project: project.name })) {
+      const evaluation = evaluateRoutineSchedule({
+        lastFiredAt: routine.lastFiredAt,
+        now,
+        schedule: { at: routine.scheduleAt },
+        state: routine.state
+      });
+      if (evaluation.kind !== "fire_now") {
+        continue;
+      }
+      const providerName = routine.provider ?? project.agent.provider;
+      const provider = input.agentProviders[providerName];
+      const providerCommand = input.providersConfig[providerName].command;
+      if (provider === undefined) {
+        skipped.push({
+          projectName: project.name,
+          reason: `provider_not_registered: ${providerName}`,
+          routineName: routine.name
+        });
+        continue;
+      }
+      const capReason = capSkipReason(input.activeRuns, input.globalConcurrency, project);
+      if (capReason !== null) {
+        input.logger?.info(
+          { project: project.name, reason: capReason, routine: routine.name },
+          "symphonika routine firing skipped by concurrency cap"
+        );
+        skipped.push({
+          projectName: project.name,
+          reason: capReason,
+          routineName: routine.name
+        });
+        continue;
+      }
+
+      const routineDetail = input.runStore.getRoutine({
+        name: routine.name,
+        projectName: project.name
+      });
+      if (routineDetail === undefined) {
+        skipped.push({
+          projectName: project.name,
+          reason: "routine disappeared before firing",
+          routineName: routine.name
+        });
+        continue;
+      }
+
+      const firingId = createFiringId();
+      input.activeRuns.reserveSlot({
+        issueNumber: syntheticRoutineIssueNumber(firingId),
+        projectName: project.name,
+        respectsIssueLabels: false,
+        runId: firingId
+      });
+      input.runStore.createRoutineFiring({
+        id: firingId,
+        projectName: project.name,
+        providerCommand,
+        providerName,
+        routineName: routine.name
+      });
+      input.runStore.markRoutineExpired({
+        firedAt: now.toISOString(),
+        name: routine.name,
+        projectName: project.name
+      });
+      fired.push(firingId);
+
+      try {
+        await runRoutineFiring({
+          firingId,
+          prepareRoutineWorkspace,
+          project,
+          provider,
+          providerCommand,
+          providerName,
+          routine: routineDetail,
+          runStore: input.runStore,
+          stateRoot: input.stateRoot,
+          configDir: input.configDir,
+          activeRuns: input.activeRuns
+        });
+      } finally {
+        input.activeRuns.unregister(firingId);
+      }
+    }
+  }
+
+  return { fired, skipped };
+}
+
+async function runRoutineFiring(input: {
+  activeRuns: ActiveRunRegistry;
+  configDir: string;
+  firingId: string;
+  prepareRoutineWorkspace: (
+    input: PrepareRoutineWorkspaceInput
+  ) => Promise<PreparedRoutineWorkspace>;
+  project: RunControllerProjectConfig;
+  provider: NonNullable<AgentProviderRegistry[AgentProviderName]>;
+  providerCommand: string;
+  providerName: AgentProviderName;
+  routine: RoutineStatus & { prompt: string };
+  runStore: RunStore;
+  stateRoot: string;
+}): Promise<void> {
+  const events: NormalizedProviderEvent[] = [];
+  let prepared: PreparedRoutineWorkspace | undefined;
+  let rawLogPath: string | undefined;
+  let normalizedLogPath: string | undefined;
+  try {
+    input.runStore.updateRoutineFiringState(input.firingId, "preparing_workspace");
+    prepared = await input.prepareRoutineWorkspace({
+      configDir: input.configDir,
+      firingId: input.firingId,
+      project: input.project,
+      routineName: input.routine.name
+    });
+    const evidence = await prepareRoutineEvidence({
+      configDir: input.configDir,
+      firingId: input.firingId,
+      prepared,
+      project: input.project,
+      providerCommand: input.providerCommand,
+      providerName: input.providerName,
+      routine: input.routine,
+      stateRoot: input.stateRoot
+    });
+    rawLogPath = evidence.rawLogPath;
+    normalizedLogPath = evidence.normalizedLogPath;
+    input.runStore.updateRoutineFiringWorkspace({
+      id: input.firingId,
+      normalizedLogPath,
+      promptPath: evidence.promptPath,
+      rawLogPath,
+      workspacePath: prepared.workspacePath
+    });
+    await input.provider.validate(input.providerCommand);
+    input.runStore.updateRoutineFiringState(input.firingId, "running");
+    input.activeRuns.attachProvider(input.firingId, {
+      cancel: () => input.provider.cancel(input.firingId),
+      provider: input.provider,
+      respectsIssueLabels: false
+    });
+
+    for await (const event of input.provider.runAttempt({
+      branchName: prepared.branchName,
+      issue: routineIssueSnapshot(input.routine),
+      prompt: evidence.prompt,
+      promptPath: evidence.promptPath,
+      provider: {
+        command: input.providerCommand,
+        name: input.providerName
+      },
+      run: {
+        attempt: 1,
+        id: input.firingId
+      },
+      workspacePath: prepared.workspacePath
+    })) {
+      await appendRoutineEvent({
+        event,
+        normalizedLogPath,
+        rawLogPath
+      });
+      if (event.normalized !== undefined) {
+        events.push(event.normalized);
+      }
+    }
+    const outcome = classifyRoutineOutcome(events);
+    input.runStore.completeRoutineFiring({
+      id: input.firingId,
+      state: outcome.kind,
+      terminalReason: outcome.reason.length === 0 ? null : outcome.reason,
+      workspacePath: prepared.workspacePath
+    });
+  } catch (error) {
+    const reason =
+      error instanceof RoutinePromptRenderError
+        ? error.terminalReason
+        : errorMessage(error);
+    input.runStore.completeRoutineFiring({
+      id: input.firingId,
+      state: "failed",
+      terminalReason: reason,
+      ...(prepared === undefined ? {} : { workspacePath: prepared.workspacePath })
+    });
+  }
+}
+
+async function prepareRoutineEvidence(input: {
+  firingId: string;
+  configDir: string;
+  prepared: PreparedRoutineWorkspace;
+  project: RunControllerProjectConfig;
+  providerCommand: string;
+  providerName: AgentProviderName;
+  routine: RoutineStatus & { prompt: string };
+  stateRoot: string;
+}): Promise<{
+  normalizedLogPath: string;
+  prompt: string;
+  promptPath: string;
+  rawLogPath: string;
+}> {
+  const routine = input.routine;
+  const rendered = renderRoutinePrompt({
+    firing: { id: input.firingId },
+    project: { name: input.project.name },
+    provider: { command: input.providerCommand, name: input.providerName },
+    routine: {
+      kind: routine.kind,
+      name: routine.name,
+      schedule_at: routine.scheduleAt,
+      source_path: routine.sourcePath
+    },
+    template: routine.prompt,
+    templatePath: routine.sourcePath,
+    workspace: {
+      path: input.prepared.workspacePath,
+      root: path.resolve(input.configDir, input.project.workspace.root)
+    }
+  });
+  const directory = path.join(
+    path.resolve(input.stateRoot),
+    "logs",
+    "routines",
+    safePathSegment(input.firingId)
+  );
+  await mkdir(directory, { recursive: true });
+  const promptPath = path.join(directory, "prompt.md");
+  const metadataPath = path.join(directory, "prompt-metadata.json");
+  const rawLogPath = path.join(directory, "provider.raw.jsonl");
+  const normalizedLogPath = path.join(directory, "provider.normalized.jsonl");
+  await Promise.all([
+    writeFile(promptPath, rendered.prompt, "utf8"),
+    writeFile(
+      metadataPath,
+      `${JSON.stringify(
+        {
+          autonomy_preamble_version: rendered.preambleVersion,
+          firing: { id: input.firingId },
+          project: { name: input.project.name },
+          provider: { command: input.providerCommand, name: input.providerName },
+          routine: {
+            kind: routine.kind,
+            name: routine.name,
+            schedule_at: routine.scheduleAt,
+            source_path: routine.sourcePath
+          },
+          template_content_hash: rendered.templateContentHash,
+          workspace: {
+            path: input.prepared.workspacePath,
+            root: path.resolve(input.configDir, input.project.workspace.root)
+          }
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    ),
+    writeFile(rawLogPath, "", "utf8"),
+    writeFile(normalizedLogPath, "", "utf8")
+  ]);
+  return {
+    normalizedLogPath,
+    prompt: rendered.prompt,
+    promptPath,
+    rawLogPath
+  };
+}
+
+async function appendRoutineEvent(input: {
+  event: ProviderEvent;
+  normalizedLogPath: string;
+  rawLogPath: string;
+}): Promise<void> {
+  await Promise.all([
+    appendJsonl(input.rawLogPath, input.event.raw),
+    ...(input.event.normalized === undefined
+      ? []
+      : [appendJsonl(input.normalizedLogPath, input.event.normalized)])
+  ]);
+}
+
+function classifyRoutineOutcome(
+  events: NormalizedProviderEvent[]
+): RoutineTerminalOutcome {
+  const inputRequired = events.find((event) => event.type === "input_required");
+  if (inputRequired !== undefined) {
+    return {
+      kind: "failed",
+      reason: stringField(inputRequired, "message") ?? "provider requested input"
+    };
+  }
+  if (events.some((event) => event.type === "malformed_event")) {
+    return { kind: "failed", reason: "malformed_provider_event" };
+  }
+  const turnFailed = events.find((event) => event.type === "turn_failed");
+  if (turnFailed !== undefined) {
+    return {
+      kind: "failed",
+      reason: stringField(turnFailed, "message") ?? "turn_failed"
+    };
+  }
+  const exit = events.find((event) => event.type === "process_exit");
+  if (exit === undefined) {
+    return { kind: "failed", reason: "no_process_exit_event" };
+  }
+  if (exit.cancelled === true) {
+    return { kind: "cancelled", reason: "provider_cancelled" };
+  }
+  const exitCode = numberField(exit, "exitCode");
+  if (exitCode === 0) {
+    return { kind: "succeeded", reason: "" };
+  }
+  return {
+    kind: "failed",
+    reason:
+      exitCode === undefined
+        ? `process_exit_signal_${stringField(exit, "signal") ?? "unknown"}`
+        : `process_exit_${exitCode}`
+  };
+}
+
+function capSkipReason(
+  activeRuns: ActiveRunRegistry,
+  globalConcurrency: { maxInFlight: number | undefined },
+  project: RunControllerProjectConfig
+): string | null {
+  if (
+    globalConcurrency.maxInFlight !== undefined &&
+    activeRuns.countInFlight() >= globalConcurrency.maxInFlight
+  ) {
+    return `global max_in_flight (${globalConcurrency.maxInFlight}) reached`;
+  }
+  const projectMax = project.max_in_flight ?? 1;
+  if (activeRuns.countInFlightByProject(project.name) >= projectMax) {
+    return `project ${project.name} max_in_flight (${projectMax}) reached`;
+  }
+  return null;
+}
+
+function routineIssueSnapshot(routine: RoutineStatus) {
+  return {
+    body: "",
+    created_at: "",
+    id: 0,
+    labels: [`routine:${routine.name}`],
+    number: 0,
+    priority: 99,
+    state: "open" as const,
+    title: routine.name,
+    updated_at: "",
+    url: ""
+  };
+}
+
+function syntheticRoutineIssueNumber(firingId: string): number {
+  let hash = 0;
+  for (const char of firingId) {
+    hash = (hash * 31 + char.charCodeAt(0)) | 0;
+  }
+  return -Math.max(1, Math.abs(hash));
+}
+
+async function appendJsonl(filePath: string, value: unknown): Promise<void> {
+  await appendFile(filePath, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  if (typeof value === "object" && value !== null && key in value) {
+    const field = (value as Record<string, unknown>)[key];
+    return typeof field === "string" ? field : undefined;
+  }
+  return undefined;
+}
+
+function numberField(value: unknown, key: string): number | undefined {
+  if (typeof value === "object" && value !== null && key in value) {
+    const field = (value as Record<string, unknown>)[key];
+    return typeof field === "number" ? field : undefined;
+  }
+  return undefined;
+}
+
+function safePathSegment(input: string): string {
+  const segment = input.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return segment.length === 0 ? "firing" : segment;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/routines/dispatcher.ts
+++ b/src/routines/dispatcher.ts
@@ -133,10 +133,14 @@ export async function dispatchDueRoutines(
         continue;
       }
 
-      const claimed = input.runStore.markRoutineExpired({
+      const firingId = createFiringId();
+      const claimed = input.runStore.claimRoutineFiring({
         firedAt: now.toISOString(),
-        name: routine.name,
-        projectName: project.name
+        firingId,
+        projectName: project.name,
+        providerCommand,
+        providerName,
+        routineName: routine.name
       });
       if (!claimed) {
         skipped.push({
@@ -147,23 +151,14 @@ export async function dispatchDueRoutines(
         continue;
       }
 
-      const firingId = createFiringId();
-      input.activeRuns.reserveSlot({
-        issueNumber: syntheticRoutineIssueNumber(firingId),
-        projectName: project.name,
-        respectsIssueLabels: false,
-        runId: firingId
-      });
-      input.runStore.createRoutineFiring({
-        id: firingId,
-        projectName: project.name,
-        providerCommand,
-        providerName,
-        routineName: routine.name
-      });
-      fired.push(firingId);
-
       try {
+        input.activeRuns.reserveSlot({
+          issueNumber: syntheticRoutineIssueNumber(firingId),
+          projectName: project.name,
+          respectsIssueLabels: false,
+          runId: firingId
+        });
+        fired.push(firingId);
         await runRoutineFiring({
           firingId,
           prepareRoutineWorkspace,

--- a/src/routines/dispatcher.ts
+++ b/src/routines/dispatcher.ts
@@ -66,10 +66,10 @@ export async function dispatchDueRoutines(
   const createFiringId = input.createFiringId ?? (() => createUlid());
 
   for (const project of input.projects.values()) {
-    input.runStore.syncRoutines(project.name, project.routines ?? []);
     if (project.disabled === true) {
       continue;
     }
+    input.runStore.syncRoutines(project.name, project.routines ?? []);
     for (const routine of input.runStore.listRoutines({ project: project.name })) {
       const evaluation = evaluateRoutineSchedule({
         lastFiredAt: routine.lastFiredAt,

--- a/src/routines/dispatcher.ts
+++ b/src/routines/dispatcher.ts
@@ -118,6 +118,35 @@ export async function dispatchDueRoutines(
         continue;
       }
 
+      const reEvaluation = evaluateRoutineSchedule({
+        lastFiredAt: routineDetail.lastFiredAt,
+        now,
+        schedule: { at: routineDetail.scheduleAt },
+        state: routineDetail.state
+      });
+      if (reEvaluation.kind !== "fire_now") {
+        skipped.push({
+          projectName: project.name,
+          reason: "routine no longer eligible after re-read",
+          routineName: routine.name
+        });
+        continue;
+      }
+
+      const claimed = input.runStore.markRoutineExpired({
+        firedAt: now.toISOString(),
+        name: routine.name,
+        projectName: project.name
+      });
+      if (!claimed) {
+        skipped.push({
+          projectName: project.name,
+          reason: "routine already claimed by another worker",
+          routineName: routine.name
+        });
+        continue;
+      }
+
       const firingId = createFiringId();
       input.activeRuns.reserveSlot({
         issueNumber: syntheticRoutineIssueNumber(firingId),
@@ -131,11 +160,6 @@ export async function dispatchDueRoutines(
         providerCommand,
         providerName,
         routineName: routine.name
-      });
-      input.runStore.markRoutineExpired({
-        firedAt: now.toISOString(),
-        name: routine.name,
-        projectName: project.name
       });
       fired.push(firingId);
 

--- a/src/routines/prompt-renderer.ts
+++ b/src/routines/prompt-renderer.ts
@@ -1,0 +1,164 @@
+import { createHash } from "node:crypto";
+
+import {
+  AUTONOMY_PREAMBLE,
+  AUTONOMY_PREAMBLE_VERSION
+} from "../workflow/autonomous-prompt.js";
+import type { RoutineKind } from "./types.js";
+
+export type RoutinePromptInput = {
+  firing: {
+    id: string;
+  };
+  project: {
+    name: string;
+  };
+  provider: {
+    command: string;
+    name: "codex" | "claude";
+  };
+  routine: {
+    kind: RoutineKind;
+    name: string;
+    schedule_at: string;
+    source_path: string;
+  };
+  template: string;
+  templatePath: string;
+  workspace: {
+    path: string;
+    root: string;
+  };
+};
+
+export type RenderedRoutinePrompt = {
+  preambleVersion: string;
+  prompt: string;
+  templateContentHash: string;
+};
+
+type RoutinePromptContext = Pick<
+  RoutinePromptInput,
+  "firing" | "project" | "provider" | "routine" | "workspace"
+>;
+
+const allowedTemplateFields: Record<
+  keyof RoutinePromptContext,
+  ReadonlySet<string>
+> = {
+  firing: new Set(["id"]),
+  project: new Set(["name"]),
+  provider: new Set(["command", "name"]),
+  routine: new Set(["kind", "name", "schedule_at", "source_path"]),
+  workspace: new Set(["path", "root"])
+};
+
+const tagPattern = /{{\s*([^{}]+?)\s*}}/g;
+
+export class RoutinePromptRenderError extends Error {
+  readonly terminalReason = "prompt_render_error";
+
+  constructor(message: string) {
+    super(`prompt_render_error: ${message}`);
+    this.name = "RoutinePromptRenderError";
+  }
+}
+
+export function renderRoutinePrompt(
+  input: RoutinePromptInput
+): RenderedRoutinePrompt {
+  const context: RoutinePromptContext = {
+    firing: input.firing,
+    project: input.project,
+    provider: input.provider,
+    routine: input.routine,
+    workspace: input.workspace
+  };
+  const rendered = input.template.replace(tagPattern, (_tag, expression) =>
+    stringifyTemplateValue(
+      resolveTemplateValue(String(expression).trim(), context, input.templatePath),
+      input.templatePath
+    )
+  );
+
+  return {
+    preambleVersion: AUTONOMY_PREAMBLE_VERSION,
+    prompt: [AUTONOMY_PREAMBLE, rendered].join("\n"),
+    templateContentHash: contentHash(input.template)
+  };
+}
+
+function resolveTemplateValue(
+  expression: string,
+  context: RoutinePromptContext,
+  templatePath: string
+): unknown {
+  const error = templateExpressionError(expression, templatePath);
+  if (error !== undefined) {
+    throw new RoutinePromptRenderError(error);
+  }
+
+  const [topLevel, field] = expression.split(".");
+  if (topLevel === undefined || !isRoutinePromptObjectName(topLevel)) {
+    throw new RoutinePromptRenderError(
+      `routine template at ${templatePath} references unknown variable {{${expression}}}`
+    );
+  }
+
+  if (field === undefined) {
+    return context[topLevel];
+  }
+
+  return context[topLevel][field as keyof (typeof context)[typeof topLevel]];
+}
+
+function stringifyTemplateValue(value: unknown, templatePath: string): string {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+
+  if (value === null || value === undefined) {
+    throw new RoutinePromptRenderError(
+      `routine template at ${templatePath} resolved to an empty value`
+    );
+  }
+
+  return JSON.stringify(value);
+}
+
+function templateExpressionError(
+  expression: string,
+  templatePath: string
+): string | undefined {
+  const parts = expression.split(".");
+  const topLevel = parts[0];
+
+  if (!/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(expression)) {
+    return `routine template at ${templatePath} has unsupported tag {{${expression}}}`;
+  }
+
+  if (topLevel === undefined || !isRoutinePromptObjectName(topLevel)) {
+    return `routine template at ${templatePath} references unknown variable {{${expression}}}`;
+  }
+
+  const field = parts[1];
+  if (field !== undefined && !allowedTemplateFields[topLevel].has(field)) {
+    return `routine template at ${templatePath} references unknown variable {{${expression}}}`;
+  }
+
+  return undefined;
+}
+
+function isRoutinePromptObjectName(
+  input: string
+): input is keyof RoutinePromptContext {
+  return Object.hasOwn(allowedTemplateFields, input);
+}
+
+function contentHash(contents: string): string {
+  return `sha256:${createHash("sha256").update(contents).digest("hex")}`;
+}

--- a/src/routines/schedule.ts
+++ b/src/routines/schedule.ts
@@ -1,0 +1,35 @@
+import type { RoutineState } from "./types.js";
+
+export type RoutineOneShotSchedule = {
+  at: string;
+};
+
+export type RoutineScheduleEvaluation =
+  | { kind: "expired" }
+  | { kind: "fire_now" }
+  | { at: string; kind: "wait_until" };
+
+export type EvaluateRoutineScheduleInput = {
+  lastFiredAt: string | null;
+  now: Date;
+  schedule: RoutineOneShotSchedule;
+  state: RoutineState;
+};
+
+export function evaluateRoutineSchedule(
+  input: EvaluateRoutineScheduleInput
+): RoutineScheduleEvaluation {
+  if (input.state === "expired" || input.lastFiredAt !== null) {
+    return { kind: "expired" };
+  }
+
+  const at = new Date(input.schedule.at);
+  if (input.now.getTime() >= at.getTime()) {
+    return { kind: "fire_now" };
+  }
+
+  return {
+    at: input.schedule.at,
+    kind: "wait_until"
+  };
+}

--- a/src/routines/types.ts
+++ b/src/routines/types.ts
@@ -1,0 +1,38 @@
+import type { AgentProviderName } from "../provider.js";
+
+export type RoutineKind = "report";
+
+export type RoutineState = "active" | "expired";
+
+export type RoutineFiringState =
+  | "queued"
+  | "preparing_workspace"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export type RoutineSchedule = {
+  at: string;
+};
+
+export type RoutineDeclaration = {
+  kind: RoutineKind;
+  name: string;
+  prompt: string;
+  provider: AgentProviderName | null;
+  schedule: RoutineSchedule;
+  sourcePath: string;
+};
+
+export type RoutineStatus = {
+  kind: RoutineKind;
+  lastFiredAt: string | null;
+  name: string;
+  nextFireAt: string | null;
+  projectName: string;
+  provider: AgentProviderName | null;
+  scheduleAt: string;
+  sourcePath: string;
+  state: RoutineState;
+};

--- a/src/routines/ulid.ts
+++ b/src/routines/ulid.ts
@@ -1,0 +1,26 @@
+import { randomBytes } from "node:crypto";
+
+const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+export function createUlid(now = Date.now()): string {
+  return `${encodeTime(now)}${encodeRandom()}`;
+}
+
+function encodeTime(now: number): string {
+  let value = Math.max(0, Math.floor(now));
+  let output = "";
+  for (let index = 0; index < 10; index += 1) {
+    output = ENCODING[value % 32]! + output;
+    value = Math.floor(value / 32);
+  }
+  return output;
+}
+
+function encodeRandom(): string {
+  const bytes = randomBytes(16);
+  let output = "";
+  for (let index = 0; output.length < 16; index += 1) {
+    output += ENCODING[bytes[index % bytes.length]! % 32]!;
+  }
+  return output;
+}

--- a/src/routines/workspace.ts
+++ b/src/routines/workspace.ts
@@ -1,0 +1,102 @@
+import { execFile } from "node:child_process";
+import { mkdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import type { WorkspaceProject } from "../workspace.js";
+
+const execFileAsync = promisify(execFile);
+
+export type PrepareRoutineWorkspaceInput = {
+  configDir: string;
+  firingId: string;
+  project: WorkspaceProject;
+  routineName: string;
+};
+
+export type PreparedRoutineWorkspace = {
+  branchName: string;
+  branchRef: string;
+  cachePath: string;
+  reused: boolean;
+  workspacePath: string;
+};
+
+export async function prepareRoutineWorkspace(
+  input: PrepareRoutineWorkspaceInput
+): Promise<PreparedRoutineWorkspace> {
+  const workspaceRoot = path.resolve(input.configDir, input.project.workspace.root);
+  const cachePath = path.join(workspaceRoot, ".cache", "repo.git");
+  const workspacePath = path.join(
+    workspaceRoot,
+    "routines",
+    input.routineName,
+    input.firingId
+  );
+  const branchRef = `refs/remotes/origin/${input.project.workspace.git.base_branch}`;
+  await ensureRepositoryCache(input.project, cachePath);
+  if (await exists(workspacePath)) {
+    return {
+      branchName: input.project.workspace.git.base_branch,
+      branchRef,
+      cachePath,
+      reused: true,
+      workspacePath
+    };
+  }
+  await mkdir(path.dirname(workspacePath), { recursive: true });
+  await git([
+    "-C",
+    cachePath,
+    "worktree",
+    "add",
+    "--detach",
+    workspacePath,
+    `origin/${input.project.workspace.git.base_branch}`
+  ]);
+  return {
+    branchName: input.project.workspace.git.base_branch,
+    branchRef,
+    cachePath,
+    reused: false,
+    workspacePath
+  };
+}
+
+async function ensureRepositoryCache(
+  project: WorkspaceProject,
+  cachePath: string
+): Promise<void> {
+  if (!(await exists(cachePath))) {
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await git(["clone", "--bare", project.workspace.git.remote, cachePath]);
+  }
+  await git([
+    "-C",
+    cachePath,
+    "fetch",
+    "origin",
+    `${project.workspace.git.base_branch}:refs/remotes/origin/${project.workspace.git.base_branch}`
+  ]);
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function git(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args);
+  return stdout.trim();
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/routines/workspace.ts
+++ b/src/routines/workspace.ts
@@ -3,7 +3,7 @@ import { mkdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import type { WorkspaceProject } from "../workspace.js";
+import { ensureRepositoryCache, type WorkspaceProject } from "../workspace.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -61,23 +61,6 @@ export async function prepareRoutineWorkspace(
     reused: false,
     workspacePath
   };
-}
-
-async function ensureRepositoryCache(
-  project: WorkspaceProject,
-  cachePath: string
-): Promise<void> {
-  if (!(await exists(cachePath))) {
-    await mkdir(path.dirname(cachePath), { recursive: true });
-    await git(["clone", "--bare", project.workspace.git.remote, cachePath]);
-  }
-  await git([
-    "-C",
-    cachePath,
-    "fetch",
-    "origin",
-    `${project.workspace.git.base_branch}:refs/remotes/origin/${project.workspace.git.base_branch}`
-  ]);
 }
 
 async function exists(filePath: string): Promise<boolean> {

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -404,6 +404,13 @@ export const INPUT_REQUIRED_LEGACY_BACKFILL_GRACE_MS = 60_000;
 export const INPUT_REQUIRED_LEGACY_TERMINAL_REASON =
   "provider requested input (legacy)";
 
+class RoutineAlreadyClaimedError extends Error {
+  constructor() {
+    super("routine already claimed");
+    this.name = "RoutineAlreadyClaimedError";
+  }
+}
+
 export class RunStore {
   private readonly database: SqliteDatabase;
   private readonly stateRoot: string;
@@ -1033,6 +1040,48 @@ export class RunStore {
         updated_at: now
       });
     this.recordRoutineFiringTransition(input.id, "queued", now);
+  }
+
+  claimRoutineFiring(input: {
+    firedAt: string;
+    firingId: string;
+    projectName: string;
+    providerCommand: string;
+    providerName: AgentProviderName;
+    routineName: string;
+  }): boolean {
+    const claim = this.database.transaction(() => {
+      this.createRoutineFiring({
+        id: input.firingId,
+        projectName: input.projectName,
+        providerCommand: input.providerCommand,
+        providerName: input.providerName,
+        routineName: input.routineName
+      });
+      const result = this.database
+        .prepare(
+          [
+            "update routines set",
+            "state = 'expired',",
+            "last_fired_at = ?,",
+            "updated_at = ?",
+            "where project_name = ? and name = ? and state = 'active'"
+          ].join(" ")
+        )
+        .run(input.firedAt, timestamp(), input.projectName, input.routineName);
+      if (result.changes === 0) {
+        throw new RoutineAlreadyClaimedError();
+      }
+    });
+    try {
+      claim();
+      return true;
+    } catch (error) {
+      if (error instanceof RoutineAlreadyClaimedError) {
+        return false;
+      }
+      throw error;
+    }
   }
 
   updateRoutineFiringState(id: string, state: RoutineFiringState): void {

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -7,6 +7,13 @@ import type { Database as SqliteDatabase } from "better-sqlite3";
 import type { IssueSnapshot } from "./issue-polling.js";
 import { isPathInside } from "./path-safety.js";
 import type { AgentProviderName, NormalizedProviderEvent } from "./provider.js";
+import type {
+  RoutineDeclaration,
+  RoutineFiringState,
+  RoutineKind,
+  RoutineState,
+  RoutineStatus
+} from "./routines/types.js";
 import type { ExpandedWorkflow } from "./workflow.js";
 
 export type RunState =
@@ -110,6 +117,25 @@ export type ProjectState = {
   validationMessage: string | null;
   validationState: ProjectValidationState;
   weight: number;
+};
+
+export type RoutineFiringStatus = {
+  createdAt: string;
+  id: string;
+  projectName: string;
+  provider: AgentProviderName;
+  providerCommand: string;
+  routineName: string;
+  state: RoutineFiringState;
+  terminalReason: string | null;
+  updatedAt: string;
+  workspacePath: string;
+};
+
+export type RoutineFiringStateTransition = {
+  createdAt: string;
+  sequence: number;
+  state: RoutineFiringState;
 };
 
 export type SyncProjectStateInput = {
@@ -344,6 +370,32 @@ type ProjectStateRow = {
   validation_message: string | null;
   validation_state: ProjectValidationState;
   weight: number;
+};
+
+type RoutineRow = {
+  created_at: string;
+  kind: RoutineKind;
+  last_fired_at: string | null;
+  name: string;
+  project_name: string;
+  provider_name: AgentProviderName | null;
+  schedule_at: string;
+  source_path: string;
+  state: RoutineState;
+  updated_at: string;
+};
+
+type RoutineFiringRow = {
+  created_at: string;
+  id: string;
+  project_name: string;
+  provider_command: string;
+  provider_name: AgentProviderName;
+  routine_name: string;
+  state: RoutineFiringState;
+  terminal_reason: string | null;
+  updated_at: string;
+  workspace_path: string | null;
 };
 
 export const PULL_REQUEST_DISCOVERY_LIMIT = 25;
@@ -835,6 +887,256 @@ export class RunStore {
       )
       .all() as ProjectStateRow[];
     return rows.map((row) => mapProjectStateRow(row));
+  }
+
+  syncRoutines(projectName: string, routines: RoutineDeclaration[]): void {
+    const now = timestamp();
+    const upsert = this.database.prepare(
+      [
+        "insert into routines (",
+        "project_name, name, source_path, kind, provider_name, schedule_at, prompt_body, state, created_at, updated_at",
+        ") values (",
+        "@project_name, @name, @source_path, @kind, @provider_name, @schedule_at, @prompt_body, 'active', @created_at, @updated_at",
+        ")",
+        "on conflict(project_name, name) do update set",
+        "source_path = excluded.source_path,",
+        "kind = excluded.kind,",
+        "provider_name = excluded.provider_name,",
+        "schedule_at = excluded.schedule_at,",
+        "prompt_body = excluded.prompt_body,",
+        // Preserve expired one-shots across daemon restarts and reloads.
+        "state = case when routines.state = 'expired' then routines.state else 'active' end,",
+        "updated_at = excluded.updated_at"
+      ].join(" ")
+    );
+    const apply = this.database.transaction(() => {
+      if (routines.length === 0) {
+        this.database
+          .prepare("delete from routines where project_name = ?")
+          .run(projectName);
+      } else {
+        const names = routines.map((routine) => routine.name);
+        const placeholders = names.map(() => "?").join(", ");
+        this.database
+          .prepare(
+            `delete from routines where project_name = ? and name not in (${placeholders})`
+          )
+          .run(projectName, ...names);
+      }
+      for (const routine of routines) {
+        upsert.run({
+          created_at: now,
+          kind: routine.kind,
+          name: routine.name,
+          project_name: projectName,
+          prompt_body: routine.prompt,
+          provider_name: routine.provider,
+          schedule_at: routine.schedule.at,
+          source_path: routine.sourcePath,
+          updated_at: now
+        });
+      }
+    });
+    apply();
+  }
+
+  listRoutines(filter: { project?: string } = {}): RoutineStatus[] {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+    if (filter.project !== undefined) {
+      conditions.push("project_name = @project");
+      params.project = filter.project;
+    }
+    const where = conditions.length === 0 ? "" : `where ${conditions.join(" and ")}`;
+    const rows = this.database
+      .prepare(
+        [
+          "select project_name, name, source_path, kind, provider_name, schedule_at, state, last_fired_at, created_at, updated_at",
+          "from routines",
+          where,
+          "order by project_name asc, name asc"
+        ]
+          .filter((part) => part.length > 0)
+          .join(" ")
+      )
+      .all(params) as RoutineRow[];
+    return rows.map((row) => mapRoutineRow(row));
+  }
+
+  getRoutine(input: {
+    name: string;
+    projectName: string;
+  }): (RoutineStatus & { prompt: string }) | undefined {
+    const row = this.database
+      .prepare(
+        [
+          "select project_name, name, source_path, kind, provider_name, schedule_at, state, last_fired_at, created_at, updated_at, prompt_body",
+          "from routines where project_name = ? and name = ?"
+        ].join(" ")
+      )
+      .get(input.projectName, input.name) as
+      | (RoutineRow & { prompt_body: string })
+      | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    return {
+      ...mapRoutineRow(row),
+      prompt: row.prompt_body
+    };
+  }
+
+  markRoutineExpired(input: {
+    firedAt: string;
+    name: string;
+    projectName: string;
+  }): void {
+    this.database
+      .prepare(
+        [
+          "update routines set",
+          "state = 'expired',",
+          "last_fired_at = ?,",
+          "updated_at = ?",
+          "where project_name = ? and name = ?"
+        ].join(" ")
+      )
+      .run(input.firedAt, timestamp(), input.projectName, input.name);
+  }
+
+  createRoutineFiring(input: {
+    id: string;
+    projectName: string;
+    providerCommand: string;
+    providerName: AgentProviderName;
+    routineName: string;
+  }): void {
+    const now = timestamp();
+    this.database
+      .prepare(
+        [
+          "insert into routine_firings (",
+          "id, project_name, routine_name, state, provider_name, provider_command, created_at, updated_at",
+          ") values (",
+          "@id, @project_name, @routine_name, 'queued', @provider_name, @provider_command, @created_at, @updated_at",
+          ")"
+        ].join(" ")
+      )
+      .run({
+        created_at: now,
+        id: input.id,
+        project_name: input.projectName,
+        provider_command: input.providerCommand,
+        provider_name: input.providerName,
+        routine_name: input.routineName,
+        updated_at: now
+      });
+    this.recordRoutineFiringTransition(input.id, "queued", now);
+  }
+
+  updateRoutineFiringState(id: string, state: RoutineFiringState): void {
+    const now = timestamp();
+    this.database
+      .prepare("update routine_firings set state = ?, updated_at = ? where id = ?")
+      .run(state, now, id);
+    this.recordRoutineFiringTransition(id, state, now);
+  }
+
+  completeRoutineFiring(input: {
+    id: string;
+    state: Extract<RoutineFiringState, "succeeded" | "failed" | "cancelled">;
+    terminalReason?: string | null;
+    workspacePath?: string;
+  }): void {
+    const now = timestamp();
+    this.database
+      .prepare(
+        [
+          "update routine_firings set",
+          "state = @state,",
+          "terminal_reason = @terminal_reason,",
+          "workspace_path = coalesce(@workspace_path, workspace_path),",
+          "updated_at = @updated_at",
+          "where id = @id"
+        ].join(" ")
+      )
+      .run({
+        id: input.id,
+        state: input.state,
+        terminal_reason: input.terminalReason ?? null,
+        updated_at: now,
+        workspace_path: input.workspacePath ?? null
+      });
+    this.recordRoutineFiringTransition(input.id, input.state, now);
+  }
+
+  updateRoutineFiringWorkspace(input: {
+    id: string;
+    normalizedLogPath?: string;
+    promptPath?: string;
+    rawLogPath?: string;
+    workspacePath: string;
+  }): void {
+    this.database
+      .prepare(
+        [
+          "update routine_firings set",
+          "workspace_path = @workspace_path,",
+          "prompt_path = coalesce(@prompt_path, prompt_path),",
+          "raw_log_path = coalesce(@raw_log_path, raw_log_path),",
+          "normalized_log_path = coalesce(@normalized_log_path, normalized_log_path),",
+          "updated_at = @updated_at",
+          "where id = @id"
+        ].join(" ")
+      )
+      .run({
+        id: input.id,
+        normalized_log_path: input.normalizedLogPath ?? null,
+        prompt_path: input.promptPath ?? null,
+        raw_log_path: input.rawLogPath ?? null,
+        updated_at: timestamp(),
+        workspace_path: input.workspacePath
+      });
+  }
+
+  listRoutineFirings(filter: { project?: string } = {}): RoutineFiringStatus[] {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+    if (filter.project !== undefined) {
+      conditions.push("project_name = @project");
+      params.project = filter.project;
+    }
+    const where = conditions.length === 0 ? "" : `where ${conditions.join(" and ")}`;
+    const rows = this.database
+      .prepare(
+        [
+          "select id, project_name, routine_name, state, provider_name, provider_command, workspace_path, terminal_reason, created_at, updated_at",
+          "from routine_firings",
+          where,
+          "order by created_at desc, id desc"
+        ]
+          .filter((part) => part.length > 0)
+          .join(" ")
+      )
+      .all(params) as RoutineFiringRow[];
+    return rows.map((row) => mapRoutineFiringRow(row));
+  }
+
+  listRoutineFiringTransitions(id: string): RoutineFiringStateTransition[] {
+    const rows = this.database
+      .prepare(
+        "select sequence, state, created_at from routine_firing_state_transitions where firing_id = ? order by sequence asc"
+      )
+      .all(id) as Array<{
+      created_at: string;
+      sequence: number;
+      state: RoutineFiringState;
+    }>;
+    return rows.map((row) => ({
+      createdAt: row.created_at,
+      sequence: row.sequence,
+      state: row.state
+    }));
   }
 
   getProjectStatesByName(): Map<string, ProjectState> {
@@ -1686,6 +1988,47 @@ export class RunStore {
         created_at text not null,
         updated_at text not null
       );
+
+      create table if not exists routines (
+        project_name text not null,
+        name text not null,
+        source_path text not null,
+        kind text not null,
+        provider_name text,
+        schedule_at text not null,
+        prompt_body text not null,
+        state text not null,
+        last_fired_at text,
+        created_at text not null,
+        updated_at text not null,
+        primary key (project_name, name)
+      );
+
+      create table if not exists routine_firings (
+        id text primary key,
+        project_name text not null,
+        routine_name text not null,
+        state text not null,
+        provider_name text not null,
+        provider_command text not null,
+        workspace_path text,
+        prompt_path text,
+        raw_log_path text,
+        normalized_log_path text,
+        terminal_reason text,
+        created_at text not null,
+        updated_at text not null,
+        foreign key (project_name, routine_name) references routines(project_name, name)
+      );
+
+      create table if not exists routine_firing_state_transitions (
+        id integer primary key autoincrement,
+        firing_id text not null,
+        sequence integer not null,
+        state text not null,
+        created_at text not null,
+        foreign key (firing_id) references routine_firings(id)
+      );
     `);
 
     const additions: Array<[string, string, string]> = [
@@ -1703,7 +2046,10 @@ export class RunStore {
       ["runs", "state_transition_reason", "text"],
       ["attempts", "failure_classification", "text"],
       ["attempts", "metadata_path", "text"],
-      ["attempts", "workflow_graph_path", "text"]
+      ["attempts", "workflow_graph_path", "text"],
+      ["routine_firings", "prompt_path", "text"],
+      ["routine_firings", "raw_log_path", "text"],
+      ["routine_firings", "normalized_log_path", "text"]
     ];
 
     const apply = this.database.transaction(() => {
@@ -1774,6 +2120,22 @@ export class RunStore {
         "insert into run_state_transitions (run_id, sequence, state, created_at) values (?, ?, ?, ?)"
       )
       .run(runId, sequence, state, createdAt);
+  }
+
+  private recordRoutineFiringTransition(
+    firingId: string,
+    state: RoutineFiringState,
+    createdAt: string
+  ): void {
+    const sequence = nextRoutineFiringTransitionSequence(
+      this.database,
+      firingId
+    );
+    this.database
+      .prepare(
+        "insert into routine_firing_state_transitions (firing_id, sequence, state, created_at) values (?, ?, ?, ?)"
+      )
+      .run(firingId, sequence, state, createdAt);
   }
 
   private getRunArtifactRow(runId: string): RunArtifactRow | undefined {
@@ -1896,6 +2258,19 @@ function nextTransitionSequence(database: SqliteDatabase, runId: string): number
       "select coalesce(max(sequence), 0) + 1 as next_sequence from run_state_transitions where run_id = ?"
     )
     .get(runId) as { next_sequence?: number } | undefined;
+
+  return row?.next_sequence ?? 1;
+}
+
+function nextRoutineFiringTransitionSequence(
+  database: SqliteDatabase,
+  firingId: string
+): number {
+  const row = database
+    .prepare(
+      "select coalesce(max(sequence), 0) + 1 as next_sequence from routine_firing_state_transitions where firing_id = ?"
+    )
+    .get(firingId) as { next_sequence?: number } | undefined;
 
   return row?.next_sequence ?? 1;
 }
@@ -2048,6 +2423,38 @@ function mapProjectStateRow(row: ProjectStateRow): ProjectState {
     validationMessage: row.validation_message ?? null,
     validationState: row.validation_state,
     weight: row.weight
+  };
+}
+
+function mapRoutineRow(row: RoutineRow): RoutineStatus {
+  return {
+    kind: row.kind,
+    lastFiredAt: row.last_fired_at ?? null,
+    name: row.name,
+    nextFireAt:
+      row.state === "active" && row.last_fired_at === null
+        ? row.schedule_at
+        : null,
+    projectName: row.project_name,
+    provider: row.provider_name ?? null,
+    scheduleAt: row.schedule_at,
+    sourcePath: row.source_path,
+    state: row.state
+  };
+}
+
+function mapRoutineFiringRow(row: RoutineFiringRow): RoutineFiringStatus {
+  return {
+    createdAt: row.created_at,
+    id: row.id,
+    projectName: row.project_name,
+    provider: row.provider_name,
+    providerCommand: row.provider_command,
+    routineName: row.routine_name,
+    state: row.state,
+    terminalReason: row.terminal_reason ?? null,
+    updatedAt: row.updated_at,
+    workspacePath: row.workspace_path ?? ""
   };
 }
 

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -990,18 +990,19 @@ export class RunStore {
     firedAt: string;
     name: string;
     projectName: string;
-  }): void {
-    this.database
+  }): boolean {
+    const result = this.database
       .prepare(
         [
           "update routines set",
           "state = 'expired',",
           "last_fired_at = ?,",
           "updated_at = ?",
-          "where project_name = ? and name = ?"
+          "where project_name = ? and name = ? and state = 'active'"
         ].join(" ")
       )
       .run(input.firedAt, timestamp(), input.projectName, input.name);
+    return result.changes > 0;
   }
 
   createRoutineFiring(input: {

--- a/src/status-dashboard.ts
+++ b/src/status-dashboard.ts
@@ -1,6 +1,11 @@
 import type { DoctorProjectReport } from "./doctor.js";
 import type { NormalizedProviderEvent } from "./provider.js";
-import type { ProviderEventRecord, RunState, RunStatus } from "./run-store.js";
+import type {
+  ProviderEventRecord,
+  RunState,
+  RunStatus
+} from "./run-store.js";
+import type { RoutineStatus } from "./routines/types.js";
 
 export type DashboardIssueCounts = {
   candidate: number;
@@ -23,6 +28,7 @@ export type StatusDashboardInput = {
   latestEvents: ReadonlyMap<string, DashboardEventSummary>;
   projects: DoctorProjectReport[];
   reload: string;
+  routines?: RoutineStatus[];
   runs: RunStatus[];
   stateRoot: string;
 };
@@ -100,12 +106,38 @@ export function renderStatusDashboard(input: StatusDashboardInput): string {
     ...formatActiveRuns(activeRuns, input.latestEvents),
     "├─ Attention",
     ...formatAttention(input.projects, attentionRuns),
+    "├─ Routines",
+    ...formatRoutines(input.routines ?? []),
     "├─ Recent runs",
     ...formatRecentRuns(recentRuns),
     "╰─"
   ];
 
   return `${lines.join("\n")}\n`;
+}
+
+function formatRoutines(routines: RoutineStatus[]): string[] {
+  if (routines.length === 0) {
+    return ["│   No routines configured"];
+  }
+  return [
+    "│   PROJECT      ROUTINE              STATE     NEXT_FIRE_AT              LAST_FIRED_AT",
+    "│   --------------------------------------------------------------------------------",
+    ...routines.map((routine) =>
+      [
+        "│  ",
+        pad(truncate(routine.projectName, 12), 12),
+        " ",
+        pad(truncate(routine.name, 20), 20),
+        " ",
+        pad(routine.state, 9),
+        " ",
+        pad(truncate(routine.nextFireAt ?? "-", 25), 25),
+        " ",
+        truncate(routine.lastFiredAt ?? "-", 25)
+      ].join("")
+    )
+  ];
 }
 
 export function summarizeDashboardEvent(

--- a/src/workflow/autonomous-prompt.ts
+++ b/src/workflow/autonomous-prompt.ts
@@ -99,7 +99,7 @@ const allowedTemplateFields: Record<keyof PromptContext, ReadonlySet<string>> = 
 
 const tagPattern = /{{\s*([^{}]+?)\s*}}/g;
 
-const AUTONOMY_PREAMBLE = [
+export const AUTONOMY_PREAMBLE = [
   "# Autonomous run instructions",
   "",
   "You are running as an autonomous full-permission coding worker. No operator will respond to prompts, approve tool calls, or read intermediate output during this run; behaviour that depends on a human answering mid-run is a failure mode.",

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -201,7 +201,7 @@ async function worktreePathForBranch(
 // See ADR 0053.
 const fetchLocks = new Map<string, Promise<unknown>>();
 
-async function ensureRepositoryCache(
+export async function ensureRepositoryCache(
   project: WorkspaceProject,
   cachePath: string
 ): Promise<void> {

--- a/tests/http-app.test.ts
+++ b/tests/http-app.test.ts
@@ -114,6 +114,7 @@ describe("HTTP app", () => {
         ok: true,
         usingLastKnownGood: false
       },
+      routines: [],
       runs: [],
       scheduled: [],
       service: "symphonika",

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -688,4 +688,98 @@ describe("RuntimeConfigReloader concurrency caps", () => {
       "name \"../bad\" is not path-safe"
     );
   });
+
+  it("rejects duplicate routine names within a project", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md");
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+    const routineBody = [
+      "---",
+      "name: daily-report",
+      "schedule:",
+      "  at: 2026-05-22T10:00:00.000Z",
+      "kind: report",
+      "---",
+      "Report on {{project.name}}.",
+      ""
+    ].join("\n");
+    await writeFile(path.join(root, "daily-report.md"), routineBody);
+    await writeFile(path.join(root, "daily-report-2.md"), routineBody);
+    const configPath = path.join(root, "symphonika.yml");
+    const original = await readFile(configPath, "utf8");
+    await writeFile(
+      configPath,
+      original.replace(
+        "    workflow: ./WORKFLOW.md",
+        [
+          "    workflow: ./WORKFLOW.md",
+          "    routines:",
+          "      - ./daily-report.md",
+          "      - ./daily-report-2.md"
+        ].join("\n")
+      )
+    );
+
+    const reloader = new RuntimeConfigReloader({ configPath });
+    await reloader.reload();
+
+    expect(reloader.getStatus().ok).toBe(false);
+    expect(reloader.getStatus().errors.join("\n")).toContain(
+      'duplicate routine name "daily-report"'
+    );
+  });
+
+  it("does not block reload of active projects on a broken routine file in a disabled project", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md");
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+    await writeFile(
+      path.join(root, "broken-routine.md"),
+      ["---", "name: ../bad", "kind: report", "---", "Body", ""].join("\n")
+    );
+    const configPath = path.join(root, "symphonika.yml");
+    const original = await readFile(configPath, "utf8");
+    await writeFile(
+      configPath,
+      original.replace(
+        "  - name: symphonika",
+        [
+          "  - name: disabled-project",
+          "    disabled: true",
+          "    weight: 1",
+          "    tracker:",
+          "      kind: github",
+          "      owner: pmatos",
+          "      repo: symphonika",
+          '      token: "$GITHUB_TOKEN"',
+          "    issue_filters:",
+          '      states: ["open"]',
+          '      labels_all: ["agent-ready"]',
+          '      labels_none: ["blocked"]',
+          "    priority:",
+          "      labels: {}",
+          "      default: 99",
+          "    workspace:",
+          "      root: ./.symphonika/workspaces/disabled-project",
+          "      git:",
+          "        remote: git@github.com:pmatos/disabled-project.git",
+          "        base_branch: main",
+          "    agent:",
+          "      provider: codex",
+          "    workflow: ./WORKFLOW.md",
+          "    routines:",
+          "      - ./broken-routine.md",
+          "  - name: symphonika"
+        ].join("\n")
+      )
+    );
+
+    const reloader = new RuntimeConfigReloader({ configPath });
+    await reloader.reload();
+
+    expect(reloader.getStatus().ok).toBe(true);
+    expect(reloader.projectsByName().has("symphonika")).toBe(true);
+    expect(reloader.projectsByName().get("disabled-project")?.disabled).toBe(true);
+    expect(reloader.projectsByName().get("disabled-project")?.routines).toEqual([]);
+  });
 });

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -599,4 +599,93 @@ describe("RuntimeConfigReloader concurrency caps", () => {
     expect(status.ok).toBe(false);
     expect(status.errors.join("\n")).toMatch(/max_in_flight/);
   });
+
+  it("loads configured project routines into the runtime snapshot", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md");
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+    await writeFile(
+      path.join(root, "daily-report.md"),
+      [
+        "---",
+        "name: daily-report",
+        "schedule:",
+        "  at: 2026-05-22T10:00:00.000Z",
+        "kind: report",
+        "---",
+        "Report on {{project.name}}.",
+        ""
+      ].join("\n")
+    );
+    const configPath = path.join(root, "symphonika.yml");
+    const original = await readFile(configPath, "utf8");
+    await writeFile(
+      configPath,
+      original.replace(
+        "    workflow: ./WORKFLOW.md",
+        ["    workflow: ./WORKFLOW.md", "    routines:", "      - ./daily-report.md"].join("\n")
+      )
+    );
+
+    const reloader = new RuntimeConfigReloader({ configPath });
+    await reloader.reload();
+    const project = reloader.projectsByName().get("symphonika");
+
+    expect(reloader.getStatus().ok).toBe(true);
+    expect(project?.routines).toEqual([
+      expect.objectContaining({
+        kind: "report",
+        name: "daily-report",
+        provider: null,
+        schedule: { at: "2026-05-22T10:00:00.000Z" }
+      })
+    ]);
+  });
+
+  it("keeps the last-known-good snapshot when a routine declaration becomes invalid", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md");
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+    const routinePath = path.join(root, "daily-report.md");
+    await writeFile(
+      routinePath,
+      [
+        "---",
+        "name: daily-report",
+        "schedule:",
+        "  at: 2026-05-22T10:00:00.000Z",
+        "kind: report",
+        "---",
+        "Report on {{project.name}}.",
+        ""
+      ].join("\n")
+    );
+    const configPath = path.join(root, "symphonika.yml");
+    const original = await readFile(configPath, "utf8");
+    await writeFile(
+      configPath,
+      original.replace(
+        "    workflow: ./WORKFLOW.md",
+        ["    workflow: ./WORKFLOW.md", "    routines:", "      - ./daily-report.md"].join("\n")
+      )
+    );
+
+    const reloader = new RuntimeConfigReloader({ configPath });
+    await reloader.reload();
+    const firstSnapshot = reloader.getSnapshot();
+    await writeFile(
+      routinePath,
+      ["---", "name: ../bad", "kind: report", "---", "Body", ""].join("\n")
+    );
+    await reloader.reload();
+
+    expect(reloader.getSnapshot()).toBe(firstSnapshot);
+    expect(reloader.getStatus()).toMatchObject({
+      ok: false,
+      usingLastKnownGood: true
+    });
+    expect(reloader.getStatus().errors.join("\n")).toContain(
+      "name \"../bad\" is not path-safe"
+    );
+  });
 });

--- a/tests/routine-daemon.test.ts
+++ b/tests/routine-daemon.test.ts
@@ -1,0 +1,207 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startDaemon } from "../src/daemon.js";
+import type { AgentProvider, ProviderEvent, ProviderRunInput } from "../src/provider.js";
+import type { PreparedRoutineWorkspace } from "../src/routines/workspace.js";
+
+const tempRoots: string[] = [];
+
+type RoutineApiRow = {
+  lastFiredAt: string | null;
+  name: string;
+  nextFireAt: string | null;
+  projectName: string;
+  state: string;
+};
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-routine-daemon-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("daemon routine firing", () => {
+  it("fires a one-shot kind: report routine once after the scheduled time", async () => {
+    const root = await makeTempRoot();
+    const fireAt = new Date(Date.now() + 50).toISOString();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "alpha",
+      "routines",
+      "daily-report",
+      "routine-fire-1"
+    );
+    await writeRoutineProject(root, fireAt);
+    const providerInputs: ProviderRunInput[] = [];
+    const provider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (
+        input: ProviderRunInput
+      ): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        providerInputs.push(input);
+        yield {
+          normalized: { sessionId: "routine-session", type: "session_started" },
+          raw: { id: "routine-session" }
+        };
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+    const prepareRoutineWorkspace = vi.fn(
+      (): Promise<PreparedRoutineWorkspace> =>
+        Promise.resolve({
+          branchName: "main",
+          branchRef: "refs/remotes/origin/main",
+          cachePath: path.join(root, ".cache", "repo.git"),
+          reused: false,
+          workspacePath
+        })
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRoutineFiringId: () => "routine-fire-1",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi: {
+        addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareRoutineWorkspace
+    });
+
+    try {
+      const routines = await waitForRoutine(daemon.url, "expired");
+      expect(routines).toHaveLength(1);
+      const routine = routines[0];
+      expect(routine?.lastFiredAt).toEqual(expect.any(String));
+      expect(routine).toMatchObject({
+        name: "daily-report",
+        nextFireAt: null,
+        projectName: "alpha",
+        state: "expired"
+      });
+      const status = (await fetch(`${daemon.url}/api/status`).then((response) =>
+        response.json()
+      )) as { routines?: RoutineApiRow[] };
+      expect(status.routines).toEqual(routines);
+      await waitForProviderInputs(providerInputs, 1);
+      expect(providerInputs).toHaveLength(1);
+      expect(providerInputs[0]?.prompt).toContain("Routine daily-report for alpha.");
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      await fetch(`${daemon.url}/api/poll-now`, { method: "POST" });
+      expect(providerInputs).toHaveLength(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+});
+
+async function writeRoutineProject(root: string, fireAt: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await writeFile(path.join(root, "WORKFLOW.md"), "Work on {{issue.title}}.\n");
+  await writeFile(
+    path.join(root, "daily-report.md"),
+    [
+      "---",
+      "name: daily-report",
+      "schedule:",
+      `  at: ${fireAt}`,
+      "kind: report",
+      "---",
+      "Routine {{routine.name}} for {{project.name}}.",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 25",
+      "providers:",
+      "  codex:",
+      '    command: "codex fake"',
+      "  claude:",
+      '    command: "claude fake"',
+      "projects:",
+      "  - name: alpha",
+      "    disabled: false",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: alpha",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/alpha",
+      "      git:",
+      "        remote: git@github.com:pmatos/alpha.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./WORKFLOW.md",
+      "    routines:",
+      "      - ./daily-report.md",
+      ""
+    ].join("\n")
+  );
+}
+
+async function waitForProviderInputs(
+  inputs: ProviderRunInput[],
+  count: number
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (inputs.length >= count) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`provider did not receive ${count} input(s)`);
+}
+
+async function waitForRoutine(
+  baseUrl: string,
+  state: string
+): Promise<RoutineApiRow[]> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const body = (await fetch(`${baseUrl}/api/routines`).then((response) =>
+      response.json()
+    )) as { routines: RoutineApiRow[] };
+    if (body.routines.some((routine) => routine.state === state)) {
+      return body.routines;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`routine did not reach ${state}`);
+}

--- a/tests/routine-declaration-loader.test.ts
+++ b/tests/routine-declaration-loader.test.ts
@@ -1,0 +1,142 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadRoutineDeclaration } from "../src/routines/declaration-loader.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-routine-loader-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("RoutineDeclarationLoader", () => {
+  it("parses a Markdown kind: report routine with one-shot at schedule", async () => {
+    const root = await makeTempRoot();
+    const routinePath = path.join(root, "weekly-report.md");
+    await writeFile(
+      routinePath,
+      [
+        "---",
+        "name: weekly-report",
+        "schedule:",
+        "  at: 2026-05-22T10:00:00.000Z",
+        "kind: report",
+        "provider: claude",
+        "---",
+        "Summarize {{project.name}} from {{workspace.path}}.",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadRoutineDeclaration(routinePath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.routine).toEqual({
+      kind: "report",
+      name: "weekly-report",
+      prompt: "Summarize {{project.name}} from {{workspace.path}}.\n",
+      provider: "claude",
+      schedule: { at: "2026-05-22T10:00:00.000Z" },
+      sourcePath: routinePath
+    });
+  });
+
+  it("reports missing required front matter fields", async () => {
+    const root = await makeTempRoot();
+    const routinePath = path.join(root, "missing.md");
+    await writeFile(routinePath, ["---", "name: missing", "---", "Body", ""].join("\n"));
+
+    const result = await loadRoutineDeclaration(routinePath);
+
+    expect(result.routine).toBeNull();
+    expect(result.errors.join("\n")).toContain("schedule.at");
+    expect(result.errors.join("\n")).toContain("kind");
+  });
+
+  it("rejects names that are unsafe as a single workspace path segment", async () => {
+    const root = await makeTempRoot();
+    const routinePath = path.join(root, "unsafe.md");
+    await writeFile(
+      routinePath,
+      [
+        "---",
+        "name: ../weekly-report",
+        "schedule:",
+        "  at: 2026-05-22T10:00:00.000Z",
+        "kind: report",
+        "---",
+        "Body",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadRoutineDeclaration(routinePath);
+
+    expect(result.routine).toBeNull();
+    expect(result.errors).toContain(
+      `routine at ${routinePath} name "../weekly-report" is not path-safe`
+    );
+  });
+
+  it("rejects mutually-exclusive schedule fields", async () => {
+    const root = await makeTempRoot();
+    await mkdir(path.join(root, "routines"), { recursive: true });
+    const routinePath = path.join(root, "routines", "conflicting.md");
+    await writeFile(
+      routinePath,
+      [
+        "---",
+        "name: conflicting",
+        "schedule:",
+        "  at: 2026-05-22T10:00:00.000Z",
+        "  cron: '0 8 * * *'",
+        "kind: report",
+        "---",
+        "Body",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadRoutineDeclaration(routinePath);
+
+    expect(result.routine).toBeNull();
+    expect(result.errors).toContain(
+      `routine at ${routinePath} schedule must define only one schedule field; supported in this slice: at`
+    );
+  });
+
+  it("reports invalid schedule.at dates without throwing", async () => {
+    const root = await makeTempRoot();
+    const routinePath = path.join(root, "invalid-date.md");
+    await writeFile(
+      routinePath,
+      [
+        "---",
+        "name: invalid-date",
+        "schedule:",
+        "  at: tomorrow-ish",
+        "kind: report",
+        "---",
+        "Body",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadRoutineDeclaration(routinePath);
+
+    expect(result.routine).toBeNull();
+    expect(result.errors).toContain(
+      `routine at ${routinePath} schedule.at must be a valid ISO 8601 date`
+    );
+  });
+});

--- a/tests/routine-declaration-loader.test.ts
+++ b/tests/routine-declaration-loader.test.ts
@@ -115,6 +115,19 @@ describe("RoutineDeclarationLoader", () => {
     );
   });
 
+  it("rejects YAML front matter that parses as a list", async () => {
+    const root = await makeTempRoot();
+    const routinePath = path.join(root, "list-front-matter.md");
+    await writeFile(routinePath, ["---", "- foo", "- bar", "---", "Body", ""].join("\n"));
+
+    const result = await loadRoutineDeclaration(routinePath);
+
+    expect(result.routine).toBeNull();
+    expect(result.errors).toContain(
+      `routine front matter at ${routinePath} must be a mapping`
+    );
+  });
+
   it("reports invalid schedule.at dates without throwing", async () => {
     const root = await makeTempRoot();
     const routinePath = path.join(root, "invalid-date.md");

--- a/tests/routine-dispatcher.test.ts
+++ b/tests/routine-dispatcher.test.ts
@@ -1,0 +1,319 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ActiveRunRegistry } from "../src/lifecycle/active-runs.js";
+import type { AgentProvider, ProviderEvent, ProviderRunInput } from "../src/provider.js";
+import { dispatchDueRoutines } from "../src/routines/dispatcher.js";
+import type {
+  PreparedRoutineWorkspace,
+  PrepareRoutineWorkspaceInput
+} from "../src/routines/workspace.js";
+import { openRunStore } from "../src/run-store.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-routine-dispatch-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("RoutineFiringDispatcher", () => {
+  it("fires a due one-shot report routine exactly once", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "alpha",
+      "routines",
+      "daily-report",
+      "fire-1"
+    );
+    const runStore = openRunStore({ stateRoot });
+    const activeRuns = new ActiveRunRegistry();
+    const providerInputs: ProviderRunInput[] = [];
+    const provider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (
+        input: ProviderRunInput
+      ): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        providerInputs.push(input);
+        yield {
+          normalized: { sessionId: "routine-session", type: "session_started" },
+          raw: { id: "routine-session" }
+        };
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+    const prepareRoutineWorkspace = vi.fn(
+      (input: PrepareRoutineWorkspaceInput): Promise<PreparedRoutineWorkspace> =>
+        Promise.resolve({
+          branchName: input.project.workspace.git.base_branch,
+          branchRef: "refs/remotes/origin/main",
+          cachePath: path.join(root, ".cache", "repo.git"),
+          reused: false,
+          workspacePath
+        })
+    );
+
+    try {
+      const result = await dispatchDueRoutines({
+        activeRuns,
+        agentProviders: { codex: provider },
+        configDir: root,
+        createFiringId: () => "fire-1",
+        globalConcurrency: { maxInFlight: undefined },
+        logger: pino({ enabled: false }),
+        now: new Date("2026-05-22T10:00:01.000Z"),
+        prepareRoutineWorkspace,
+        projects: new Map([
+          [
+            "alpha",
+            {
+              agent: { provider: "codex" },
+              disabled: false,
+              issue_filters: {
+                labels_all: ["agent-ready"],
+                labels_none: ["blocked"],
+                states: ["open"]
+              },
+              name: "alpha",
+              priority: { default: 99, labels: {} },
+              routines: [
+                {
+                  kind: "report",
+                  name: "daily-report",
+                  prompt: "Routine {{routine.name}} for {{project.name}}.",
+                  provider: null,
+                  schedule: { at: "2026-05-22T10:00:00.000Z" },
+                  sourcePath: path.join(root, "daily-report.md")
+                }
+              ],
+              tracker: {
+                kind: "github",
+                owner: "pmatos",
+                repo: "alpha",
+                token: "$GITHUB_TOKEN"
+              },
+              workspace: {
+                git: {
+                  base_branch: "main",
+                  remote: "git@github.com:pmatos/alpha.git"
+                },
+                root: "./.symphonika/workspaces/alpha"
+              },
+              workflow: {
+                format: "markdown",
+                path: "./WORKFLOW.md"
+              }
+            }
+          ]
+        ]),
+        providersConfig: {
+          claude: { command: "claude fake" },
+          codex: { command: "codex fake" }
+        },
+        runStore,
+        stateRoot
+      });
+
+      expect(result.fired).toEqual(["fire-1"]);
+      const prepareInput = prepareRoutineWorkspace.mock.calls[0]?.[0];
+      expect(prepareInput?.firingId).toBe("fire-1");
+      expect(prepareInput?.project.name).toBe("alpha");
+      expect(prepareInput?.routineName).toBe("daily-report");
+      expect(provider.validate).toHaveBeenCalledWith("codex fake");
+      expect(providerInputs).toHaveLength(1);
+      const providerInput = providerInputs[0];
+      expect(providerInput?.prompt).toContain("Routine daily-report for alpha.");
+      expect(providerInput).toMatchObject({
+        branchName: "main",
+        provider: { command: "codex fake", name: "codex" },
+        run: { attempt: 1, id: "fire-1" },
+        workspacePath
+      });
+      expect(runStore.listRoutineFirings()).toEqual([
+        expect.objectContaining({
+          id: "fire-1",
+          provider: "codex",
+          routineName: "daily-report",
+          state: "succeeded",
+          workspacePath
+        })
+      ]);
+      expect(runStore.listRoutineFiringTransitions("fire-1").map((entry) => entry.state)).toEqual([
+        "queued",
+        "preparing_workspace",
+        "running",
+        "succeeded"
+      ]);
+      const routineStatus = runStore.listRoutines()[0];
+      expect(routineStatus?.lastFiredAt).toEqual(expect.any(String));
+      expect(routineStatus).toMatchObject({
+        nextFireAt: null,
+        state: "expired"
+      });
+
+      const second = await dispatchDueRoutines({
+        activeRuns,
+        agentProviders: { codex: provider },
+        configDir: root,
+        createFiringId: () => "fire-2",
+        globalConcurrency: { maxInFlight: undefined },
+        logger: pino({ enabled: false }),
+        now: new Date("2026-05-22T10:00:02.000Z"),
+        prepareRoutineWorkspace,
+        projects: new Map([
+          [
+            "alpha",
+            {
+              ...runStoreProjectFixture(),
+              routines: [
+                {
+                  kind: "report",
+                  name: "daily-report",
+                  prompt: "Routine {{routine.name}} for {{project.name}}.",
+                  provider: null,
+                  schedule: { at: "2026-05-22T10:00:00.000Z" },
+                  sourcePath: path.join(root, "daily-report.md")
+                }
+              ]
+            }
+          ]
+        ]),
+        providersConfig: {
+          claude: { command: "claude fake" },
+          codex: { command: "codex fake" }
+        },
+        runStore,
+        stateRoot
+      });
+
+      expect(second.fired).toEqual([]);
+      expect(providerInputs).toHaveLength(1);
+    } finally {
+      runStore.close();
+    }
+  });
+
+  it("marks a firing failed with prompt_render_error for issue/run/branch references", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const runStore = openRunStore({ stateRoot });
+    const provider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+
+    try {
+      await dispatchDueRoutines({
+        activeRuns: new ActiveRunRegistry(),
+        agentProviders: { codex: provider },
+        configDir: root,
+        createFiringId: () => "fire-render-error",
+        globalConcurrency: { maxInFlight: undefined },
+        logger: pino({ enabled: false }),
+        now: new Date("2026-05-22T10:00:01.000Z"),
+        prepareRoutineWorkspace: () =>
+          Promise.resolve({
+            branchName: "main",
+            branchRef: "refs/remotes/origin/main",
+            cachePath: path.join(root, ".cache", "repo.git"),
+            reused: false,
+            workspacePath: path.join(root, "workspace")
+          }),
+        projects: new Map([
+          [
+            "alpha",
+            {
+              ...runStoreProjectFixture(),
+              routines: [
+                {
+                  kind: "report",
+                  name: "daily-report",
+                  prompt: "Bad {{issue.title}} {{run.id}} {{branch.name}}.",
+                  provider: null,
+                  schedule: { at: "2026-05-22T10:00:00.000Z" },
+                  sourcePath: path.join(root, "daily-report.md")
+                }
+              ]
+            }
+          ]
+        ]),
+        providersConfig: {
+          claude: { command: "claude fake" },
+          codex: { command: "codex fake" }
+        },
+        runStore,
+        stateRoot
+      });
+
+      expect(runStore.listRoutineFirings()).toEqual([
+        expect.objectContaining({
+          id: "fire-render-error",
+          state: "failed",
+          terminalReason: "prompt_render_error"
+        })
+      ]);
+      expect(provider.runAttempt).not.toHaveBeenCalled();
+    } finally {
+      runStore.close();
+    }
+  });
+});
+
+function runStoreProjectFixture() {
+  return {
+    agent: { provider: "codex" as const },
+    disabled: false,
+    issue_filters: {
+      labels_all: ["agent-ready"],
+      labels_none: ["blocked"],
+      states: ["open" as const]
+    },
+    name: "alpha",
+    priority: { default: 99, labels: {} },
+    tracker: {
+      kind: "github" as const,
+      owner: "pmatos",
+      repo: "alpha",
+      token: "$GITHUB_TOKEN"
+    },
+    workspace: {
+      git: {
+        base_branch: "main",
+        remote: "git@github.com:pmatos/alpha.git"
+      },
+      root: "./.symphonika/workspaces/alpha"
+    },
+    workflow: {
+      format: "markdown" as const,
+      path: "./WORKFLOW.md"
+    }
+  };
+}

--- a/tests/routine-prompt-renderer.test.ts
+++ b/tests/routine-prompt-renderer.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { renderRoutinePrompt } from "../src/routines/prompt-renderer.js";
+import { renderAutonomousPrompt } from "../src/workflow.js";
+
+const baseInput = {
+  firing: {
+    id: "fire-1"
+  },
+  project: {
+    name: "symphonika"
+  },
+  provider: {
+    command: "codex fake",
+    name: "codex" as const
+  },
+  routine: {
+    kind: "report" as const,
+    name: "daily-report",
+    schedule_at: "2026-05-22T10:00:00.000Z",
+    source_path: "/tmp/daily-report.md"
+  },
+  template:
+    "Report {{routine.name}} for {{project.name}} in {{workspace.path}} via {{provider.name}} firing {{firing.id}}.",
+  templatePath: "/tmp/daily-report.md",
+  workspace: {
+    path: "/tmp/workspace/routines/daily-report/fire-1",
+    root: "/tmp/workspace"
+  }
+};
+
+describe("RoutinePromptRenderer", () => {
+  it("renders routine variables and prepends the standard autonomy preamble", () => {
+    const routinePrompt = renderRoutinePrompt(baseInput);
+    const issuePrompt = renderAutonomousPrompt({
+      branch: { name: "sym/x/1", ref: "refs/heads/sym/x/1" },
+      issue: {
+        body: "",
+        created_at: "",
+        id: 1,
+        labels: [],
+        number: 1,
+        priority: 99,
+        state: "open",
+        title: "Issue",
+        updated_at: "",
+        url: ""
+      },
+      project: { name: "symphonika" },
+      provider: baseInput.provider,
+      run: { attempt: 1, continuation: false, id: "run-1" },
+      template: "Report",
+      workflowPath: "/tmp/WORKFLOW.md",
+      workspace: {
+        path: "/tmp/workspace/issues/1",
+        previous_attempt: false,
+        root: "/tmp/workspace"
+      }
+    });
+
+    expect(routinePrompt.prompt).toContain(
+      "Report daily-report for symphonika in /tmp/workspace/routines/daily-report/fire-1 via codex firing fire-1."
+    );
+    expect(routinePrompt.prompt.slice(0, routinePrompt.prompt.indexOf("Report"))).toBe(
+      issuePrompt.prompt.slice(0, issuePrompt.prompt.indexOf("Report"))
+    );
+  });
+
+  it("rejects issue, run, and branch variables with prompt_render_error", () => {
+    for (const tag of ["{{issue.title}}", "{{run.id}}", "{{branch.name}}"]) {
+      expect(() =>
+        renderRoutinePrompt({
+          ...baseInput,
+          template: `Bad ${tag}`
+        })
+      ).toThrowError(/prompt_render_error/);
+    }
+  });
+});

--- a/tests/routine-schedule.test.ts
+++ b/tests/routine-schedule.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateRoutineSchedule } from "../src/routines/schedule.js";
+
+describe("ScheduleEvaluator", () => {
+  it("waits until a future one-shot at schedule", () => {
+    const result = evaluateRoutineSchedule({
+      lastFiredAt: null,
+      now: new Date("2026-05-22T10:00:00.000Z"),
+      schedule: { at: "2026-05-22T10:01:00.000Z" },
+      state: "active"
+    });
+
+    expect(result).toEqual({
+      at: "2026-05-22T10:01:00.000Z",
+      kind: "wait_until"
+    });
+  });
+
+  it("fires once when now reaches the one-shot at time", () => {
+    const result = evaluateRoutineSchedule({
+      lastFiredAt: null,
+      now: new Date("2026-05-22T10:01:00.000Z"),
+      schedule: { at: "2026-05-22T10:01:00.000Z" },
+      state: "active"
+    });
+
+    expect(result).toEqual({ kind: "fire_now" });
+  });
+
+  it("expires after a one-shot routine has fired", () => {
+    const result = evaluateRoutineSchedule({
+      lastFiredAt: "2026-05-22T10:01:02.000Z",
+      now: new Date("2026-05-22T10:02:00.000Z"),
+      schedule: { at: "2026-05-22T10:01:00.000Z" },
+      state: "expired"
+    });
+
+    expect(result).toEqual({ kind: "expired" });
+  });
+});

--- a/tests/routine-store.test.ts
+++ b/tests/routine-store.test.ts
@@ -159,4 +159,38 @@ describe("RunStore routines", () => {
       store.close();
     }
   });
+
+  it("markRoutineExpired claims active routines exactly once", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.syncRoutines("alpha", [
+        {
+          kind: "report",
+          name: "daily-report",
+          prompt: "Report.",
+          provider: "codex",
+          schedule: { at: "2026-05-22T10:00:00.000Z" },
+          sourcePath: "/tmp/daily-report.md"
+        }
+      ]);
+
+      const firstClaim = store.markRoutineExpired({
+        firedAt: "2026-05-22T10:00:02.000Z",
+        name: "daily-report",
+        projectName: "alpha"
+      });
+      const secondClaim = store.markRoutineExpired({
+        firedAt: "2026-05-22T10:00:03.000Z",
+        name: "daily-report",
+        projectName: "alpha"
+      });
+
+      expect(firstClaim).toBe(true);
+      expect(secondClaim).toBe(false);
+      expect(store.listRoutines()[0]?.lastFiredAt).toBe("2026-05-22T10:00:02.000Z");
+    } finally {
+      store.close();
+    }
+  });
 });

--- a/tests/routine-store.test.ts
+++ b/tests/routine-store.test.ts
@@ -160,6 +160,54 @@ describe("RunStore routines", () => {
     }
   });
 
+  it("claimRoutineFiring inserts the firing only when the claim wins", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.syncRoutines("alpha", [
+        {
+          kind: "report",
+          name: "daily-report",
+          prompt: "Report.",
+          provider: "codex",
+          schedule: { at: "2026-05-22T10:00:00.000Z" },
+          sourcePath: "/tmp/daily-report.md"
+        }
+      ]);
+
+      const first = store.claimRoutineFiring({
+        firedAt: "2026-05-22T10:00:02.000Z",
+        firingId: "fire-1",
+        projectName: "alpha",
+        providerCommand: "codex fake",
+        providerName: "codex",
+        routineName: "daily-report"
+      });
+      const second = store.claimRoutineFiring({
+        firedAt: "2026-05-22T10:00:03.000Z",
+        firingId: "fire-2",
+        projectName: "alpha",
+        providerCommand: "codex fake",
+        providerName: "codex",
+        routineName: "daily-report"
+      });
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+      expect(store.listRoutineFirings().map((firing) => firing.id)).toEqual([
+        "fire-1"
+      ]);
+      expect(store.listRoutines()[0]).toEqual(
+        expect.objectContaining({
+          lastFiredAt: "2026-05-22T10:00:02.000Z",
+          state: "expired"
+        })
+      );
+    } finally {
+      store.close();
+    }
+  });
+
   it("markRoutineExpired claims active routines exactly once", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });

--- a/tests/routine-store.test.ts
+++ b/tests/routine-store.test.ts
@@ -1,0 +1,162 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { openRunStore } from "../src/run-store.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-routine-store-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("RunStore routines", () => {
+  it("upserts routines and lists operator status fields", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.syncRoutines("alpha", [
+        {
+          kind: "report",
+          name: "daily-report",
+          prompt: "Report.",
+          provider: null,
+          schedule: { at: "2026-05-22T10:00:00.000Z" },
+          sourcePath: "/tmp/daily-report.md"
+        }
+      ]);
+
+      expect(store.listRoutines()).toEqual([
+        {
+          kind: "report",
+          lastFiredAt: null,
+          name: "daily-report",
+          nextFireAt: "2026-05-22T10:00:00.000Z",
+          projectName: "alpha",
+          provider: null,
+          scheduleAt: "2026-05-22T10:00:00.000Z",
+          sourcePath: "/tmp/daily-report.md",
+          state: "active"
+        }
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("removes routines that are no longer configured for the project", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.syncRoutines("alpha", [
+        {
+          kind: "report",
+          name: "daily-report",
+          prompt: "Report.",
+          provider: null,
+          schedule: { at: "2026-05-22T10:00:00.000Z" },
+          sourcePath: "/tmp/daily-report.md"
+        },
+        {
+          kind: "report",
+          name: "weekly-report",
+          prompt: "Report.",
+          provider: null,
+          schedule: { at: "2026-05-23T10:00:00.000Z" },
+          sourcePath: "/tmp/weekly-report.md"
+        }
+      ]);
+
+      store.syncRoutines("alpha", [
+        {
+          kind: "report",
+          name: "weekly-report",
+          prompt: "Updated report.",
+          provider: null,
+          schedule: { at: "2026-05-24T10:00:00.000Z" },
+          sourcePath: "/tmp/weekly-report.md"
+        }
+      ]);
+
+      expect(store.listRoutines().map((routine) => routine.name)).toEqual([
+        "weekly-report"
+      ]);
+      store.syncRoutines("alpha", []);
+      expect(store.listRoutines({ project: "alpha" })).toEqual([]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("records a firing and expires the one-shot routine", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.syncRoutines("alpha", [
+        {
+          kind: "report",
+          name: "daily-report",
+          prompt: "Report.",
+          provider: "codex",
+          schedule: { at: "2026-05-22T10:00:00.000Z" },
+          sourcePath: "/tmp/daily-report.md"
+        }
+      ]);
+      store.createRoutineFiring({
+        id: "fire-1",
+        projectName: "alpha",
+        providerCommand: "codex fake",
+        providerName: "codex",
+        routineName: "daily-report"
+      });
+      store.updateRoutineFiringState("fire-1", "preparing_workspace");
+      store.updateRoutineFiringState("fire-1", "running");
+      store.completeRoutineFiring({
+        id: "fire-1",
+        state: "succeeded",
+        workspacePath: "/tmp/workspace"
+      });
+      store.markRoutineExpired({
+        firedAt: "2026-05-22T10:00:02.000Z",
+        name: "daily-report",
+        projectName: "alpha"
+      });
+
+      expect(store.listRoutineFirings()).toEqual([
+        expect.objectContaining({
+          id: "fire-1",
+          projectName: "alpha",
+          provider: "codex",
+          routineName: "daily-report",
+          state: "succeeded",
+          terminalReason: null,
+          workspacePath: "/tmp/workspace"
+        })
+      ]);
+      expect(store.listRoutineFiringTransitions("fire-1").map((entry) => entry.state)).toEqual([
+        "queued",
+        "preparing_workspace",
+        "running",
+        "succeeded"
+      ]);
+      expect(store.listRoutines()[0]).toEqual(
+        expect.objectContaining({
+          lastFiredAt: "2026-05-22T10:00:02.000Z",
+          nextFireAt: null,
+          state: "expired"
+        })
+      );
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/tests/routine-surfaces.test.ts
+++ b/tests/routine-surfaces.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildCli } from "../src/cli.js";
+import { createHttpApp } from "../src/http/app.js";
+import { openRunStore } from "../src/run-store.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-routine-surfaces-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("routine operator surfaces", () => {
+  it("GET /api/routines returns routine status rows", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      seedRoutine(store);
+      const app = createHttpApp({
+        runStore: store,
+        stateRoot,
+        version: "0.1.0"
+      });
+
+      const response = await app.request("/api/routines");
+      const body = (await response.json()) as { routines: unknown[] };
+
+      expect(response.status).toBe(200);
+      expect(body.routines).toEqual([
+        expect.objectContaining({
+          lastFiredAt: null,
+          name: "daily-report",
+          nextFireAt: "2026-05-22T10:00:00.000Z",
+          projectName: "alpha",
+          state: "active"
+        })
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("renders routines on the local dashboard page", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      seedRoutine(store);
+      const app = createHttpApp({
+        runStore: store,
+        stateRoot,
+        version: "0.1.0"
+      });
+
+      const response = await app.request("/");
+      const body = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(body).toContain("Routines");
+      expect(body).toContain("daily-report");
+      expect(body).toContain("next_fire_at");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("symphonika routines lists routines per project", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    seedRoutine(store);
+    store.close();
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({
+      openRunStore: () => openRunStore({ stateRoot }),
+      registerSignalHandlers: false
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+    program.exitOverride();
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "routines",
+      "--config",
+      path.join(stateRoot, "symphonika.yml")
+    ]);
+
+    expect(output.stdout).toContain("project  routine  state  next_fire_at  last_fired_at");
+    expect(output.stdout).toContain(
+      "alpha  daily-report  active  2026-05-22T10:00:00.000Z  -"
+    );
+  });
+});
+
+function seedRoutine(store: ReturnType<typeof openRunStore>): void {
+  store.syncRoutines("alpha", [
+    {
+      kind: "report",
+      name: "daily-report",
+      prompt: "Report.",
+      provider: null,
+      schedule: { at: "2026-05-22T10:00:00.000Z" },
+      sourcePath: "/tmp/daily-report.md"
+    }
+  ]);
+}


### PR DESCRIPTION
Summary:
- add routine declaration loading, schedule evaluation, prompt rendering, and firing dispatch
- persist routine/routine_firing state and expose routines in CLI, dashboard, and API
- document routine concepts and add end-to-end tests

Validation:
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #190