### PR TITLE
Make run detail page explain failures

### DIFF
--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -11,6 +11,7 @@ import {
 import type {
   ListRunsFilter,
   ProjectState,
+  ProviderEventRecord,
   RunArtifactDescriptor,
   RunState,
   RunStatus,
@@ -46,6 +47,12 @@ const KNOWN_RUN_STATES: ReadonlySet<RunState> = new Set([
   "cancelled",
   "stale"
 ]);
+
+const FAILURE_STATES: ReadonlySet<RunState> = new Set(["failed", "stale"]);
+
+// A single run's detail view is cheap to render; coalescing streamed message
+// tokens collapses hundreds of rows into a handful, so fetch a generous tail.
+const EVENT_TAIL_LIMIT = 500;
 
 export function registerPages(options: RegisterPagesOptions): void {
   options.app.get("/", (context) => {
@@ -94,7 +101,21 @@ export function registerPages(options: RegisterPagesOptions): void {
       );
     }
 
-    const events = options.runStore.listProviderEvents(id, { limit: 100 });
+    const tailDesc = options.runStore.listProviderEvents(id, {
+      limit: EVENT_TAIL_LIMIT,
+      order: "desc"
+    });
+    const events = tailDesc.slice().reverse();
+    const eventsTruncated = tailDesc.length >= EVENT_TAIL_LIMIT;
+    const isFailure = FAILURE_STATES.has(detail.state);
+    const terminalAttempt = detail.attempts[detail.attempts.length - 1];
+    const failureEvent = isFailure
+      ? options.runStore.getLastFailureEvent(id, terminalAttempt?.id)
+      : undefined;
+    const exitEvent = findLast(
+      events,
+      (event) => event.normalized.type === "process_exit"
+    );
     const artifacts = options.runStore.listRunArtifacts(id);
     const workflowGraph = await options.runStore.getWorkflowGraph(id);
     const capKind = parseCapReachedReason(detail.terminalReason);
@@ -110,12 +131,13 @@ export function registerPages(options: RegisterPagesOptions): void {
           };
     const sections = [
       `<h1>Run ${escapeHtml(detail.id)}</h1>`,
+      renderOutcomeBanner(detail, failureEvent, exitEvent),
       renderRunSummary(detail, capContext),
       renderWorkflowGraphSummary(workflowGraph),
       renderCancelForm(detail),
       renderAttemptsTable(detail.attempts),
       renderTransitionsTable(detail.transitions),
-      renderEventsTable(events),
+      renderEventsTable(events, eventsTruncated),
       renderRunFileLinks(detail.id, artifacts)
     ].join("");
     return context.html(layout(`Run ${detail.id}`, sections));
@@ -140,6 +162,15 @@ code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
 .state-failed, .state-cancelled, .state-stale { color: #b00020; }
 .state-succeeded { color: #007a3d; }
 nav a { margin-right: 1rem; }
+.banner { border-radius: 6px; padding: 0.75rem 1rem; margin: 0.8rem 0 1.2rem; }
+.banner-failed { background: #fdecef; border: 1px solid #f2b8c2; }
+.banner-title { font-weight: 700; margin: 0 0 0.35rem; }
+.banner-failed .banner-title { color: #b00020; }
+.banner-reason { margin: 0 0 0.4rem; white-space: pre-wrap; font-size: 0.95rem; }
+.banner-context { margin: 0; font-size: 0.82rem; color: #555; }
+.banner-context code { background: rgba(0,0,0,0.05); padding: 0 0.2rem; border-radius: 3px; }
+.msg { white-space: pre-wrap; font-family: inherit; max-height: 22rem; overflow: auto; margin: 0; }
+.hint { color: #555; font-size: 0.82rem; margin: 0.2rem 0 0.6rem; }
 </style>
 </head>
 <body>
@@ -382,27 +413,155 @@ function renderTransitionsTable(
   return `<section><h2>State transitions</h2><table><thead><tr><th>Seq</th><th>State</th><th>At</th></tr></thead><tbody>${rows}</tbody></table></section>`;
 }
 
+function renderOutcomeBanner(
+  detail: RunStatus,
+  failureEvent: ProviderEventRecord | undefined,
+  exitEvent: ProviderEventRecord | undefined
+): string {
+  // Only failure-state runs get a banner. A prior attempt's failure event must
+  // never surface on a run that ultimately succeeded or is still running.
+  if (!FAILURE_STATES.has(detail.state)) {
+    return "";
+  }
+  const providerMessage =
+    failureEvent !== undefined &&
+    typeof failureEvent.normalized.message === "string"
+      ? failureEvent.normalized.message
+      : undefined;
+
+  const reason =
+    providerMessage !== undefined
+      ? `<p class="banner-reason">${escapeHtml(providerMessage)}</p>`
+      : `<p class="banner-reason">No provider failure message was recorded. See the transcript and logs below.</p>`;
+
+  const context: string[] = [];
+  if (detail.terminalReason !== null) {
+    context.push(
+      `terminal reason <code>${escapeHtml(detail.terminalReason)}</code>`
+    );
+  }
+  const abnormalExit = formatAbnormalExit(exitEvent);
+  if (abnormalExit !== undefined) {
+    context.push(abnormalExit);
+  }
+  context.push(`provider <code>${escapeHtml(detail.provider)}</code>`);
+  if (failureEvent !== undefined) {
+    context.push(`event #${failureEvent.sequence}`);
+  }
+
+  return `<section class="banner banner-failed"><p class="banner-title">Run ${escapeHtml(detail.state)}</p>${reason}<p class="banner-context">${context.join(" &middot; ")}</p></section>`;
+}
+
+// Exit code is reported only when abnormal: codex exits 0 even after refusing a
+// task, so a "process exited 0" line next to a failure would mislead.
+function formatAbnormalExit(
+  exitEvent: ProviderEventRecord | undefined
+): string | undefined {
+  if (exitEvent === undefined) {
+    return undefined;
+  }
+  const normalized = exitEvent.normalized;
+  const exitCode =
+    typeof normalized.exitCode === "number" ? normalized.exitCode : undefined;
+  const signal =
+    typeof normalized.signal === "string" ? normalized.signal : undefined;
+  const bits: string[] = [];
+  if (exitCode !== undefined && exitCode !== 0) {
+    bits.push(`exit code ${exitCode}`);
+  }
+  if (signal !== undefined) {
+    bits.push(`signal ${signal}`);
+  }
+  return bits.length === 0 ? undefined : `process ${bits.join(", ")}`;
+}
+
+type EventDisplayRow =
+  | {
+      kind: "message";
+      firstSequence: number;
+      lastSequence: number;
+      text: string;
+      createdAt: string;
+    }
+  | {
+      kind: "event";
+      sequence: number;
+      type: string;
+      detail: string;
+      createdAt: string;
+    };
+
+// Codex streams assistant text one token per event; merge runs of adjacent
+// message events into a single readable block, breaking on any other event.
+function coalesceEvents(events: ProviderEventRecord[]): EventDisplayRow[] {
+  const rows: EventDisplayRow[] = [];
+  let buffer: Extract<EventDisplayRow, { kind: "message" }> | undefined;
+  const flush = (): void => {
+    if (buffer !== undefined) {
+      rows.push(buffer);
+      buffer = undefined;
+    }
+  };
+
+  for (const event of events) {
+    const message = event.normalized.message;
+    if (event.type === "message" && typeof message === "string") {
+      if (buffer === undefined) {
+        buffer = {
+          createdAt: event.createdAt,
+          firstSequence: event.sequence,
+          kind: "message",
+          lastSequence: event.sequence,
+          text: message
+        };
+      } else {
+        buffer.text += message;
+        buffer.lastSequence = event.sequence;
+        buffer.createdAt = event.createdAt;
+      }
+      continue;
+    }
+
+    flush();
+    rows.push({
+      createdAt: event.createdAt,
+      detail:
+        typeof message === "string"
+          ? message
+          : JSON.stringify(event.normalized),
+      kind: "event",
+      sequence: event.sequence,
+      type: event.type
+    });
+  }
+
+  flush();
+  return rows;
+}
+
 function renderEventsTable(
-  events: {
-    sequence: number;
-    type: string;
-    createdAt: string;
-    normalized: { type: string; [key: string]: unknown };
-  }[]
+  events: ProviderEventRecord[],
+  truncated: boolean
 ): string {
   if (events.length === 0) {
-    return `<section><h2>Recent events</h2><p><em>No events recorded yet.</em></p></section>`;
+    return `<section><h2>Transcript &amp; events</h2><p><em>No events recorded yet.</em></p></section>`;
   }
-  const rows = events
-    .map((event) => {
-      const message =
-        typeof event.normalized.message === "string"
-          ? event.normalized.message
-          : JSON.stringify(event.normalized);
-      return `<tr><td>${event.sequence}</td><td>${escapeHtml(event.type)}</td><td><code>${escapeHtml(message)}</code></td><td>${escapeHtml(event.createdAt)}</td></tr>`;
+  const rows = coalesceEvents(events)
+    .map((row) => {
+      if (row.kind === "message") {
+        const seq =
+          row.firstSequence === row.lastSequence
+            ? `${row.firstSequence}`
+            : `${row.firstSequence}–${row.lastSequence}`;
+        return `<tr><td>${seq}</td><td>message</td><td><div class="msg">${escapeHtml(row.text)}</div></td><td>${escapeHtml(row.createdAt)}</td></tr>`;
+      }
+      return `<tr><td>${row.sequence}</td><td>${escapeHtml(row.type)}</td><td><code>${escapeHtml(row.detail)}</code></td><td>${escapeHtml(row.createdAt)}</td></tr>`;
     })
     .join("");
-  return `<section><h2>Recent events (last ${events.length})</h2><table><thead><tr><th>Seq</th><th>Type</th><th>Detail</th><th>At</th></tr></thead><tbody>${rows}</tbody></table></section>`;
+  const scope = truncated
+    ? `most recent ${events.length}`
+    : `all ${events.length}`;
+  return `<section><h2>Transcript &amp; events</h2><p class="hint">Showing ${scope} events, oldest first. Streamed message tokens are merged into blocks; full logs are under Files below.</p><table><thead><tr><th>Seq</th><th>Type</th><th>Detail</th><th>At</th></tr></thead><tbody>${rows}</tbody></table></section>`;
 }
 
 function renderRunFileLinks(
@@ -465,6 +624,19 @@ function formatArtifactKind(kind: RunArtifactDescriptor["kind"]): string {
     case "provider_normalized":
       return "Normalized event log";
   }
+}
+
+function findLast<T>(
+  items: readonly T[],
+  predicate: (item: T) => boolean
+): T | undefined {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item !== undefined && predicate(item)) {
+      return item;
+    }
+  }
+  return undefined;
 }
 
 function escapeHtml(value: string): string {

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -101,12 +101,15 @@ export function registerPages(options: RegisterPagesOptions): void {
       );
     }
 
+    // Fetch one extra row so we can distinguish "exactly EVENT_TAIL_LIMIT
+    // events, nothing cut" from "more than EVENT_TAIL_LIMIT, truncated" — the
+    // count label must not claim truncation when none happened.
     const tailDesc = options.runStore.listProviderEvents(id, {
-      limit: EVENT_TAIL_LIMIT,
+      limit: EVENT_TAIL_LIMIT + 1,
       order: "desc"
     });
-    const events = tailDesc.slice().reverse();
-    const eventsTruncated = tailDesc.length >= EVENT_TAIL_LIMIT;
+    const eventsTruncated = tailDesc.length > EVENT_TAIL_LIMIT;
+    const events = tailDesc.slice(0, EVENT_TAIL_LIMIT).reverse();
     const isFailure = FAILURE_STATES.has(detail.state);
     const terminalAttempt = detail.attempts[detail.attempts.length - 1];
     const failureEvent = isFailure

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -112,10 +112,18 @@ export function registerPages(options: RegisterPagesOptions): void {
     const failureEvent = isFailure
       ? options.runStore.getLastFailureEvent(id, terminalAttempt?.id)
       : undefined;
-    const exitEvent = findLast(
-      events,
-      (event) => event.normalized.type === "process_exit"
-    );
+    // Scope to the terminal attempt for the same reason failureEvent is: an
+    // earlier attempt's abnormal process_exit must not be attributed to the
+    // terminal failure (e.g. a stale run whose terminal attempt was killed via
+    // the watchdog DB update and never emitted its own process_exit).
+    const exitEvent = isFailure
+      ? findLast(
+          events,
+          (event) =>
+            event.normalized.type === "process_exit" &&
+            event.attemptId === terminalAttempt?.id
+        )
+      : undefined;
     const artifacts = options.runStore.listRunArtifacts(id);
     const workflowGraph = await options.runStore.getWorkflowGraph(id);
     const capKind = parseCapReachedReason(detail.terminalReason);

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -350,6 +350,18 @@ type ProviderEventRow = {
   type: string;
 };
 
+function mapProviderEventRow(row: ProviderEventRow): ProviderEventRecord {
+  return {
+    attemptId: row.attempt_id,
+    createdAt: row.created_at,
+    normalized: JSON.parse(row.normalized_json) as NormalizedProviderEvent,
+    raw: JSON.parse(row.raw_json) as unknown,
+    runId: row.run_id,
+    sequence: row.sequence,
+    type: row.type
+  };
+}
+
 type WatchdogCandidateRunRow = {
   id: string;
   issue_number: number;
@@ -1681,15 +1693,38 @@ export class RunStore {
       )
       .all(params) as ProviderEventRow[];
 
-    return rows.map((row) => ({
-      attemptId: row.attempt_id,
-      createdAt: row.created_at,
-      normalized: JSON.parse(row.normalized_json) as NormalizedProviderEvent,
-      raw: JSON.parse(row.raw_json) as unknown,
-      runId: row.run_id,
-      sequence: row.sequence,
-      type: row.type
-    }));
+    return rows.map((row) => mapProviderEventRow(row));
+  }
+
+  // Provider event `sequence` resets to 1 on every attempt, so an unscoped
+  // `order by sequence desc` would pick whichever attempt produced the most
+  // events, not the latest one. Callers pass the terminal attempt id to get the
+  // failure that actually determined the run's outcome.
+  getLastFailureEvent(
+    runId: string,
+    attemptId?: string
+  ): ProviderEventRecord | undefined {
+    const conditions = [
+      "run_id = @runId",
+      "type in ('turn_failed', 'malformed_event')"
+    ];
+    const params: Record<string, unknown> = { runId };
+    if (attemptId !== undefined) {
+      conditions.push("attempt_id = @attemptId");
+      params.attemptId = attemptId;
+    }
+    const row = this.database
+      .prepare(
+        [
+          "select run_id, attempt_id, sequence, type, raw_json, normalized_json, created_at",
+          "from provider_events",
+          `where ${conditions.join(" and ")}`,
+          "order by sequence desc, id desc",
+          "limit 1"
+        ].join(" ")
+      )
+      .get(params) as ProviderEventRow | undefined;
+    return row === undefined ? undefined : mapProviderEventRow(row);
   }
 
   listRunArtifacts(runId: string): RunArtifactDescriptor[] {

--- a/tests/run-store-detail.test.ts
+++ b/tests/run-store-detail.test.ts
@@ -694,6 +694,71 @@ describe("RunStore detail queries", () => {
       store.close();
     }
   });
+
+  it("getLastFailureEvent is scoped to the requested attempt", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.createRun({
+        id: "r-fail",
+        issue: sampleIssue(),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      for (const attemptNumber of [1, 2]) {
+        store.createAttempt({
+          attemptNumber,
+          branchName: "branch",
+          branchRef: "refs/heads/branch",
+          id: `r-fail-attempt-${attemptNumber}`,
+          issueSnapshotPath: "/tmp/snap.json",
+          metadataPath: "/tmp/meta.json",
+          normalizedLogPath: "/tmp/normalized.jsonl",
+          promptPath: "/tmp/prompt.md",
+          providerCommand: "x",
+          providerName: "codex",
+          rawLogPath: "/tmp/raw.jsonl",
+          runId: "r-fail",
+          state: "running",
+          workflowGraphPath: "",
+          workspacePath: "/tmp/work"
+        });
+      }
+      // sequence resets per attempt: attempt-1 fails late (seq 5), attempt-2
+      // fails early (seq 1). An unscoped `order by sequence desc` would wrongly
+      // pick attempt-1's message for a run whose terminal attempt is attempt-2.
+      store.recordProviderEvent({
+        attemptId: "r-fail-attempt-1",
+        normalized: { type: "turn_failed", message: "attempt-1 refusal" },
+        raw: { kind: "turn_failed" },
+        runId: "r-fail",
+        sequence: 5
+      });
+      store.recordProviderEvent({
+        attemptId: "r-fail-attempt-2",
+        normalized: { type: "turn_failed", message: "attempt-2 crash" },
+        raw: { kind: "turn_failed" },
+        runId: "r-fail",
+        sequence: 1
+      });
+
+      expect(
+        store.getLastFailureEvent("r-fail", "r-fail-attempt-2")?.normalized
+          .message
+      ).toBe("attempt-2 crash");
+      expect(
+        store.getLastFailureEvent("r-fail", "r-fail-attempt-1")?.normalized
+          .message
+      ).toBe("attempt-1 refusal");
+      // A terminal attempt with no failure event must not inherit a prior one.
+      expect(
+        store.getLastFailureEvent("r-fail", "r-fail-attempt-missing")
+      ).toBeUndefined();
+    } finally {
+      store.close();
+    }
+  });
 });
 
 async function streamText(


### PR DESCRIPTION
## Problem

The `/runs/:id` page was unusable for diagnosing failed runs. On a real failed run (`aeca19b8-…`, a codex refusal), the page showed hundreds of single-token rows and no failure reason. Three compounding defects:

1. **The failure reason was structurally hidden.** The page called `listProviderEvents(id, {limit: 100})`, which returns the **first** 100 events (`order by sequence asc`), while the heading claimed *"Recent events (last 100)."* The run's terminal `turn_failed` event was #479 of 480 — never in the rendered window.
2. **Token-per-row transcript.** Codex streams assistant text one token per `item/agentMessage/delta` event; each became its own row (342 of 374 events on that run).
3. **Only jargon shown.** The summary displayed `terminal_reason: workflow_terminal_blocked`; the human-readable provider message was never surfaced.

## Changes

- **Failure banner** at the top of `/runs/:id` for failed/stale runs, surfacing the terminal attempt's provider failure message, with `terminal_reason` + provider as secondary context. Exit code is shown *only when abnormal* — codex exits `0` after refusing, so an "exit 0" line would mislead.
- **Coalesced transcript** — runs of adjacent streamed `message` events merge into readable prose blocks, breaking on any other event type.
- **Tail, not head** — fetches the most-recent events (`order desc`, reversed to chronological) with an honest count label.
- `RunStore.getLastFailureEvent(runId, attemptId?)`, **attempt-scoped**: provider event `sequence` resets per attempt and attempts share a `run_id`, so an unscoped lookup would pick the wrong attempt and could paint a stale failure banner on a run that *succeeded on retry*. New regression test locks this down.

## Verification

Served the built page against the live DB and loaded the real failed run:

- Banner: **"Run failed — This content was flagged for possible cybersecurity risk…"** (the message the old page hid).
- Context: `terminal reason workflow_terminal_blocked · provider codex · event #479`.
- Transcript: **342 token-rows → 6 prose blocks**; heading *"Showing all 374 events, oldest first."*

Typecheck, eslint, prettier clean; test suite passes (Node v22).

## Follow-ups (not in this PR)

- Capture codex `stderr` (currently discarded) so a crash reason survives when there's no JSON-RPC failure event.
- Persist a failure summary onto the run row.