### PR TITLE
feat: add workflow evidence ignores to watchdog

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -285,6 +285,24 @@ Each Project must reference a valid `WORKFLOW.md`.
 `WORKFLOW.md` is reloadable and repository-owned. It contains the prompt body and may contain
 optional YAML front matter for prompt-adjacent execution policy.
 
+Markdown Workflow Contract front matter may declare repository-owned Watchdog evidence noise as
+workspace-relative directory paths:
+
+```yaml
+---
+evidence:
+  ignore:
+    - vendor/
+    - out/
+---
+```
+
+Each `evidence.ignore` entry must be a non-empty string, must not start with `/`, and must not
+contain `..`. The list is additive to the Watchdog's built-in directory excludes; it cannot disable
+them. Invalid entries make the Workflow Contract invalid through the normal doctor and defensive
+reload surfaces. Unlike the rendered prompt captured for an attempt, the current valid
+`evidence.ignore` policy is resolved for active Runs on every Watchdog reconciliation tick.
+
 Workflow contracts are re-read as part of the daemon's defensive service-config reload. A valid
 workflow edit applies to future attempts. In-flight attempts keep the rendered prompt and workflow
 content hash captured when the attempt was created. If a reload sees an invalid workflow for an
@@ -856,9 +874,11 @@ Sampling reads the Normalized Event Log only forward of the stored byte offset a
 Workspace tree once. A transient retry writes a new per-attempt log path, so the byte offset and the
 output-token baseline are reset whenever `normalized_log_path` changes and the new attempt's events
 are read from the start. The hard-coded v1 exclude set is `.git/`, `target/`, and `node_modules/`,
-skipped at the directory-entry level and not descended; `watchdog.mtime_ignore` adds
-workspace-relative globs whose matching files are dropped from the mtime walk at the individual-file
-level, so build-output churn (e.g. `*.log`) cannot keep a wedged Run alive.
+skipped at the directory-entry level and not descended. The current per-Project Workflow Contract's
+`evidence.ignore` list adds workspace-relative directory trees that are also skipped before descent;
+the hard-coded set always remains active. Separately, `watchdog.mtime_ignore` adds workspace-relative
+globs whose matching files are dropped from the mtime walk at the individual-file level, so
+build-output churn (e.g. `*.log`) cannot keep a wedged Run alive.
 
 A sampled Run is making progress when any one signal advances since the previous sample:
 

--- a/docs/adr/0054-watchdog-progress-liveness.md
+++ b/docs/adr/0054-watchdog-progress-liveness.md
@@ -29,13 +29,11 @@ A Progress Signal is the tuple:
 - `last_tool_call_at` — timestamp of the most recent `NormalizedProviderEventType = "tool_call"`
   event.
 - `workspace_mtime_max` — maximum file mtime under the Run's `workspacePath`, with `.git/`,
-  `target/`, `node_modules/`, and any workspace-relative glob listed in the watchdog config's
-  `mtime_ignore` set excluded so build-output churn neither masks real stalls nor forces them. The
-  exclude set lives in the `watchdog` service config (below) — not in the Workflow Contract, whose
-  parsed front matter the contract loader discards. Carrying it requires the service-config reload
-  schema and the `RuntimeConfigSnapshot` to gain an explicit, validated `watchdog` field as part of
-  this work; today the schema only passes unknown top-level keys through and the snapshot is built
-  from known fields, so a `watchdog` block would otherwise be dropped before the daemon reads it.
+  `target/`, and `node_modules/` excluded at the directory level. The daemon-owned watchdog config's
+  `mtime_ignore` set excludes matching individual files. The follow-up evidence-ignore slice also
+  retains a repository-owned `evidence.ignore` directory list from Markdown Workflow Contract front
+  matter; those workspace-relative trees are pruned before descent while the built-in set always
+  remains active. Together these layers keep build-output churn from masking real stalls.
 - `turn_id_set_size` — distinct `turnId` values observed across `usage_updated` and
   `turn_completed` events. Only the Codex provider tags these events with a `turnId`; the Claude
   provider emits `sessionId` instead, so this signal advances for Codex Runs only. Claude Runs
