### PR TITLE
chore(gitignore): ignore .codex marker file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ crash-*
 
 .claude/settings.local.json
 .claude/worktrees/
+.codex
 .ultraplan/


### PR DESCRIPTION
## Summary

- Add `.codex` to `.gitignore`, mirroring the existing `.claude/*` ignore rules.
- Codex CLI drops an empty `.codex` marker in the project root; this keeps it out of `git status` instead of forcing every contributor to stash or `git clean` around it.

No content is committed — the marker file itself is deleted from the working tree as part of this branch's setup, and future codex runs that re-create it will be ignored.

## Test plan

- [ ] After merge, run `codex` locally; confirm `.codex` re-appears in the working tree and does not show in `git status`.
- [ ] No functional changes — CI doc/lint jobs only.