### PR TITLE
ci: skip Claude review for bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Skip bot-authored PRs (e.g. Dependabot): claude-code-action rejects bot
+    # actors, and bot `pull_request` runs can't access CLAUDE_CODE_OAUTH_TOKEN
+    # anyway, so the job would always fail. See #215.
+    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What

Adds a job-level `if` to `.github/workflows/claude-code-review.yml` so the `claude-review` job is skipped for bot-authored PRs:

```yaml
if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
```

## Why

`anthropics/claude-code-action@v1` rejects non-human actors, so the job fails on **every** Dependabot PR:

```
Action failed with error: Workflow initiated by non-human actor: dependabot (type: Bot).
```

Allowing the bot (`allowed_bots`) wouldn't help: the workflow triggers on `pull_request` and authenticates via `secrets.CLAUDE_CODE_OAUTH_TOKEN`, which is **not available to Dependabot `pull_request` runs**, so the action would just fail later at auth. Skipping the job is the robust fix — a skipped job is not a failure, AI review of mechanical dep bumps is low value, and the secret is inaccessible to bot runs regardless.

Scoped to all bots (`*[bot]`) rather than only Dependabot so other bot PRs don't hit the same wall.

Surfaced by `pm-autofix-pr` while triaging #212 (the deps-bump diff is unrelated to this failure).

Closes #215