@@ -152,6 +150,12 @@ must not overwrite it with `no_progress` — this mirrors the existing `reconcil
    clock is started in step 5 rather than tripping the threshold immediately.
 5. Otherwise persists the still-idle sample, setting `idle_since` on the first idle observation
    (when it is still unset) so the grace clock starts on first idle and survives restarts.
+
+The evidence-ignore follow-up resolves the current valid Workflow Contract snapshot for each Run's
+Project on every daemon reconciliation tick. Invalid `evidence.ignore` edits use the same
+operator-visible reload error and last-known-good snapshot behavior as other Workflow Contract
+validation failures. Declared entries prune matching directory entries before metadata reads or
+descent; the service-config `mtime_ignore` glob layer continues to filter individual files.
 
 Separately from the per-tick steps above, `idle_since` is cleared as a transition-time hook
 whenever a Run leaves `running` for `waiting`. This cannot be a step of the sampling loop, which

--- a/docs/specs/2026-07-19-workflow-evidence-ignore-design.md
+++ b/docs/specs/2026-07-19-workflow-evidence-ignore-design.md
@@ -1,0 +1,41 @@
+# Workflow Contract evidence-ignore design
+
+Status: accepted by issue #201
+
+## Goal
+
+Let a Project declare workspace-relative directory trees in Markdown Workflow Contract front matter
+whose mtimes do not count as Watchdog progress. The policy is additive to the built-in `.git/`,
+`target/`, and `node_modules/` excludes and remains separate from service-config
+`watchdog.mtime_ignore`, which filters individual files by glob.
+
+## Selected design
+
+`parseWorkflowContract` retains a validated `evidence.ignore` list on the parsed contract. Entries
+must be non-empty strings, must not start with `/`, and must not contain `..`. The runtime reload
+pipeline copies the policy into each Markdown `WorkflowSnapshot`; invalid edits use the existing
+reload-error and last-known-good behavior.
+
+On each daemon reconciliation tick, the Watchdog resolves the current Workflow Snapshot for the
+sampled Run's Project. The workspace walker compares each directory's workspace-relative POSIX path
+with the declared set before reading metadata or descending. Built-in excludes are checked
+independently and therefore cannot be replaced by Workflow Contract configuration.
+
+Raw-FSM workflow files are unchanged. Issue #201 and ADR 0054 define this policy as Markdown
+Workflow Contract front matter, and no raw-FSM location for prompt-adjacent policy is specified.
+
+## Alternatives considered
+
+- Adding more service-config globs would not express repository-owned per-Project policy and would
+  retain file-level traversal rather than pruning whole trees.
+- Extending the built-in directory set would require a Symphonika release for every Project-specific
+  build directory.
+- Adding a raw-FSM policy location in this slice would invent syntax beyond issue #201.
+
+## Validation and tests
+
+Tests cover contract parsing, absolute/parent/non-string rejection, doctor surfacing, defensive
+reload fallback, directory-pruning behavior, built-in excludes, ignored-only stale termination,
+unignored progress, and simultaneous ignored and normal workspace changes. Daemon-level tests prove
+that the current Workflow Contract snapshot reaches the Watchdog rather than only exercising the
+walker in isolation.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -377,6 +377,12 @@ export async function startDaemon(
         await reconcileWatchdog({
           activeRuns,
           config: watchdog,
+          evidenceIgnoreForProject: (projectName) => {
+            const workflow = projects.get(projectName)?.workflow;
+            return workflow !== undefined && "expandedWorkflow" in workflow
+              ? workflow.evidence.ignore
+              : [];
+          },
           logger,
           now: () => new Date(nowMs),
           runStore

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -53,6 +53,7 @@ import type {
   ExpandedWorkflow,
   ExpandedWorkflowState,
   WorkflowAction,
+  WorkflowEvidence,
   WorkflowPredicateMap
 } from "../workflow.js";
 
@@ -75,6 +76,7 @@ import { buildCapReachedReason } from "./terminal-reason.js";
 export type WorkflowSnapshot = {
   body: string;
   contentHash: string;
+  evidence: WorkflowEvidence;
   expandedWorkflow: ExpandedWorkflow;
   format: WorkflowReference["format"];
   path: string;
@@ -83,6 +85,7 @@ export type WorkflowSnapshot = {
 type LoadedWorkflow = {
   body: string;
   contentHash: string;
+  evidence: WorkflowEvidence;
   errors: string[];
   expandedWorkflow: ExpandedWorkflow;
   format: WorkflowReference["format"];
@@ -2587,6 +2590,7 @@ export class RunController {
     return {
       body: workflow.body,
       contentHash: workflow.contentHash,
+      evidence: workflow.evidence,
       errors: [],
       expandedWorkflow: workflow.expandedWorkflow,
       format: workflow.format,
@@ -2615,6 +2619,7 @@ export class RunController {
         return {
           body: "",
           contentHash: expanded.workflow.contentHash,
+          evidence: { ignore: [] },
           errors: expanded.errors,
           expandedWorkflow: expanded.workflow,
           format,
@@ -2625,6 +2630,7 @@ export class RunController {
       return {
         body: contract.body,
         contentHash: contract.contentHash,
+        evidence: contract.evidence,
         errors: [...contract.errors, ...expanded.errors],
         expandedWorkflow: expanded.workflow,
         format,
@@ -2635,6 +2641,7 @@ export class RunController {
     return {
       body: workflow.body,
       contentHash: workflow.contentHash,
+      evidence: workflow.evidence,
       errors: [],
       expandedWorkflow: workflow.expandedWorkflow,
       format: workflow.format,

--- a/src/lifecycle/watchdog.ts
+++ b/src/lifecycle/watchdog.ts
@@ -20,6 +20,7 @@ const WORKSPACE_PROGRESS_THRESHOLD_MS = 1_000;
 export type ReconcileWatchdogInput = {
   activeRuns: ActiveRunRegistry;
   config: WatchdogConfig;
+  evidenceIgnoreForProject?: (projectName: string) => readonly string[];
   logger?: Logger;
   now?: () => Date;
   runStore: RunStore;
@@ -64,6 +65,7 @@ export async function reconcileWatchdog(
   for (const run of input.runStore.listWatchdogCandidateRuns()) {
     const previous = input.runStore.getWatchdogSample(run.runId);
     const next = await sampleRun({
+      directoryIgnore: input.evidenceIgnoreForProject?.(run.projectName) ?? [],
       mtimeIgnore: input.config.mtimeIgnore,
       previous,
       run,
@@ -125,7 +127,8 @@ export async function reconcileWatchdog(
 
 export async function sampleWorkspaceMtimeMax(
   workspacePath: string,
-  mtimeIgnore: readonly string[] = []
+  mtimeIgnore: readonly string[] = [],
+  directoryIgnore: readonly string[] = []
 ): Promise<number> {
   if (workspacePath.length === 0) {
     return 0;
@@ -137,10 +140,14 @@ export async function sampleWorkspaceMtimeMax(
       return Math.floor(root.mtimeMs);
     }
     const ignore = mtimeIgnore.map(globToRegExp);
+    const ignoredDirectories = new Set(
+      directoryIgnore.map(normalizeDirectoryIgnore)
+    );
     return await walkWorkspaceMtimeMax(
       workspacePath,
       workspacePath,
       ignore,
+      ignoredDirectories,
       Math.floor(root.mtimeMs)
     );
   } catch {
@@ -149,6 +156,7 @@ export async function sampleWorkspaceMtimeMax(
 }
 
 async function sampleRun(input: {
+  directoryIgnore: readonly string[];
   mtimeIgnore: readonly string[];
   previous: WatchdogSample | undefined;
   run: WatchdogCandidateRun;
@@ -200,7 +208,8 @@ async function sampleRun(input: {
     turnIdSetSize,
     workspaceMtimeMax: await sampleWorkspaceMtimeMax(
       input.run.workspacePath,
-      input.mtimeIgnore
+      input.mtimeIgnore,
+      input.directoryIgnore
     )
   };
 }
@@ -240,6 +249,7 @@ async function walkWorkspaceMtimeMax(
   directory: string,
   workspaceRoot: string,
   ignore: readonly RegExp[],
+  ignoredDirectories: ReadonlySet<string>,
   currentMax: number
 ): Promise<number> {
   let max = currentMax;
@@ -251,10 +261,15 @@ async function walkWorkspaceMtimeMax(
   }
 
   for await (const entry of dir) {
-    if (entry.isDirectory() && WORKSPACE_EXCLUDED_DIRS.has(entry.name)) {
+    const entryPath = path.join(directory, entry.name);
+    const relative = workspaceRelativePath(workspaceRoot, entryPath);
+    if (
+      entry.isDirectory() &&
+      (WORKSPACE_EXCLUDED_DIRS.has(entry.name) ||
+        ignoredDirectories.has(relative))
+    ) {
       continue;
     }
-    const entryPath = path.join(directory, entry.name);
     let stats;
     try {
       // lstat (not stat) so symlinks are never followed: a symlinked directory
@@ -271,7 +286,13 @@ async function walkWorkspaceMtimeMax(
       max = Math.max(max, Math.floor(stats.mtimeMs));
       max = Math.max(
         max,
-        await walkWorkspaceMtimeMax(entryPath, workspaceRoot, ignore, max)
+        await walkWorkspaceMtimeMax(
+          entryPath,
+          workspaceRoot,
+          ignore,
+          ignoredDirectories,
+          max
+        )
       );
     } else if (!isMtimeIgnored(workspaceRoot, entryPath, ignore)) {
       // ADR 0054: drop files whose workspace-relative path matches an
@@ -291,11 +312,19 @@ function isMtimeIgnored(
   if (ignore.length === 0) {
     return false;
   }
-  const relative = path
-    .relative(workspaceRoot, entryPath)
-    .split(path.sep)
-    .join("/");
+  const relative = workspaceRelativePath(workspaceRoot, entryPath);
   return ignore.some((pattern) => pattern.test(relative));
+}
+
+function normalizeDirectoryIgnore(directory: string): string {
+  return directory.replace(/^\.\/+/, "").replace(/\/+$/, "");
+}
+
+function workspaceRelativePath(
+  workspaceRoot: string,
+  entryPath: string
+): string {
+  return path.relative(workspaceRoot, entryPath).split(path.sep).join("/");
 }
 
 // Compile a workspace-relative glob to an anchored RegExp. `*` matches within a

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -323,10 +323,23 @@ async function loadRuntimeConfigSnapshot(input: {
     }
 
     if (pollingProject.data.disabled === true) {
+      // Disabling a Project halts new dispatch but does not cancel an active
+      // run, and the Project stays in the runtime map. Carry forward the last
+      // loaded WorkflowSnapshot when one exists so the Watchdog keeps this
+      // Project's evidence.ignore policy for its still-running rows; otherwise
+      // build-output churn would masquerade as progress and keep a wedged run
+      // alive (ADR 0054).
+      const previousWorkflow = input.previous?.projects.find(
+        (project) => project.name === pollingProject.data.name
+      )?.workflow;
       dispatchProjects.push({
         ...pollingProject.data,
         routines: [],
-        workflow: detail.data.workflow,
+        workflow:
+          previousWorkflow !== undefined &&
+          "expandedWorkflow" in previousWorkflow
+            ? previousWorkflow
+            : detail.data.workflow,
         workspace: detail.data.workspace
       });
       continue;

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -470,6 +470,7 @@ async function readWorkflowSnapshot(
     return {
       body: "",
       contentHash: expanded.workflow.contentHash,
+      evidence: { ignore: [] },
       expandedWorkflow: expanded.workflow,
       format,
       path: workflowPath
@@ -485,6 +486,7 @@ async function readWorkflowSnapshot(
   return {
     body: workflow.body,
     contentHash: workflow.contentHash,
+    evidence: workflow.evidence,
     expandedWorkflow: expanded.workflow,
     format,
     path: workflow.path

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -20,7 +20,10 @@ export {
   validateWorkflowContract,
   validateWorkflowTemplate
 } from "./workflow/contract-loading.js";
-export type { WorkflowContract } from "./workflow/contract-loading.js";
+export type {
+  WorkflowContract,
+  WorkflowEvidence
+} from "./workflow/contract-loading.js";
 export {
   expandWorkflowDefinition,
   explainWorkflow,

--- a/src/workflow/contract-loading.ts
+++ b/src/workflow/contract-loading.ts
@@ -8,8 +8,13 @@ import { validatePromptTemplateExpressions } from "./autonomous-prompt.js";
 export type WorkflowContract = {
   body: string;
   contentHash: string;
+  evidence: WorkflowEvidence;
   errors: string[];
   path: string;
+};
+
+export type WorkflowEvidence = {
+  ignore: string[];
 };
 
 export type ProjectWorkflowReference = {
@@ -71,6 +76,7 @@ export function parseWorkflowContract(
     return {
       body: contents,
       contentHash: contentHash(contents),
+      evidence: { ignore: [] },
       errors: [],
       path: workflowPath
     };
@@ -83,6 +89,7 @@ export function parseWorkflowContract(
     return {
       body: "",
       contentHash: contentHash(contents),
+      evidence: { ignore: [] },
       errors: [
         `workflow front matter at ${workflowPath} is missing a closing ---`
       ],
@@ -93,6 +100,7 @@ export function parseWorkflowContract(
   const frontMatterSource = lines.slice(1, closingLine).join("\n");
   const errors: string[] = [];
   const frontMatter = parseFrontMatter(frontMatterSource, workflowPath, errors);
+  const evidence = parseWorkflowEvidence(frontMatter, workflowPath, errors);
 
   if (frontMatter !== undefined) {
     for (const key of Object.keys(frontMatter)) {
@@ -107,9 +115,60 @@ export function parseWorkflowContract(
   return {
     body: lines.slice(closingLine + 1).join("\n"),
     contentHash: contentHash(contents),
+    evidence,
     errors,
     path: workflowPath
   };
+}
+
+function parseWorkflowEvidence(
+  frontMatter: Record<string, unknown> | undefined,
+  workflowPath: string,
+  errors: string[]
+): WorkflowEvidence {
+  const rawEvidence = frontMatter?.evidence;
+  if (rawEvidence === undefined) {
+    return { ignore: [] };
+  }
+  if (!isRecord(rawEvidence)) {
+    errors.push(
+      `workflow front matter at ${workflowPath} evidence must be a mapping`
+    );
+    return { ignore: [] };
+  }
+  if (rawEvidence.ignore === undefined) {
+    return { ignore: [] };
+  }
+  if (!Array.isArray(rawEvidence.ignore)) {
+    errors.push(
+      `workflow front matter at ${workflowPath} evidence.ignore must be a list`
+    );
+    return { ignore: [] };
+  }
+  const ignore: string[] = [];
+  for (const [index, entry] of rawEvidence.ignore.entries()) {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      errors.push(
+        `workflow front matter at ${workflowPath} evidence.ignore[${index}] must be a non-empty string`
+      );
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (trimmed.includes("..")) {
+      errors.push(
+        `workflow front matter at ${workflowPath} evidence.ignore[${index}] must not contain ..`
+      );
+      continue;
+    }
+    if (trimmed.startsWith("/")) {
+      errors.push(
+        `workflow front matter at ${workflowPath} evidence.ignore[${index}] must be workspace-relative`
+      );
+      continue;
+    }
+    ignore.push(trimmed);
+  }
+  return { ignore };
 }
 
 export function validateWorkflowTemplate(

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -290,6 +290,29 @@ describe("doctor", () => {
     expect(output.stdout).toContain("doctor ok");
   });
 
+  it("reports invalid Workflow Contract evidence.ignore entries", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeValidConfig(configPath);
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      [
+        "---",
+        "evidence:",
+        '  ignore: ["../escape"]',
+        "---",
+        "Work on {{issue.title}} for {{project.name}}.",
+        ""
+      ].join("\n")
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stderr).toContain("evidence.ignore[0] must not contain ..");
+  });
+
   it("rejects workflow front matter service discovery keys", async () => {
     const root = await makeTempRoot();
     const configPath = path.join(root, "symphonika.yml");

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -301,6 +301,83 @@ describe("RuntimeConfigReloader workflow validation", () => {
     ]);
   });
 
+  it("retains Workflow Contract evidence.ignore in the Project snapshot", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md");
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      [
+        "---",
+        "evidence:",
+        '  ignore: ["vendor/", "out/"]',
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n")
+    );
+
+    const reloader = new RuntimeConfigReloader({
+      configPath: path.join(root, "symphonika.yml")
+    });
+    await reloader.reload();
+
+    const workflow = reloader.projectsByName().get("symphonika")?.workflow;
+    if (workflow === undefined || !("expandedWorkflow" in workflow)) {
+      throw new Error("expected workflow snapshot to be an object");
+    }
+    expect(workflow.evidence.ignore).toEqual(["vendor/", "out/"]);
+  });
+
+  it("keeps the last-known-good Workflow Contract when evidence.ignore becomes invalid", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md");
+    const workflowPath = path.join(root, "WORKFLOW.md");
+    await writeFile(
+      workflowPath,
+      [
+        "---",
+        "evidence:",
+        '  ignore: ["vendor/"]',
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n")
+    );
+
+    const reloader = new RuntimeConfigReloader({
+      configPath: path.join(root, "symphonika.yml")
+    });
+    await reloader.reload();
+    const firstSnapshot = reloader.getSnapshot();
+
+    await writeFile(
+      workflowPath,
+      [
+        "---",
+        "evidence:",
+        '  ignore: ["../escape"]',
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n")
+    );
+    await reloader.reload();
+
+    expect(reloader.getSnapshot()).toBe(firstSnapshot);
+    const workflow = reloader.projectsByName().get("symphonika")?.workflow;
+    if (workflow === undefined || !("expandedWorkflow" in workflow)) {
+      throw new Error("expected the last-known-good workflow snapshot");
+    }
+    expect(workflow.evidence.ignore).toEqual(["vendor/"]);
+    expect(reloader.getStatus()).toMatchObject({
+      ok: false,
+      usingLastKnownGood: true
+    });
+    expect(reloader.getStatus().errors.join("\n")).toContain(
+      "evidence.ignore[0] must not contain .."
+    );
+  });
+
   it("keeps the last-known-good snapshot when project detail validation fails on reload", async () => {
     const root = await makeTempRoot();
     await writeProjectConfig(root, "WORKFLOW.md");

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -328,6 +328,66 @@ describe("RuntimeConfigReloader workflow validation", () => {
     expect(workflow.evidence.ignore).toEqual(["vendor/", "out/"]);
   });
 
+  it("retains a disabled Project's evidence.ignore across the reload that disables it", async () => {
+    const root = await makeTempRoot();
+    await writeProjectConfig(root, "WORKFLOW.md");
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      [
+        "---",
+        "evidence:",
+        '  ignore: ["vendor/", "out/"]',
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n")
+    );
+
+    const configPath = path.join(root, "symphonika.yml");
+    const reloader = new RuntimeConfigReloader({ configPath });
+    await reloader.reload();
+
+    const enabledWorkflow = reloader
+      .projectsByName()
+      .get("symphonika")?.workflow;
+    if (
+      enabledWorkflow === undefined ||
+      !("expandedWorkflow" in enabledWorkflow)
+    ) {
+      throw new Error(
+        "expected the enabled Project to load a workflow snapshot"
+      );
+    }
+    expect(enabledWorkflow.evidence.ignore).toEqual(["vendor/", "out/"]);
+
+    // Disabling a Project halts new dispatch but does not cancel an already
+    // active run; the Watchdog keeps sampling that run, so its evidence.ignore
+    // policy must survive the reload that flips the Project to disabled.
+    const disabledConfig = (await readFile(configPath, "utf8")).replace(
+      "disabled: false",
+      "disabled: true"
+    );
+    await writeFile(configPath, disabledConfig);
+    await reloader.reload();
+
+    expect(reloader.getStatus()).toMatchObject({
+      ok: true,
+      usingLastKnownGood: false
+    });
+    const disabledWorkflow = reloader
+      .projectsByName()
+      .get("symphonika")?.workflow;
+    if (
+      disabledWorkflow === undefined ||
+      !("expandedWorkflow" in disabledWorkflow)
+    ) {
+      throw new Error(
+        "expected the disabled Project to retain its workflow snapshot"
+      );
+    }
+    expect(disabledWorkflow.evidence.ignore).toEqual(["vendor/", "out/"]);
+  });
+
   it("keeps the last-known-good Workflow Contract when evidence.ignore becomes invalid", async () => {
     const root = await makeTempRoot();
     await writeProjectConfig(root, "WORKFLOW.md");

--- a/tests/watchdog-daemon.test.ts
+++ b/tests/watchdog-daemon.test.ts
@@ -73,12 +73,14 @@ describe("daemon watchdog", () => {
     }
   });
 
-  it("keeps a provider alive when workspace mtime is the only progress signal", async () => {
+  it("keeps a provider alive when an undeclared vendor directory is its only progress signal", async () => {
     const root = await makeTempRoot();
     await writeProject(root);
     const prepared = preparedWorkspaceFixture(root);
-    await mkdir(prepared.workspacePath, { recursive: true });
-    const provider = workspaceMtimeProvider();
+    await mkdir(path.join(prepared.workspacePath, "vendor"), {
+      recursive: true
+    });
+    const provider = workspaceMtimeProvider("vendor/heartbeat.txt");
 
     const daemon = await startDaemon({
       agentProviders: { codex: provider },
@@ -97,6 +99,79 @@ describe("daemon watchdog", () => {
       const run = await getRun(daemon.url, "run-watchdog-mtime");
       expect(run).toMatchObject({
         id: "run-watchdog-mtime",
+        state: "running",
+        terminalReason: null
+      });
+    } finally {
+      provider.stopAll();
+      await daemon.stop();
+    }
+  });
+
+  it("stales a provider whose only workspace changes are ignored by its Workflow Contract", async () => {
+    const root = await makeTempRoot();
+    await writeProject(root, { evidenceIgnore: ["vendor/"] });
+    const prepared = preparedWorkspaceFixture(root);
+    await mkdir(path.join(prepared.workspacePath, "vendor"), {
+      recursive: true
+    });
+    const provider = workspaceMtimeProvider("vendor/heartbeat.txt");
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-watchdog-ignored-vendor",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi: githubIssuesApiFixture(),
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: prepareWorkspace(prepared)
+    });
+
+    try {
+      const run = await waitForRunState(daemon.url, "stale", {
+        timeoutMs: 1_000
+      });
+      expect(run).toMatchObject({
+        id: "run-watchdog-ignored-vendor",
+        state: "stale",
+        terminalReason: "no_progress"
+      });
+    } finally {
+      provider.stopAll();
+      await daemon.stop();
+    }
+  });
+
+  it("keeps a provider alive when normal workspace changes accompany ignored output", async () => {
+    const root = await makeTempRoot();
+    await writeProject(root, { evidenceIgnore: ["out/"] });
+    const prepared = preparedWorkspaceFixture(root);
+    await mkdir(path.join(prepared.workspacePath, "out"), { recursive: true });
+    const provider = workspaceMtimeProvider([
+      "out/generated.txt",
+      "heartbeat.txt"
+    ]);
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => "run-watchdog-ignored-out-with-progress",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi: githubIssuesApiFixture(),
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: prepareWorkspace(prepared)
+    });
+
+    try {
+      await waitForRunState(daemon.url, "running");
+      await new Promise((resolve) => setTimeout(resolve, 220));
+      const run = await getRun(
+        daemon.url,
+        "run-watchdog-ignored-out-with-progress"
+      );
+      expect(run).toMatchObject({
         state: "running",
         terminalReason: null
       });
@@ -200,18 +275,24 @@ function idleUsageProvider(): ControllableProvider {
   });
 }
 
-function workspaceMtimeProvider(): ControllableProvider {
+function workspaceMtimeProvider(
+  relativePath: string | string[] = "heartbeat.txt"
+): ControllableProvider {
   return controllableProvider(async function* (
     input: ProviderRunInput,
     stopped: Promise<void>
   ): AsyncGenerator<ProviderEvent> {
-    const touched = path.join(input.workspacePath, "heartbeat.txt");
-    await writeFile(touched, "heartbeat\n");
+    const touched = (
+      Array.isArray(relativePath) ? relativePath : [relativePath]
+    ).map((entry) => path.join(input.workspacePath, entry));
+    await Promise.all(touched.map((entry) => writeFile(entry, "heartbeat\n")));
     let tick = 0;
     const interval = setInterval(() => {
       tick += 1;
       const next = new Date(Date.now() + tick * 1_000);
-      void utimes(touched, next, next);
+      for (const entry of touched) {
+        void utimes(entry, next, next);
+      }
     }, 15);
     try {
       await stopped;
@@ -351,7 +432,10 @@ function prepareWorkspace(prepared: PreparedIssueWorkspace) {
   };
 }
 
-async function writeProject(root: string): Promise<void> {
+async function writeProject(
+  root: string,
+  options: { evidenceIgnore?: string[] } = {}
+): Promise<void> {
   await writeFile(
     path.join(root, "symphonika.yml"),
     [
@@ -397,7 +481,17 @@ async function writeProject(root: string): Promise<void> {
   );
   await writeFile(
     path.join(root, "WORKFLOW.md"),
-    "Work on #{{issue.number}}.\n"
+    options.evidenceIgnore === undefined
+      ? "Work on #{{issue.number}}.\n"
+      : [
+          "---",
+          "evidence:",
+          "  ignore:",
+          ...options.evidenceIgnore.map((entry) => `    - ${entry}`),
+          "---",
+          "Work on #{{issue.number}}.",
+          ""
+        ].join("\n")
   );
 }
 

--- a/tests/watchdog.test.ts
+++ b/tests/watchdog.test.ts
@@ -120,7 +120,9 @@ describe("sampleWorkspaceMtimeMax", () => {
     await utimes(excluded, excludedTime, excludedTime);
     await utimes(root, includedTime, includedTime);
 
-    expect(await sampleWorkspaceMtimeMax(root)).toBe(includedTime.getTime());
+    expect(await sampleWorkspaceMtimeMax(root, [], ["vendor/"])).toBe(
+      includedTime.getTime()
+    );
   });
 
   it("does not follow symlinked directories out of the workspace", async () => {
@@ -173,6 +175,27 @@ describe("sampleWorkspaceMtimeMax", () => {
     expect(await sampleWorkspaceMtimeMax(root)).toBe(newerTime.getTime());
     // The glob drops .log files at any depth, so src.ts's 10:00 wins.
     expect(await sampleWorkspaceMtimeMax(root, ["**/*.log"])).toBe(
+      baseTime.getTime()
+    );
+  });
+
+  it("does not descend into directories declared by evidence.ignore", async () => {
+    const root = await makeTempRoot();
+    await mkdir(path.join(root, "vendor", "generated"), { recursive: true });
+    const included = path.join(root, "src.ts");
+    const ignoredDirectory = path.join(root, "vendor");
+    const ignored = path.join(ignoredDirectory, "generated", "newer.ts");
+    await writeFile(included, "included\n");
+    await writeFile(ignored, "ignored\n");
+
+    const baseTime = new Date("2026-05-22T10:00:00.000Z");
+    const newerTime = new Date("2026-05-22T12:00:00.000Z");
+    await utimes(included, baseTime, baseTime);
+    await utimes(ignored, newerTime, newerTime);
+    await utimes(ignoredDirectory, newerTime, newerTime);
+    await utimes(root, baseTime, baseTime);
+
+    expect(await sampleWorkspaceMtimeMax(root, [], ["vendor/"])).toBe(
       baseTime.getTime()
     );
   });

--- a/tests/workflow-contract-loading.test.ts
+++ b/tests/workflow-contract-loading.test.ts
@@ -65,6 +65,107 @@ describe("workflow contract loading", () => {
     });
     expect(workflow.contentHash).toMatch(/^sha256:[a-f0-9]{64}$/);
   });
+
+  it("parses evidence.ignore directories from Workflow Contract front matter", () => {
+    const workflowPath = "/repo/WORKFLOW.md";
+
+    const workflow = parseWorkflowContract(
+      [
+        "---",
+        "evidence:",
+        "  ignore:",
+        '    - "vendor/"',
+        '    - "out"',
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n"),
+      workflowPath
+    );
+
+    expect(workflow.errors).toEqual([]);
+    expect(workflow.evidence.ignore).toEqual(["vendor/", "out"]);
+  });
+
+  it("rejects evidence.ignore entries containing parent traversal", () => {
+    const workflowPath = "/repo/WORKFLOW.md";
+
+    const workflow = parseWorkflowContract(
+      [
+        "---",
+        "evidence:",
+        '  ignore: ["../escape"]',
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n"),
+      workflowPath
+    );
+
+    expect(workflow.errors).toContain(
+      `workflow front matter at ${workflowPath} evidence.ignore[0] must not contain ..`
+    );
+  });
+
+  it("rejects absolute evidence.ignore entries", () => {
+    const workflowPath = "/repo/WORKFLOW.md";
+
+    const workflow = parseWorkflowContract(
+      [
+        "---",
+        "evidence:",
+        '  ignore: ["/tmp/output"]',
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n"),
+      workflowPath
+    );
+
+    expect(workflow.errors).toContain(
+      `workflow front matter at ${workflowPath} evidence.ignore[0] must be workspace-relative`
+    );
+  });
+
+  it("rejects non-string evidence.ignore entries", () => {
+    const workflowPath = "/repo/WORKFLOW.md";
+
+    const workflow = parseWorkflowContract(
+      [
+        "---",
+        "evidence:",
+        '  ignore: ["vendor/", 42]',
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n"),
+      workflowPath
+    );
+
+    expect(workflow.errors).toContain(
+      `workflow front matter at ${workflowPath} evidence.ignore[1] must be a non-empty string`
+    );
+  });
+
+  it("rejects evidence.ignore when it is not a list", () => {
+    const workflowPath = "/repo/WORKFLOW.md";
+
+    const workflow = parseWorkflowContract(
+      [
+        "---",
+        "evidence:",
+        "  ignore: vendor/",
+        "---",
+        "Work on {{issue.title}}.",
+        ""
+      ].join("\n"),
+      workflowPath
+    );
+
+    expect(workflow.errors).toContain(
+      `workflow front matter at ${workflowPath} evidence.ignore must be a list`
+    );
+  });
 });
 
 describe("workflow format routing", () => {


### PR DESCRIPTION
Summary:
- parse and validate Workflow Contract evidence.ignore directory lists
- retain last-known-good per-Project policies through runtime reloads
- prune declared directory trees during Watchdog sampling while preserving built-in excludes and file-glob ignores
- cover doctor, reload, sampler, and daemon behavior and update the contract docs

Validation:
- npm run lint
- npm run typecheck
- npm test: 610 tests passed with npm 11; npm 12 blocks the existing npm-link prepare-script test
- npm run build

Closes #201