### PR TITLE
feat: add per-project watchdog grace overrides

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -278,6 +278,13 @@ projects:
 
 The bootstrap slice must use this final multi-project shape even with one configured Project.
 
+A Project may override only `watchdog.grace_minutes` with a positive integer. It inherits
+`watchdog.enabled`, `watchdog.sample_interval_seconds`, and `watchdog.mtime_ignore` from daemon
+scope, so a Project can lengthen its grace window but cannot opt into a daemon-disabled Watchdog.
+Project overrides are part of the defensive Service Config reload snapshot: any invalid value or
+unknown key rejects the candidate snapshot for all Projects and leaves the last known-good snapshot
+live.
+
 ### 5.2 Workflow Contract
 
 Each Project must reference a valid `WORKFLOW.md`.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -327,6 +327,10 @@ export async function startDaemon(
     if (!state.configExists) {
       return;
     }
+    const serviceConfig = runtimeConfig.getSnapshot();
+    if (serviceConfig === undefined) {
+      return;
+    }
     const projects = runtimeConfig.projectsByName();
     if (projects.size === 0) {
       return;
@@ -367,7 +371,7 @@ export async function startDaemon(
     }
 
     try {
-      const watchdog = runtimeConfig.watchdogConfig();
+      const watchdog = serviceConfig.watchdog;
       const nowMs = Date.now();
       if (
         watchdog.enabled &&
@@ -379,6 +383,7 @@ export async function startDaemon(
           config: watchdog,
           logger,
           now: () => new Date(nowMs),
+          projects: serviceConfig.projects,
           runStore
         });
       }

--- a/src/lifecycle/watchdog.ts
+++ b/src/lifecycle/watchdog.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import type { Logger } from "pino";
 
 import type { NormalizedProviderEvent } from "../provider.js";
-import type { WatchdogConfig } from "../reload.js";
+import {
+  resolveWatchdogConfig,
+  type WatchdogConfig,
+  type WatchdogServiceConfig
+} from "../reload.js";
 import type {
   RunStore,
   WatchdogCandidateRun,
@@ -22,6 +26,7 @@ export type ReconcileWatchdogInput = {
   config: WatchdogConfig;
   logger?: Logger;
   now?: () => Date;
+  projects?: WatchdogServiceConfig["projects"];
   runStore: RunStore;
 };
 
@@ -58,13 +63,18 @@ export async function reconcileWatchdog(
 
   const now = input.now?.() ?? new Date();
   const sampledAt = now.toISOString();
+  const serviceConfig: WatchdogServiceConfig = {
+    projects: input.projects ?? [],
+    watchdog: input.config
+  };
   let sampled = 0;
   let terminated = 0;
 
   for (const run of input.runStore.listWatchdogCandidateRuns()) {
+    const config = resolveWatchdogConfig(serviceConfig, run.projectName);
     const previous = input.runStore.getWatchdogSample(run.runId);
     const next = await sampleRun({
-      mtimeIgnore: input.config.mtimeIgnore,
+      mtimeIgnore: config.mtimeIgnore,
       previous,
       run,
       runStore: input.runStore,
@@ -96,10 +106,7 @@ export async function reconcileWatchdog(
     if (progress || idleSince === null) {
       continue;
     }
-    if (
-      now.getTime() - Date.parse(idleSince) <
-      input.config.graceMinutes * 60_000
-    ) {
+    if (now.getTime() - Date.parse(idleSince) < config.graceMinutes * 60_000) {
       continue;
     }
 

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -42,7 +42,7 @@ export type RuntimeConfigSnapshot = {
   loadedAt: string;
   polling: PollingServiceConfig;
   pollingIntervalMs: number;
-  projects: RunControllerProjectConfig[];
+  projects: RuntimeProjectConfig[];
   providers: RunControllerProvidersConfig;
   pullRequestPolicy: PullRequestFollowupPolicy;
   watchdog: WatchdogConfig;
@@ -66,6 +66,22 @@ export type WatchdogConfig = {
   graceMinutes: number;
   mtimeIgnore: string[];
   sampleIntervalSeconds: number;
+};
+
+export type ProjectWatchdogConfig = {
+  graceMinutes: number;
+};
+
+export type RuntimeProjectConfig = RunControllerProjectConfig & {
+  watchdog?: ProjectWatchdogConfig;
+};
+
+export type WatchdogServiceConfig = {
+  projects: readonly {
+    name: string;
+    watchdog?: ProjectWatchdogConfig;
+  }[];
+  watchdog: WatchdogConfig;
 };
 
 const DEFAULT_WATCHDOG_CONFIG: WatchdogConfig = {
@@ -98,6 +114,12 @@ const watchdogConfigSchema = z
     mtime_ignore: z.array(z.string().trim().min(1)).default([])
   })
   .passthrough();
+
+const projectWatchdogConfigSchema = z
+  .object({
+    grace_minutes: z.number().int().positive()
+  })
+  .strict();
 
 const pollingProjectSchema = z
   .object({
@@ -140,6 +162,7 @@ const runtimeProjectDetailSchema = z
   .object({
     name: z.string().trim().min(1),
     routines: z.array(pathStringSchema).optional(),
+    watchdog: projectWatchdogConfigSchema.optional(),
     workspace: projectWorkspaceSchema,
     workflow: workflowReferenceSchema
   })
@@ -225,10 +248,6 @@ export class RuntimeConfigReloader {
     return this.snapshot?.globalConcurrency ?? { maxInFlight: undefined };
   }
 
-  watchdogConfig(): WatchdogConfig {
-    return this.snapshot?.watchdog ?? DEFAULT_WATCHDOG_CONFIG;
-  }
-
   async reload(): Promise<RuntimeConfigSnapshot | undefined> {
     const attemptedAt = new Date().toISOString();
     const reloadInput = {
@@ -295,7 +314,7 @@ async function loadRuntimeConfigSnapshot(input: {
   }
 
   const pollingProjects: PollingProjectConfig[] = [];
-  const dispatchProjects: RunControllerProjectConfig[] = [];
+  const dispatchProjects: RuntimeProjectConfig[] = [];
 
   for (const [index, rawProject] of parsed.data.projects.entries()) {
     const pollingProject = pollingProjectSchema.safeParse(rawProject);
@@ -326,6 +345,13 @@ async function loadRuntimeConfigSnapshot(input: {
       dispatchProjects.push({
         ...pollingProject.data,
         routines: [],
+        ...(detail.data.watchdog === undefined
+          ? {}
+          : {
+              watchdog: {
+                graceMinutes: detail.data.watchdog.grace_minutes
+              }
+            }),
         workflow: detail.data.workflow,
         workspace: detail.data.workspace
       });
@@ -353,6 +379,13 @@ async function loadRuntimeConfigSnapshot(input: {
     dispatchProjects.push({
       ...pollingProject.data,
       routines,
+      ...(detail.data.watchdog === undefined
+        ? {}
+        : {
+            watchdog: {
+              graceMinutes: detail.data.watchdog.grace_minutes
+            }
+          }),
       workflow,
       workspace: detail.data.workspace
     });
@@ -404,6 +437,22 @@ function normalizeWatchdogConfig(
     sampleIntervalSeconds:
       raw?.sample_interval_seconds ??
       DEFAULT_WATCHDOG_CONFIG.sampleIntervalSeconds
+  };
+}
+
+export function resolveWatchdogConfig(
+  serviceConfig: WatchdogServiceConfig,
+  projectName: string
+): WatchdogConfig {
+  const projectOverride = serviceConfig.projects.find(
+    (project) => project.name === projectName
+  )?.watchdog;
+  if (projectOverride === undefined) {
+    return serviceConfig.watchdog;
+  }
+  return {
+    ...serviceConfig.watchdog,
+    graceMinutes: projectOverride.graceMinutes
   };
 }
 

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -68,11 +68,11 @@ export type WatchdogConfig = {
   sampleIntervalSeconds: number;
 };
 
-export type ProjectWatchdogConfig = {
+type ProjectWatchdogConfig = {
   graceMinutes: number;
 };
 
-export type RuntimeProjectConfig = RunControllerProjectConfig & {
+type RuntimeProjectConfig = RunControllerProjectConfig & {
   watchdog?: ProjectWatchdogConfig;
 };
 

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -328,6 +328,30 @@ async function loadRuntimeConfigSnapshot(input: {
     }
     pollingProjects.push(pollingProject.data);
 
+    // SPEC 5.1: an invalid Project watchdog override — a non-positive-integer
+    // grace_minutes or an unknown key — rejects the entire candidate snapshot
+    // for all Projects, even on first load (where there is no last-known-good,
+    // so nothing goes live). This is stricter than the other detail fields
+    // below (workspace, workflow, ...), whose first-load failure only drops the
+    // offending Project from dispatch while valid siblings keep polling.
+    const rawWatchdog = (rawProject as { watchdog?: unknown }).watchdog;
+    if (rawWatchdog !== undefined) {
+      const watchdogOverride =
+        projectWatchdogConfigSchema.safeParse(rawWatchdog);
+      if (!watchdogOverride.success) {
+        errors.push(
+          ...watchdogOverride.error.issues.map((issue) =>
+            formatZodIssueWithPrefix(issue, [
+              "projects",
+              String(index),
+              "watchdog"
+            ])
+          )
+        );
+        return lastKnownGoodOrNothing(input.previous, errors);
+      }
+    }
+
     const detail = runtimeProjectDetailSchema.safeParse(rawProject);
     if (!detail.success) {
       errors.push(

--- a/symphonika.example.yml
+++ b/symphonika.example.yml
@@ -29,6 +29,10 @@ projects:
     # per-project shared bare-repo fetch lock — see ADR 0053. Omit (or
     # leave commented) to keep the default.
     # max_in_flight: 1
+    # Verification-heavy Projects can lengthen the daemon Watchdog grace.
+    # enabled, sample_interval_seconds, and mtime_ignore remain daemon-scoped.
+    # watchdog:
+    #   grace_minutes: 180
     tracker:
       kind: github
       owner: pmatos

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { RuntimeConfigReloader } from "../src/reload.js";
+import { resolveWatchdogConfig, RuntimeConfigReloader } from "../src/reload.js";
 
 const tempRoots: string[] = [];
 
@@ -25,7 +25,11 @@ afterEach(async () => {
 async function writeProjectConfig(
   root: string,
   workflowFileName: string,
-  options: { serviceLines?: string[]; workspaceHookLines?: string[] } = {}
+  options: {
+    projectLines?: string[];
+    serviceLines?: string[];
+    workspaceHookLines?: string[];
+  } = {}
 ): Promise<void> {
   await mkdir(root, { recursive: true });
   await writeFile(
@@ -45,6 +49,7 @@ async function writeProjectConfig(
       "  - name: symphonika",
       "    disabled: false",
       "    weight: 1",
+      ...(options.projectLines ?? []),
       "    tracker:",
       "      kind: github",
       "      owner: pmatos",
@@ -832,6 +837,155 @@ describe("RuntimeConfigReloader concurrency caps", () => {
 });
 
 describe("RuntimeConfigReloader watchdog config", () => {
+  it("resolves a Project grace override while inheriting daemon settings", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md", {
+      projectLines: ["    watchdog:", "      grace_minutes: 180"],
+      serviceLines: [
+        "watchdog:",
+        "  enabled: true",
+        "  grace_minutes: 30",
+        "  sample_interval_seconds: 45",
+        "  mtime_ignore:",
+        '    - "*.log"'
+      ]
+    });
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work\n");
+
+    const reloader = new RuntimeConfigReloader({
+      configPath: path.join(root, "symphonika.yml")
+    });
+    const snapshot = await reloader.reload();
+
+    expect(snapshot).toBeDefined();
+    expect(resolveWatchdogConfig(snapshot!, "symphonika")).toEqual({
+      enabled: true,
+      graceMinutes: 180,
+      mtimeIgnore: ["*.log"],
+      sampleIntervalSeconds: 45
+    });
+  });
+
+  it("keeps every Project on the last-known-good snapshot when one override is invalid", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md", {
+      projectLines: ["    watchdog:", "      grace_minutes: 180"],
+      serviceLines: [
+        "watchdog:",
+        "  enabled: true",
+        "  grace_minutes: 30",
+        "  sample_interval_seconds: 60"
+      ]
+    });
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work\n");
+    const configPath = path.join(root, "symphonika.yml");
+    const oneProjectConfig = await readFile(configPath, "utf8");
+    const projectStart = oneProjectConfig.indexOf("  - name: symphonika");
+    const s11Project = oneProjectConfig
+      .slice(projectStart)
+      .replace("  - name: symphonika", "  - name: s11")
+      .replace("      grace_minutes: 180", "      grace_minutes: 30");
+    await writeFile(
+      configPath,
+      oneProjectConfig.replace("  - name: symphonika", "  - name: vow") +
+        s11Project
+    );
+
+    const reloader = new RuntimeConfigReloader({ configPath });
+    const firstSnapshot = await reloader.reload();
+    expect(resolveWatchdogConfig(firstSnapshot!, "vow").graceMinutes).toBe(180);
+
+    const validConfig = await readFile(configPath, "utf8");
+    await writeFile(
+      configPath,
+      validConfig.replace("      grace_minutes: 30", "      grace_minutes: 1.5")
+    );
+    await reloader.reload();
+
+    expect(reloader.getSnapshot()).toBe(firstSnapshot);
+    expect(
+      resolveWatchdogConfig(reloader.getSnapshot()!, "vow").graceMinutes
+    ).toBe(180);
+    expect(reloader.getStatus()).toMatchObject({
+      ok: false,
+      usingLastKnownGood: true
+    });
+    expect(reloader.getStatus().errors.join("\n")).toMatch(
+      /projects\.1\.watchdog\.grace_minutes/
+    );
+  });
+
+  it("rejects unknown Project watchdog keys and keeps the last-known-good snapshot", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md", {
+      projectLines: ["    watchdog:", "      grace_minutes: 180"]
+    });
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work\n");
+    const configPath = path.join(root, "symphonika.yml");
+    const reloader = new RuntimeConfigReloader({ configPath });
+    const firstSnapshot = await reloader.reload();
+    const validConfig = await readFile(configPath, "utf8");
+
+    await writeFile(
+      configPath,
+      validConfig.replace(
+        "      grace_minutes: 180",
+        ["      grace_minutes: 180", "      sample_interval_seconds: 5"].join(
+          "\n"
+        )
+      )
+    );
+    await reloader.reload();
+
+    expect(reloader.getSnapshot()).toBe(firstSnapshot);
+    expect(reloader.getStatus()).toMatchObject({
+      ok: false,
+      usingLastKnownGood: true
+    });
+    expect(reloader.getStatus().errors.join("\n")).toMatch(
+      /projects\.0\.watchdog.*unrecognized key/i
+    );
+  });
+
+  it.each(["0", "-1", '"180"'])(
+    "rejects Project grace_minutes: %s",
+    async (graceMinutes) => {
+      const root = await makeTempRoot();
+      await writeProjectConfig(root, "WORKFLOW.md", {
+        projectLines: ["    watchdog:", `      grace_minutes: ${graceMinutes}`]
+      });
+      await writeFile(path.join(root, "WORKFLOW.md"), "Work\n");
+      const reloader = new RuntimeConfigReloader({
+        configPath: path.join(root, "symphonika.yml")
+      });
+
+      await reloader.reload();
+
+      expect(reloader.getStatus().ok).toBe(false);
+      expect(reloader.getStatus().errors.join("\n")).toMatch(
+        /projects\.0\.watchdog\.grace_minutes/
+      );
+    }
+  );
+
+  it("keeps daemon disable authoritative over a Project grace override", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md", {
+      projectLines: ["    watchdog:", "      grace_minutes: 180"],
+      serviceLines: ["watchdog:", "  enabled: false"]
+    });
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work\n");
+    const reloader = new RuntimeConfigReloader({
+      configPath: path.join(root, "symphonika.yml")
+    });
+    const snapshot = await reloader.reload();
+
+    expect(resolveWatchdogConfig(snapshot!, "symphonika")).toMatchObject({
+      enabled: false,
+      graceMinutes: 180
+    });
+  });
+
   it("defaults the daemon-scope watchdog settings", async () => {
     const root = await makeTempRoot();
     await writeProjectConfig(root, "WORKFLOW.md");
@@ -848,6 +1002,10 @@ describe("RuntimeConfigReloader watchdog config", () => {
       mtimeIgnore: [],
       sampleIntervalSeconds: 60
     });
+    const snapshot = reloader.getSnapshot()!;
+    expect(resolveWatchdogConfig(snapshot, "symphonika")).toBe(
+      snapshot.watchdog
+    );
   });
 
   it("parses explicit daemon-scope watchdog settings", async () => {

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -915,6 +915,42 @@ describe("RuntimeConfigReloader watchdog config", () => {
     );
   });
 
+  it("rejects the whole candidate snapshot on first load when one Project override is invalid", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md", {
+      projectLines: ["    watchdog:", "      grace_minutes: 180"]
+    });
+    await writeFile(path.join(root, "WORKFLOW.md"), "Work\n");
+    const configPath = path.join(root, "symphonika.yml");
+    const oneProjectConfig = await readFile(configPath, "utf8");
+    const projectStart = oneProjectConfig.indexOf("  - name: symphonika");
+    const invalidSecondProject = oneProjectConfig
+      .slice(projectStart)
+      .replace("  - name: symphonika", "  - name: s11")
+      .replace("      grace_minutes: 180", "      grace_minutes: 0");
+    await writeFile(
+      configPath,
+      oneProjectConfig.replace("  - name: symphonika", "  - name: vow") +
+        invalidSecondProject
+    );
+
+    const reloader = new RuntimeConfigReloader({ configPath });
+    const snapshot = await reloader.reload();
+
+    // No prior snapshot exists, so one invalid override must reject the entire
+    // candidate: nothing goes live, not even the valid sibling "vow".
+    expect(snapshot).toBeUndefined();
+    expect(reloader.getSnapshot()).toBeUndefined();
+    expect(reloader.projectsByName().size).toBe(0);
+    expect(reloader.getStatus()).toMatchObject({
+      ok: false,
+      usingLastKnownGood: false
+    });
+    expect(reloader.getStatus().errors.join("\n")).toMatch(
+      /projects\.1\.watchdog\.grace_minutes/
+    );
+  });
+
   it("rejects unknown Project watchdog keys and keeps the last-known-good snapshot", async () => {
     const root = await makeTempRoot();
     await writeProjectConfig(root, "WORKFLOW.md", {

--- a/tests/watchdog.test.ts
+++ b/tests/watchdog.test.ts
@@ -333,6 +333,68 @@ describe("reconcileWatchdog", () => {
     }
   });
 
+  it("uses the Project grace override when deciding whether an idle run is stale", async () => {
+    const root = await makeTempRoot();
+    const workspacePath = path.join(root, "workspace");
+    await mkdir(workspacePath, { recursive: true });
+    const normalizedLogPath = path.join(root, "provider.normalized.jsonl");
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      seedRun(store, "run-vow", "vow");
+      store.updateRunEvidence("run-vow", {
+        branchName: "sym/vow/200-watchdog",
+        branchRef: "refs/heads/sym/vow/200-watchdog",
+        issueSnapshotPath: path.join(root, "issue.json"),
+        metadataPath: path.join(root, "metadata.json"),
+        normalizedLogPath,
+        promptPath: path.join(root, "prompt.md"),
+        rawLogPath: path.join(root, "raw.jsonl"),
+        workflowGraphPath: path.join(root, "workflow.json"),
+        workspacePath
+      });
+      store.updateRunState("run-vow", "running");
+      store.upsertWatchdogSample({
+        idleSince: "2026-05-22T09:00:00.000Z",
+        lastMessageAt: null,
+        lastToolCallAt: null,
+        normalizedLogOffset: 0,
+        normalizedLogPath,
+        outputTokensTotal: 0,
+        runId: "run-vow",
+        sampledAt: "2026-05-22T09:00:00.000Z",
+        turnIdSetSize: 0,
+        workspaceMtimeMax: await sampleWorkspaceMtimeMax(workspacePath)
+      });
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const activeRuns = new ActiveRunRegistry();
+      activeRuns.register({
+        cancel,
+        issueNumber: 198,
+        projectName: "vow",
+        runId: "run-vow"
+      });
+
+      await reconcileWatchdog({
+        activeRuns,
+        config: {
+          enabled: true,
+          graceMinutes: 30,
+          mtimeIgnore: [],
+          sampleIntervalSeconds: 60
+        },
+        logger,
+        now: () => new Date("2026-05-22T10:00:00.000Z"),
+        projects: [{ name: "vow", watchdog: { graceMinutes: 180 } }],
+        runStore: store
+      });
+
+      expect(store.getRun("run-vow")?.state).toBe("running");
+      expect(cancel).not.toHaveBeenCalled();
+    } finally {
+      store.close();
+    }
+  });
+
   it("starts normalized-log sampling at the stored offset", async () => {
     const root = await makeTempRoot();
     const workspacePath = path.join(root, "workspace");
@@ -1084,7 +1146,11 @@ describe("reconcileWatchdog", () => {
   });
 });
 
-function seedRun(store: RunStore, id: string): void {
+function seedRun(
+  store: RunStore,
+  id: string,
+  projectName = "symphonika"
+): void {
   store.createRun({
     id,
     issue: {
@@ -1099,7 +1165,7 @@ function seedRun(store: RunStore, id: string): void {
       updated_at: "2026-05-22T09:00:00.000Z",
       url: "https://example.test/198"
     },
-    projectName: "symphonika",
+    projectName,
     providerCommand: "codex fake",
     providerName: "codex"
   });


### PR DESCRIPTION
## Summary

- parse and strictly validate positive-integer Project Watchdog grace overrides through defensive reload
- resolve effective Watchdog settings per Project and use them in Run sampling
- preserve daemon disable/inheritance semantics and document the operator configuration

## Validation

- npm run lint
- npm run typecheck
- NPM_CONFIG_DANGEROUSLY_ALLOW_ALL_SCRIPTS=true npm test (607 tests; npm 12 accommodation for the existing npm-link packaging test)
- npm run build
- npm run format:check

Closes #200