### PR TITLE
fix(routines): hide routines for removed projects

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -516,6 +516,10 @@ Invalid Projects are disabled. Valid Projects may continue running.
 Existing runs continue by default. Removing a Project from service config marks it inactive rather
 than killing active full-permission agents. Operators can explicitly cancel runs.
 
+Routine rows for Projects omitted from the current valid service-config snapshot are marked
+inactive and pruned from operator routine listings on reload. Historical `routine_firings` rows
+remain durable run-store evidence.
+
 ### 8.5 Routines
 
 On each daemon tick, Symphonika evaluates loaded active Routines. Slice 1's `ScheduleEvaluator`

--- a/docs/adr/0021-graceful-project-disable-and-removal.md
+++ b/docs/adr/0021-graceful-project-disable-and-removal.md
@@ -1,3 +1,5 @@
 # Graceful project disable and removal
 
 Disabling a Project stops new dispatch immediately but lets existing runs continue by default. Removing a Project from service config marks it inactive rather than killing active full-permission agents; operators can explicitly cancel runs through the CLI or UI when interruption is required.
+
+Routine declarations are configuration-derived Project children, not the historical evidence itself. When a Project is omitted from the current valid service-config snapshot, its routine rows are marked inactive and pruned from operator routine listings; existing `routine_firings` rows remain in the run store for evidence and debugging.

