### PR TITLE
chore: ignore .impeccable/ local skill cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ crash-*
 .claude/settings.local.json
 .claude/worktrees/
 .codex
+.impeccable/
 .ultraplan/


### PR DESCRIPTION
## Summary

- Adds `.impeccable/` to `.gitignore` so the local skill cache (written under the repo root by the impeccable tooling) stops showing up as an untracked change.

Follow-up to #232, split out as its own PR since it's unrelated to the #231 tooling audit.