--- a/src/routines/dispatcher.ts
+++ b/src/routines/dispatcher.ts
@@ -64,12 +64,22 @@ export async function dispatchDueRoutines(
   const prepareRoutineWorkspace =
     input.prepareRoutineWorkspace ?? defaultPrepareRoutineWorkspace;
   const createFiringId = input.createFiringId ?? (() => createUlid());
+  const projects = [...input.projects.values()];
 
-  for (const project of input.projects.values()) {
+  for (const project of projects) {
     if (project.disabled === true) {
       continue;
     }
     input.runStore.syncRoutines(project.name, project.routines ?? []);
+  }
+  input.runStore.pruneRoutinesForUnknownProjects(
+    projects.map((project) => project.name)
+  );
+
+  for (const project of projects) {
+    if (project.disabled === true) {
+      continue;
+    }
     for (const routine of input.runStore.listRoutines({ project: project.name })) {
       const evaluation = evaluateRoutineSchedule({
         lastFiredAt: routine.lastFiredAt,

--- a/src/routines/schedule.ts
+++ b/src/routines/schedule.ts
@@ -19,7 +19,7 @@ export type EvaluateRoutineScheduleInput = {
 export function evaluateRoutineSchedule(
   input: EvaluateRoutineScheduleInput
 ): RoutineScheduleEvaluation {
-  if (input.state === "expired" || input.lastFiredAt !== null) {
+  if (input.state !== "active" || input.lastFiredAt !== null) {
     return { kind: "expired" };
   }
 

--- a/src/routines/types.ts
+++ b/src/routines/types.ts
@@ -2,7 +2,7 @@ import type { AgentProviderName } from "../provider.js";
 
 export type RoutineKind = "report";
 
-export type RoutineState = "active" | "expired";
+export type RoutineState = "active" | "expired" | "inactive";
 
 export type RoutineFiringState =
   | "queued"

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -947,8 +947,25 @@ export class RunStore {
     apply();
   }
 
+  pruneRoutinesForUnknownProjects(projectNames: Iterable<string>): void {
+    const now = timestamp();
+    const names = [...new Set(projectNames)];
+    if (names.length === 0) {
+      this.database
+        .prepare("update routines set state = 'inactive', updated_at = ?")
+        .run(now);
+      return;
+    }
+    const placeholders = names.map(() => "?").join(", ");
+    this.database
+      .prepare(
+        `update routines set state = 'inactive', updated_at = ? where project_name not in (${placeholders})`
+      )
+      .run(now, ...names);
+  }
+
   listRoutines(filter: { project?: string } = {}): RoutineStatus[] {
-    const conditions: string[] = [];
+    const conditions: string[] = ["state != 'inactive'"];
     const params: Record<string, unknown> = {};
     if (filter.project !== undefined) {
       conditions.push("project_name = @project");
@@ -978,7 +995,7 @@ export class RunStore {
       .prepare(
         [
           "select project_name, name, source_path, kind, provider_name, schedule_at, state, last_fired_at, created_at, updated_at, prompt_body",
-          "from routines where project_name = ? and name = ?"
+          "from routines where project_name = ? and name = ? and state != 'inactive'"
         ].join(" ")
       )
       .get(input.projectName, input.name) as

--- a/tests/routine-daemon.test.ts
+++ b/tests/routine-daemon.test.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import pino from "pino";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { buildCli } from "../src/cli.js";
 import { startDaemon } from "../src/daemon.js";
+import { openRunStore } from "../src/run-store.js";
 import type { AgentProvider, ProviderEvent, ProviderRunInput } from "../src/provider.js";
 import type { PreparedRoutineWorkspace } from "../src/routines/workspace.js";
 
@@ -115,7 +117,78 @@ describe("daemon routine firing", () => {
       await daemon.stop();
     }
   });
+
+  it("prunes routine rows for projects removed from the service config", async () => {
+    const root = await makeTempRoot();
+    await writeRoutineProject(root, "2030-05-22T10:00:00.000Z");
+    const provider = quietProvider();
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi: {
+        addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareRoutineWorkspace: vi.fn()
+    });
+
+    try {
+      await waitForRoutine(daemon.url, "active");
+
+      await writeProjectWithoutRoutines(root, "beta");
+      await fetch(`${daemon.url}/api/poll-now`, { method: "POST" });
+      expect(await waitForNoRoutines(daemon.url)).toEqual([]);
+
+      const output = { stderr: "", stdout: "" };
+      const program = buildCli({
+        openRunStore: () =>
+          openRunStore({ stateRoot: path.join(root, ".symphonika") }),
+        registerSignalHandlers: false
+      });
+      program.configureOutput({
+        writeErr: (message) => {
+          output.stderr += message;
+        },
+        writeOut: (message) => {
+          output.stdout += message;
+        }
+      });
+      program.exitOverride();
+
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "routines",
+        "--config",
+        path.join(root, "symphonika.yml")
+      ]);
+
+      expect(output.stdout).toBe("(no routines)\n");
+    } finally {
+      await daemon.stop();
+    }
+  });
 });
+
+function quietProvider(): AgentProvider {
+  return {
+    cancel: vi.fn().mockResolvedValue(undefined),
+    name: "codex",
+    runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+      await Promise.resolve();
+      yield {
+        normalized: { exitCode: 0, type: "process_exit" },
+        raw: { code: 0, kind: "exit" }
+      };
+    }),
+    validate: vi.fn().mockResolvedValue(undefined)
+  };
+}
 
 async function writeRoutineProject(root: string, fireAt: string): Promise<void> {
   await mkdir(root, { recursive: true });
@@ -133,6 +206,21 @@ async function writeRoutineProject(root: string, fireAt: string): Promise<void> 
       ""
     ].join("\n")
   );
+  await writeProjectConfig(root, "alpha", ["./daily-report.md"]);
+}
+
+async function writeProjectWithoutRoutines(
+  root: string,
+  projectName: string
+): Promise<void> {
+  await writeProjectConfig(root, projectName, []);
+}
+
+async function writeProjectConfig(
+  root: string,
+  projectName: string,
+  routines: string[]
+): Promise<void> {
   await writeFile(
     path.join(root, "symphonika.yml"),
     [
@@ -146,12 +234,12 @@ async function writeRoutineProject(root: string, fireAt: string): Promise<void> 
       "  claude:",
       '    command: "claude fake"',
       "projects:",
-      "  - name: alpha",
+      `  - name: ${projectName}`,
       "    disabled: false",
       "    tracker:",
       "      kind: github",
       "      owner: pmatos",
-      "      repo: alpha",
+      `      repo: ${projectName}`,
       '      token: "$GITHUB_TOKEN"',
       "    issue_filters:",
       '      states: ["open"]',
@@ -161,18 +249,24 @@ async function writeRoutineProject(root: string, fireAt: string): Promise<void> 
       "      labels: {}",
       "      default: 99",
       "    workspace:",
-      "      root: ./.symphonika/workspaces/alpha",
+      `      root: ./.symphonika/workspaces/${projectName}`,
       "      git:",
-      "        remote: git@github.com:pmatos/alpha.git",
+      `        remote: git@github.com:pmatos/${projectName}.git`,
       "        base_branch: main",
       "    agent:",
       "      provider: codex",
       "    workflow: ./WORKFLOW.md",
-      "    routines:",
-      "      - ./daily-report.md",
+      ...routineLines(routines),
       ""
     ].join("\n")
   );
+}
+
+function routineLines(routines: string[]): string[] {
+  if (routines.length === 0) {
+    return [];
+  }
+  return ["    routines:", ...routines.map((routine) => `      - ${routine}`)];
 }
 
 async function waitForProviderInputs(
@@ -193,7 +287,7 @@ async function waitForRoutine(
   baseUrl: string,
   state: string
 ): Promise<RoutineApiRow[]> {
-  const deadline = Date.now() + 2_000;
+  const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
     const body = (await fetch(`${baseUrl}/api/routines`).then((response) =>
       response.json()
@@ -204,4 +298,18 @@ async function waitForRoutine(
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error(`routine did not reach ${state}`);
+}
+
+async function waitForNoRoutines(baseUrl: string): Promise<RoutineApiRow[]> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const body = (await fetch(`${baseUrl}/api/routines`).then((response) =>
+      response.json()
+    )) as { routines: RoutineApiRow[] };
+    if (body.routines.length === 0) {
+      return body.routines;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("routines were not pruned");
 }

--- a/tests/routine-store.test.ts
+++ b/tests/routine-store.test.ts
@@ -97,6 +97,43 @@ describe("RunStore routines", () => {
     }
   });
 
+  it("prunes routines for removed projects while preserving firing evidence", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.syncRoutines("alpha", [
+        {
+          kind: "report",
+          name: "daily-report",
+          prompt: "Report.",
+          provider: "codex",
+          schedule: { at: "2026-05-22T10:00:00.000Z" },
+          sourcePath: "/tmp/daily-report.md"
+        }
+      ]);
+      store.createRoutineFiring({
+        id: "fire-1",
+        projectName: "alpha",
+        providerCommand: "codex fake",
+        providerName: "codex",
+        routineName: "daily-report"
+      });
+
+      store.pruneRoutinesForUnknownProjects(["beta"]);
+
+      expect(store.listRoutines()).toEqual([]);
+      expect(store.listRoutineFirings()).toEqual([
+        expect.objectContaining({
+          id: "fire-1",
+          projectName: "alpha",
+          routineName: "daily-report"
+        })
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
   it("records a firing and expires the one-shot routine", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });


### PR DESCRIPTION
Summary:
- mark routine rows inactive when their Project is omitted from the current valid service-config snapshot
- hide inactive routines from /api/routines, dashboard/CLI listings, and routine dispatch lookups while preserving routine_firings evidence
- sync/prune routine declarations before evaluating due routine firings
- document the routine lifecycle decision in SPEC.md and ADR 0021

Stacking note: #205 references routine code introduced by open PR #196, so this branch is stacked on the current #196 head until that PR lands.

Validation:
- npm run lint
- npm run typecheck
- npm test -- --no-file-parallelism (63 files, 547 tests passed)
- npm run build

Note: exact parallel npm test was run twice and hit unrelated known prepared-workspace flakiness in codex-provider/dispatch/CLI timing tests; those failed files passed individually, and the serialized full suite passed.

Closes #205