### PR TITLE
feat(routines): add git firings and PR discovery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -126,6 +126,12 @@ One durable execution attempt of a Routine, with its own workspace, provider log
 and lifecycle state.
 _Avoid_: run when specifically referring to non-issue scheduled execution
 
+**Routine Pull Request**:
+An informational association discovered from a succeeded `kind: git` Routine Firing's deterministic
+branch. It records the PR number and head SHA but never enters PR Follow-up, review re-dispatch, or
+auto-merge.
+_Avoid_: PR Follow-up when referring to Routine-opened pull requests
+
 **Run Lifecycle**:
 The stateful progression of one Run from dispatch selection through provider execution, scheduling,
 waiting, cancellation, or terminal labels.
@@ -219,6 +225,7 @@ _Avoid_: chat session
 - A **Run** can succeed even when its **Issue** remains open
 - A **Routine** belongs to one **Project** and may create zero or more **Routine Firings**
 - A **Routine Firing** consumes the same Project/global in-flight capacity as issue **Runs**
+- A succeeded `kind: git` **Routine Firing** may link zero or more read-only **Routine Pull Requests**
 - A **Run Lifecycle** consumes **Lifecycle Events** and chooses **Planned Steps**
 - A **Watchdog** samples a **Progress Signal** for each active **Run** during daemon reconciliation and may mark no-progress work `stale`, preserving **Workspace** contents
 - A **Continuation** is capped so an eligible issue cannot loop forever

--- a/SPEC.md
+++ b/SPEC.md
@@ -170,12 +170,12 @@ Symphonika stores both:
 
 ### 4.12 Routine
 
-A Routine is a Project-owned scheduled prompt declaration. Slice 1 supports hand-authored Markdown
+A Routine is a Project-owned scheduled prompt declaration. Symphonika supports hand-authored Markdown
 routine files with YAML front matter:
 
 - `name`
 - `schedule.at`
-- `kind: report`
+- `kind: report` or `kind: git`
 - optional `provider`
 
 The Markdown body is the routine prompt template. `name` must be safe as a single workspace path
@@ -184,9 +184,9 @@ segment because routine firing workspaces live under `<workspace.root>/routines/
 ### 4.13 Routine Firing
 
 A Routine Firing is one durable execution of a Routine. It records the Routine, Project, provider,
-workspace path, prompt evidence, provider logs, terminal reason, and lifecycle state. Slice 1
-supports one-shot `schedule.at` routines only; after the first firing is created, the Routine becomes
-`expired` and must not fire again on daemon restart.
+workspace path, prompt evidence, provider logs, terminal reason, lifecycle state, and any pull
+requests discovered from a `kind: git` firing branch. One-shot `schedule.at` routines become
+`expired` after the first firing is created and must not fire again on daemon restart.
 
 ## 5. Config Files
 
@@ -317,7 +317,7 @@ Available top-level objects:
 Symphonika prepends a standard autonomy preamble to every rendered workflow prompt.
 
 Routine prompt rendering uses the same strict templating rules and the same standard autonomy
-preamble. For `kind: report`, available top-level objects are:
+preamble. For every Routine kind, available top-level objects are:
 
 - `project`
 - `workspace`
@@ -325,8 +325,9 @@ preamble. For `kind: report`, available top-level objects are:
 - `routine`
 - `firing`
 
-`issue`, `run`, and `branch` are unavailable to routine prompts. Referencing any of them fails
-rendering with terminal reason `prompt_render_error`.
+`kind: git` additionally exposes `branch.name` and `branch.ref`. `branch` is unavailable to
+`kind: report`; `issue` and `run` are unavailable to every Routine kind. Referencing an unavailable
+object fails rendering with terminal reason `prompt_render_error`.
 
 The preamble tells the agent:
 
@@ -542,11 +543,20 @@ supports one-shot `schedule.at` only:
 - `fire_now` when `now >= at` and the Routine has not fired
 - `expired` after a firing exists or the Routine state is `expired`
 
-When a Routine fires, Symphonika allocates a ULID firing id, prepares a workspace at
-`<workspace.root>/routines/<routine-name>/<firing-id>/` on the Project base branch, renders the
-routine prompt, runs the configured provider, records a `routine_firings` row, and marks the
-Routine `expired`. Routine Firings use states `queued`, `preparing_workspace`, `running`,
-`succeeded`, `failed`, and `cancelled`.
+When a Routine fires, Symphonika allocates a ULID firing id and prepares a workspace at
+`<workspace.root>/routines/<routine-name>/<firing-id>/`. A `kind: report` workspace is detached at
+the Project base branch. A `kind: git` workspace is checked out on
+`sym/<project>/routine/<routine-name>/<first-10-firing-id-chars>`, created from the Project base.
+Symphonika renders the routine prompt, runs the configured provider, records a `routine_firings`
+row, and marks a one-shot Routine `expired`. Routine Firings use states `queued`,
+`preparing_workspace`, `running`, `succeeded`, `failed`, and `cancelled`.
+
+For `kind: report`, provider exit code 0 succeeds without requiring commits. For `kind: git`, exit
+code 0 applies the same commits-ahead-of-base inspection as §12.1: zero commits fails with
+`no_workspace_changes`, inspection failure fails with `workspace_inspection_failed`, and one or
+more commits succeeds. On the succeeded transition, Symphonika lists every open pull request whose
+head is the firing branch and records its PR number and head SHA. Routine PR discovery is
+informational only: it never enters PR Follow-up, review re-dispatch, or auto-merge.
 
 Routine Firings consume the same per-Project and global `max_in_flight` slots as issue Runs. If a
 cap is already full when a Routine is due, the daemon skips that fire for this slice and logs the
@@ -632,6 +642,10 @@ tracks PRs that can be associated with a completed Symphonika Run by the determi
 Repository workflows and coding agents remain responsible for opening PRs, writing comments, and
 removing `agent-ready`; Symphonika records the discovered PR number and head SHA so the daemon can
 continue the same branch after review feedback.
+
+Routine PR discovery is a separate, read-only association. A succeeded `kind: git` Routine Firing
+records every open PR found on its deterministic firing branch, but those PRs are never candidates
+for review re-dispatch or auto-merge.
 
 The v1 trigger model is poll-based and runs on the daemon tick. Webhooks are deferred.
 
@@ -1022,7 +1036,8 @@ frame, but caches the full `doctor` validation path for 5000 ms by default so pa
 not continuously re-run provider probes or GitHub validation reads. `--doctor-ttl-ms 0` disables that
 cache when an operator explicitly wants every frame to perform full validation.
 
-`routines` lists routine status per Project with `state`, `next_fire_at`, and `last_fired_at`.
+`routines` lists routine status per Project with `state`, `next_fire_at`, `last_fired_at`, and PR
+numbers discovered for the latest firing.
 
 `clear-stale` removes `sym:stale`, `sym:claimed`, and `sym:running` only after explicit confirmation.
 
@@ -1042,7 +1057,7 @@ The UI is primarily read-only. It shows:
 - raw log links or content
 - rendered prompt links
 - retry and continuation state
-- routines with `state`, `next_fire_at`, and `last_fired_at`
+- routines with `state`, `next_fire_at`, `last_fired_at`, and discovered PR numbers
 - a per-run interactive workflow graph
 
 Operator pages stay server-rendered and primarily read-only, but a page may embed a
@@ -1060,7 +1075,8 @@ The v1 mutating web actions are explicit active-run cancellation and a manual po
 uses the normal daemon scheduler path.
 
 The HTTP API exposes `GET /api/routines` with the same routine status shape as the CLI and
-dashboard.
+dashboard. `GET /api/routines/:id/firings` returns firing history and linked PRs for the named
+Routine; callers use `?project=<name>` to disambiguate the same Routine name across Projects.
 
 Label creation, stale-claim reset, and workspace cleanup remain CLI-only.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -820,7 +820,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         }
         writeOut(
           program,
-          "project  routine  state  next_fire_at  last_fired_at\n"
+          "project  routine  state  next_fire_at  last_fired_at  pull_requests\n"
         );
         for (const routine of routines) {
           writeOut(
@@ -830,7 +830,8 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
               routine.name,
               routine.state,
               routine.nextFireAt ?? "-",
-              routine.lastFiredAt ?? "-"
+              routine.lastFiredAt ?? "-",
+              formatRoutinePullRequestNumbers(routine.pullRequestNumbers)
             ].join("  ") + "\n"
           );
         }
@@ -1591,6 +1592,12 @@ function parsePositiveInt(value: string): number {
     throw new InvalidArgumentError("must be a positive integer");
   }
   return n;
+}
+
+function formatRoutinePullRequestNumbers(numbers: number[]): string {
+  return numbers.length === 0
+    ? "-"
+    : numbers.map((number) => `#${number}`).join(",");
 }
 
 function parseNonNegativeInt(value: string): number {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -455,7 +455,9 @@ export async function startDaemon(
           ...(options.createRoutineFiringId === undefined
             ? {}
             : { createFiringId: options.createRoutineFiringId }),
+          env,
           globalConcurrency: runtimeConfig.globalConcurrency(),
+          githubIssuesApi,
           logger,
           ...(options.prepareRoutineWorkspace === undefined
             ? {}

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -217,6 +217,34 @@ export function createHttpApp(options: HttpAppOptions): Hono {
       });
     });
 
+    app.get("/api/routines/:id/firings", (context) => {
+      const routineName = context.req.param("id");
+      const project = context.req.query("project");
+      const matches = runStore
+        .listRoutines(project === undefined ? {} : { project })
+        .filter((routine) => routine.name === routineName);
+      if (matches.length === 0) {
+        return context.json({ error: "routine not found" }, 404);
+      }
+      if (matches.length > 1) {
+        return context.json(
+          {
+            error:
+              "routine name is ambiguous; provide the project query parameter"
+          },
+          409
+        );
+      }
+      const routine = matches[0]!;
+      return context.json({
+        firings: runStore.listRoutineFirings({
+          project: routine.projectName,
+          routineName: routine.name
+        }),
+        routine
+      });
+    });
+
     app.get("/api/runs/:id", (context) => {
       const detail = runStore.getRun(context.req.param("id"));
       if (detail === undefined) {

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -761,15 +761,21 @@ function renderRoutinesTable(routines: RoutineStatus[]): string {
   const rows = routines
     .map(
       (routine) =>
-        `<tr><td>${escapeHtml(routine.projectName)}</td><td>${escapeHtml(routine.name)}</td><td>${escapeHtml(routine.state)}</td><td><code>${escapeHtml(routine.nextFireAt ?? "-")}</code></td><td><code>${escapeHtml(routine.lastFiredAt ?? "-")}</code></td></tr>`
+        `<tr><td>${escapeHtml(routine.projectName)}</td><td>${escapeHtml(routine.name)}</td><td>${escapeHtml(routine.state)}</td><td><code>${escapeHtml(routine.nextFireAt ?? "-")}</code></td><td><code>${escapeHtml(routine.lastFiredAt ?? "-")}</code></td><td>${escapeHtml(formatRoutinePullRequestNumbers(routine.pullRequestNumbers))}</td></tr>`
     )
     .join("");
   return tableSection(
     "Routines",
     routines.length,
-    "<tr><th>Project</th><th>Routine</th><th>State</th><th>next_fire_at</th><th>last_fired_at</th></tr>",
+    "<tr><th>Project</th><th>Routine</th><th>State</th><th>next_fire_at</th><th>last_fired_at</th><th>Pull requests</th></tr>",
     rows
   );
+}
+
+function formatRoutinePullRequestNumbers(numbers: number[]): string {
+  return numbers.length === 0
+    ? "-"
+    : numbers.map((number) => `#${number}`).join(", ");
 }
 
 function renderRunsTable(title: string, runs: RunStatus[]): string {

--- a/src/routines/declaration-loader.ts
+++ b/src/routines/declaration-loader.ts
@@ -12,7 +12,7 @@ export type RoutineDeclarationLoadResult = {
 };
 
 const providerNames = new Set(["codex", "claude"]);
-const routineKinds = new Set(["report"]);
+const routineKinds = new Set(["git", "report"]);
 
 export async function loadRoutineDeclaration(
   routinePath: string
@@ -81,7 +81,7 @@ function parseRoutineDeclaration(
   if (kind === undefined) {
     errors.push(`routine at ${routinePath} kind is required`);
   } else if (!routineKinds.has(kind)) {
-    errors.push(`routine at ${routinePath} kind must be report`);
+    errors.push(`routine at ${routinePath} kind must be git or report`);
   }
 
   const providerValue = stringField(frontMatter, "provider");

--- a/src/routines/dispatcher.ts
+++ b/src/routines/dispatcher.ts
@@ -4,6 +4,13 @@ import path from "node:path";
 import type { Logger } from "pino";
 
 import type { ActiveRunRegistry } from "../lifecycle/active-runs.js";
+import { classifyFailure } from "../lifecycle/classify-failure.js";
+import {
+  resolveEnvBackedValue,
+  tryListPullRequestsForBranch,
+  type GitHubIssuesApi,
+  type RawGitHubPullRequest
+} from "../issue-polling.js";
 import type {
   AgentProviderName,
   AgentProviderRegistry,
@@ -33,7 +40,9 @@ export type DispatchDueRoutinesInput = {
   agentProviders: AgentProviderRegistry;
   configDir: string;
   createFiringId?: () => string;
+  env?: NodeJS.ProcessEnv;
   globalConcurrency: { maxInFlight: number | undefined };
+  githubIssuesApi?: GitHubIssuesApi;
   logger?: Logger;
   now?: Date;
   prepareRoutineWorkspace?: (
@@ -177,6 +186,9 @@ export async function dispatchDueRoutines(
         fired.push(firingId);
         await runRoutineFiring({
           firingId,
+          env: input.env ?? process.env,
+          githubIssuesApi: input.githubIssuesApi,
+          logger: input.logger,
           prepareRoutineWorkspace,
           project,
           provider,
@@ -200,7 +212,10 @@ export async function dispatchDueRoutines(
 async function runRoutineFiring(input: {
   activeRuns: ActiveRunRegistry;
   configDir: string;
+  env: NodeJS.ProcessEnv;
   firingId: string;
+  githubIssuesApi: GitHubIssuesApi | undefined;
+  logger: Logger | undefined;
   prepareRoutineWorkspace: (
     input: PrepareRoutineWorkspaceInput
   ) => Promise<PreparedRoutineWorkspace>;
@@ -224,6 +239,7 @@ async function runRoutineFiring(input: {
     prepared = await input.prepareRoutineWorkspace({
       configDir: input.configDir,
       firingId: input.firingId,
+      kind: input.routine.kind,
       project: input.project,
       routineName: input.routine.name
     });
@@ -278,13 +294,29 @@ async function runRoutineFiring(input: {
         events.push(event.normalized);
       }
     }
-    const outcome = classifyRoutineOutcome(events);
+    const outcome = await classifyRoutineOutcome(events, {
+      baseBranch: input.project.workspace.git.base_branch,
+      kind: input.routine.kind,
+      workspacePath: prepared.workspacePath
+    });
     input.runStore.completeRoutineFiring({
       id: input.firingId,
       state: outcome.kind,
       terminalReason: outcome.reason.length === 0 ? null : outcome.reason,
       workspacePath: prepared.workspacePath
     });
+    if (outcome.kind === "succeeded" && input.routine.kind === "git") {
+      await discoverRoutinePullRequests({
+        branchName: prepared.branchName,
+        env: input.env,
+        firingId: input.firingId,
+        githubIssuesApi: input.githubIssuesApi,
+        logger: input.logger,
+        project: input.project,
+        routineName: input.routine.name,
+        runStore: input.runStore
+      });
+    }
   } catch (error) {
     const reason =
       error instanceof RoutinePromptRenderError
@@ -318,6 +350,14 @@ async function prepareRoutineEvidence(input: {
 }> {
   const routine = input.routine;
   const rendered = renderRoutinePrompt({
+    ...(routine.kind === "git"
+      ? {
+          branch: {
+            name: input.prepared.branchName,
+            ref: input.prepared.branchRef
+          }
+        }
+      : {}),
     firing: { id: input.firingId },
     project: { name: input.project.name },
     provider: { command: input.providerCommand, name: input.providerName },
@@ -352,6 +392,14 @@ async function prepareRoutineEvidence(input: {
       `${JSON.stringify(
         {
           autonomy_preamble_version: rendered.preambleVersion,
+          ...(routine.kind === "git"
+            ? {
+                branch: {
+                  name: input.prepared.branchName,
+                  ref: input.prepared.branchRef
+                }
+              }
+            : {}),
           firing: { id: input.firingId },
           project: { name: input.project.name },
           provider: {
@@ -399,9 +447,33 @@ async function appendRoutineEvent(input: {
   ]);
 }
 
-function classifyRoutineOutcome(
-  events: NormalizedProviderEvent[]
-): RoutineTerminalOutcome {
+async function classifyRoutineOutcome(
+  events: NormalizedProviderEvent[],
+  workspace: {
+    baseBranch: string;
+    kind: RoutineStatus["kind"];
+    workspacePath: string;
+  }
+): Promise<RoutineTerminalOutcome> {
+  if (workspace.kind === "git") {
+    const classified = await classifyFailure({
+      cancelRequested: false,
+      events,
+      successWorkspace: {
+        baseBranch: workspace.baseBranch,
+        workspacePath: workspace.workspacePath
+      }
+    });
+    switch (classified.kind) {
+      case "success":
+        return { kind: "succeeded", reason: classified.reason };
+      case "cancelled":
+        return { kind: "cancelled", reason: classified.reason };
+      case "failed":
+      case "input_required":
+        return { kind: "failed", reason: classified.reason };
+    }
+  }
   const inputRequired = events.find((event) => event.type === "input_required");
   if (inputRequired !== undefined) {
     return {
@@ -438,6 +510,75 @@ function classifyRoutineOutcome(
         ? `process_exit_signal_${stringField(exit, "signal") ?? "unknown"}`
         : `process_exit_${exitCode}`
   };
+}
+
+async function discoverRoutinePullRequests(input: {
+  branchName: string;
+  env: NodeJS.ProcessEnv;
+  firingId: string;
+  githubIssuesApi: GitHubIssuesApi | undefined;
+  logger: Logger | undefined;
+  project: RunControllerProjectConfig;
+  routineName: string;
+  runStore: RunStore;
+}): Promise<void> {
+  if (input.githubIssuesApi === undefined) {
+    return;
+  }
+  const token = resolveEnvBackedValue(input.project.tracker.token, input.env);
+  if (token === undefined) {
+    input.logger?.warn(
+      { project: input.project.name, routine: input.routineName },
+      "symphonika routine PR discovery token unavailable"
+    );
+    return;
+  }
+
+  let pullRequests: RawGitHubPullRequest[] | undefined;
+  try {
+    pullRequests = await tryListPullRequestsForBranch(input.githubIssuesApi, {
+      branch: input.branchName,
+      owner: input.project.tracker.owner,
+      repo: input.project.tracker.repo,
+      token
+    });
+  } catch (error) {
+    input.logger?.warn(
+      { branch: input.branchName, err: error },
+      "symphonika routine PR discovery failed"
+    );
+    return;
+  }
+
+  for (const pullRequest of pullRequests ?? []) {
+    if (!isOpenPullRequestForBranch(pullRequest, input.branchName)) {
+      continue;
+    }
+    input.runStore.recordRoutinePullRequest({
+      firingId: input.firingId,
+      headSha: pullRequest.head.sha,
+      prNumber: pullRequest.number,
+      projectName: input.project.name,
+      routineName: input.routineName
+    });
+  }
+}
+
+function isOpenPullRequestForBranch(
+  pullRequest: RawGitHubPullRequest,
+  branchName: string
+): pullRequest is RawGitHubPullRequest & {
+  head: { ref: string; sha: string };
+  number: number;
+} {
+  return (
+    pullRequest.state === "open" &&
+    pullRequest.number !== undefined &&
+    pullRequest.number > 0 &&
+    pullRequest.head?.ref === branchName &&
+    pullRequest.head.sha !== undefined &&
+    pullRequest.head.sha.length > 0
+  );
 }
 
 function capSkipReason(

--- a/src/routines/prompt-renderer.ts
+++ b/src/routines/prompt-renderer.ts
@@ -7,6 +7,10 @@ import {
 import type { RoutineKind } from "./types.js";
 
 export type RoutinePromptInput = {
+  branch?: {
+    name: string;
+    ref: string;
+  };
   firing: {
     id: string;
   };
@@ -39,13 +43,14 @@ export type RenderedRoutinePrompt = {
 
 type RoutinePromptContext = Pick<
   RoutinePromptInput,
-  "firing" | "project" | "provider" | "routine" | "workspace"
+  "branch" | "firing" | "project" | "provider" | "routine" | "workspace"
 >;
 
 const allowedTemplateFields: Record<
   keyof RoutinePromptContext,
   ReadonlySet<string>
 > = {
+  branch: new Set(["name", "ref"]),
   firing: new Set(["id"]),
   project: new Set(["name"]),
   provider: new Set(["command", "name"]),
@@ -68,6 +73,7 @@ export function renderRoutinePrompt(
   input: RoutinePromptInput
 ): RenderedRoutinePrompt {
   const context: RoutinePromptContext = {
+    ...(input.branch === undefined ? {} : { branch: input.branch }),
     firing: input.firing,
     project: input.project,
     provider: input.provider,
@@ -79,7 +85,8 @@ export function renderRoutinePrompt(
       resolveTemplateValue(
         String(expression).trim(),
         context,
-        input.templatePath
+        input.templatePath,
+        input.routine.kind
       ),
       input.templatePath
     )
@@ -95,9 +102,10 @@ export function renderRoutinePrompt(
 function resolveTemplateValue(
   expression: string,
   context: RoutinePromptContext,
-  templatePath: string
+  templatePath: string,
+  routineKind: RoutineKind
 ): unknown {
-  const error = templateExpressionError(expression, templatePath);
+  const error = templateExpressionError(expression, templatePath, routineKind);
   if (error !== undefined) {
     throw new RoutinePromptRenderError(error);
   }
@@ -113,7 +121,10 @@ function resolveTemplateValue(
     return context[topLevel];
   }
 
-  return context[topLevel][field as keyof (typeof context)[typeof topLevel]];
+  const object = context[topLevel];
+  return object === undefined
+    ? undefined
+    : (object as Record<string, unknown>)[field];
 }
 
 function stringifyTemplateValue(value: unknown, templatePath: string): string {
@@ -136,7 +147,8 @@ function stringifyTemplateValue(value: unknown, templatePath: string): string {
 
 function templateExpressionError(
   expression: string,
-  templatePath: string
+  templatePath: string,
+  routineKind: RoutineKind
 ): string | undefined {
   const parts = expression.split(".");
   const topLevel = parts[0];
@@ -146,6 +158,10 @@ function templateExpressionError(
   }
 
   if (topLevel === undefined || !isRoutinePromptObjectName(topLevel)) {
+    return `routine template at ${templatePath} references unknown variable {{${expression}}}`;
+  }
+
+  if (topLevel === "branch" && routineKind !== "git") {
     return `routine template at ${templatePath} references unknown variable {{${expression}}}`;
   }
 

--- a/src/routines/types.ts
+++ b/src/routines/types.ts
@@ -1,6 +1,6 @@
 import type { AgentProviderName } from "../provider.js";
 
-export type RoutineKind = "report";
+export type RoutineKind = "git" | "report";
 
 export type RoutineState = "active" | "expired" | "inactive";
 
@@ -25,6 +25,14 @@ export type RoutineDeclaration = {
   sourcePath: string;
 };
 
+export type RoutinePullRequestStatus = {
+  firingId: string;
+  headSha: string;
+  prNumber: number;
+  projectName: string;
+  routineName: string;
+};
+
 export type RoutineStatus = {
   kind: RoutineKind;
   lastFiredAt: string | null;
@@ -32,6 +40,7 @@ export type RoutineStatus = {
   nextFireAt: string | null;
   projectName: string;
   provider: AgentProviderName | null;
+  pullRequestNumbers: number[];
   scheduleAt: string;
   sourcePath: string;
   state: RoutineState;

--- a/src/routines/workspace.ts
+++ b/src/routines/workspace.ts
@@ -4,12 +4,15 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { ensureRepositoryCache, type WorkspaceProject } from "../workspace.js";
+import { slugifyWorkspaceSegment } from "../workspace-paths.js";
+import type { RoutineKind } from "./types.js";
 
 const execFileAsync = promisify(execFile);
 
 export type PrepareRoutineWorkspaceInput = {
   configDir: string;
   firingId: string;
+  kind: RoutineKind;
   project: WorkspaceProject;
   routineName: string;
 };
@@ -36,29 +39,56 @@ export async function prepareRoutineWorkspace(
     input.routineName,
     input.firingId
   );
-  const branchRef = `refs/remotes/origin/${input.project.workspace.git.base_branch}`;
+  const baseRef = `refs/remotes/origin/${input.project.workspace.git.base_branch}`;
+  const branchName =
+    input.kind === "git"
+      ? [
+          "sym",
+          slugifyWorkspaceSegment(input.project.name, "project"),
+          "routine",
+          input.routineName,
+          input.firingId.slice(0, 10)
+        ].join("/")
+      : input.project.workspace.git.base_branch;
+  const branchRef = input.kind === "git" ? `refs/heads/${branchName}` : baseRef;
   await ensureRepositoryCache(input.project, cachePath);
   if (await exists(workspacePath)) {
     return {
-      branchName: input.project.workspace.git.base_branch,
+      branchName,
       branchRef,
       cachePath,
       reused: true,
       workspacePath
     };
   }
+  if (
+    input.kind === "git" &&
+    !(await gitSucceeds(["-C", cachePath, "show-ref", "--verify", branchRef]))
+  ) {
+    await git([
+      "-C",
+      cachePath,
+      "branch",
+      branchName,
+      `origin/${input.project.workspace.git.base_branch}`
+    ]);
+  }
   await mkdir(path.dirname(workspacePath), { recursive: true });
-  await git([
-    "-C",
-    cachePath,
-    "worktree",
-    "add",
-    "--detach",
-    workspacePath,
-    `origin/${input.project.workspace.git.base_branch}`
-  ]);
+  await git(
+    input.kind === "git"
+      ? ["-C", cachePath, "worktree", "add", workspacePath, branchName]
+      : [
+          "-C",
+          cachePath,
+          "worktree",
+          "add",
+          "--detach",
+          workspacePath,
+          `origin/${input.project.workspace.git.base_branch}`
+        ]
+  );
   return {
-    branchName: input.project.workspace.git.base_branch,
+    branchName,
     branchRef,
     cachePath,
     reused: false,
@@ -81,6 +111,15 @@ async function exists(filePath: string): Promise<boolean> {
 async function git(args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("git", args);
   return stdout.trim();
+}
+
+async function gitSucceeds(args: string[]): Promise<boolean> {
+  try {
+    await git(args);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/src/routines/workspace.ts
+++ b/src/routines/workspace.ts
@@ -46,7 +46,7 @@ export async function prepareRoutineWorkspace(
           "sym",
           slugifyWorkspaceSegment(input.project.name, "project"),
           "routine",
-          input.routineName,
+          slugifyWorkspaceSegment(input.routineName, "routine"),
           input.firingId.slice(0, 10)
         ].join("/")
       : input.project.workspace.git.base_branch;

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -11,6 +11,7 @@ import type {
   RoutineDeclaration,
   RoutineFiringState,
   RoutineKind,
+  RoutinePullRequestStatus,
   RoutineState,
   RoutineStatus
 } from "./routines/types.js";
@@ -127,6 +128,7 @@ export type RoutineFiringStatus = {
   projectName: string;
   provider: AgentProviderName;
   providerCommand: string;
+  pullRequests: RoutinePullRequestStatus[];
   routineName: string;
   state: RoutineFiringState;
   terminalReason: string | null;
@@ -454,6 +456,14 @@ type RoutineFiringRow = {
   terminal_reason: string | null;
   updated_at: string;
   workspace_path: string | null;
+};
+
+type RoutinePullRequestRow = {
+  firing_id: string;
+  head_sha: string;
+  pr_number: number;
+  project_name: string;
+  routine_name: string;
 };
 
 const PULL_REQUEST_DISCOVERY_LIMIT = 25;
@@ -1172,7 +1182,13 @@ export class RunStore {
           .join(" ")
       )
       .all(params) as RoutineRow[];
-    return rows.map((row) => mapRoutineRow(row));
+    return rows.map((row) => ({
+      ...mapRoutineRow(row),
+      pullRequestNumbers: this.latestRoutinePullRequestNumbers(
+        row.project_name,
+        row.name
+      )
+    }));
   }
 
   getRoutine(input: {
@@ -1193,6 +1209,10 @@ export class RunStore {
     }
     return {
       ...mapRoutineRow(row),
+      pullRequestNumbers: this.latestRoutinePullRequestNumbers(
+        row.project_name,
+        row.name
+      ),
       prompt: row.prompt_body
     };
   }
@@ -1355,12 +1375,18 @@ export class RunStore {
       });
   }
 
-  listRoutineFirings(filter: { project?: string } = {}): RoutineFiringStatus[] {
+  listRoutineFirings(
+    filter: { project?: string; routineName?: string } = {}
+  ): RoutineFiringStatus[] {
     const conditions: string[] = [];
     const params: Record<string, unknown> = {};
     if (filter.project !== undefined) {
       conditions.push("project_name = @project");
       params.project = filter.project;
+    }
+    if (filter.routineName !== undefined) {
+      conditions.push("routine_name = @routine_name");
+      params.routine_name = filter.routineName;
     }
     const where =
       conditions.length === 0 ? "" : `where ${conditions.join(" and ")}`;
@@ -1376,7 +1402,72 @@ export class RunStore {
           .join(" ")
       )
       .all(params) as RoutineFiringRow[];
-    return rows.map((row) => mapRoutineFiringRow(row));
+    return rows.map((row) => ({
+      ...mapRoutineFiringRow(row),
+      pullRequests: this.listRoutinePullRequests({ firingId: row.id })
+    }));
+  }
+
+  recordRoutinePullRequest(input: RoutinePullRequestStatus): void {
+    this.database
+      .prepare(
+        [
+          "insert into routine_pull_requests (",
+          "project_name, routine_name, firing_id, pr_number, head_sha, created_at, updated_at",
+          ") values (",
+          "@project_name, @routine_name, @firing_id, @pr_number, @head_sha, @created_at, @updated_at",
+          ")",
+          "on conflict(project_name, routine_name, firing_id, pr_number) do update set",
+          "head_sha = excluded.head_sha, updated_at = excluded.updated_at"
+        ].join(" ")
+      )
+      .run({
+        created_at: timestamp(),
+        firing_id: input.firingId,
+        head_sha: input.headSha,
+        pr_number: input.prNumber,
+        project_name: input.projectName,
+        routine_name: input.routineName,
+        updated_at: timestamp()
+      });
+  }
+
+  listRoutinePullRequests(
+    filter: {
+      firingId?: string;
+      project?: string;
+      routineName?: string;
+    } = {}
+  ): RoutinePullRequestStatus[] {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+    if (filter.firingId !== undefined) {
+      conditions.push("firing_id = @firing_id");
+      params.firing_id = filter.firingId;
+    }
+    if (filter.project !== undefined) {
+      conditions.push("project_name = @project");
+      params.project = filter.project;
+    }
+    if (filter.routineName !== undefined) {
+      conditions.push("routine_name = @routine_name");
+      params.routine_name = filter.routineName;
+    }
+    const where =
+      conditions.length === 0 ? "" : `where ${conditions.join(" and ")}`;
+    const rows = this.database
+      .prepare(
+        [
+          "select project_name, routine_name, firing_id, pr_number, head_sha",
+          "from routine_pull_requests",
+          where,
+          "order by pr_number asc"
+        ]
+          .filter((part) => part.length > 0)
+          .join(" ")
+      )
+      .all(params) as RoutinePullRequestRow[];
+    return rows.map(mapRoutinePullRequestRow);
   }
 
   listRoutineFiringTransitions(id: string): RoutineFiringStateTransition[] {
@@ -2355,6 +2446,20 @@ export class RunStore {
         created_at text not null,
         foreign key (firing_id) references routine_firings(id)
       );
+
+      create table if not exists routine_pull_requests (
+        id integer primary key autoincrement,
+        project_name text not null,
+        routine_name text not null,
+        firing_id text not null,
+        pr_number integer not null,
+        head_sha text not null,
+        created_at text not null,
+        updated_at text not null,
+        unique(project_name, routine_name, firing_id, pr_number),
+        foreign key (project_name, routine_name) references routines(project_name, name),
+        foreign key (firing_id) references routine_firings(id)
+      );
     `);
 
     const additions: Array<[string, string, string]> = [
@@ -2464,6 +2569,26 @@ export class RunStore {
         "insert into routine_firing_state_transitions (firing_id, sequence, state, created_at) values (?, ?, ?, ?)"
       )
       .run(firingId, sequence, state, createdAt);
+  }
+
+  private latestRoutinePullRequestNumbers(
+    projectName: string,
+    routineName: string
+  ): number[] {
+    const latest = this.database
+      .prepare(
+        [
+          "select id from routine_firings",
+          "where project_name = ? and routine_name = ?",
+          "order by created_at desc, id desc limit 1"
+        ].join(" ")
+      )
+      .get(projectName, routineName) as { id: string } | undefined;
+    return latest === undefined
+      ? []
+      : this.listRoutinePullRequests({ firingId: latest.id }).map(
+          (pullRequest) => pullRequest.prNumber
+        );
   }
 
   private getRunArtifactRow(runId: string): RunArtifactRow | undefined {
@@ -2789,6 +2914,7 @@ function mapRoutineRow(row: RoutineRow): RoutineStatus {
         : null,
     projectName: row.project_name,
     provider: row.provider_name ?? null,
+    pullRequestNumbers: [],
     scheduleAt: row.schedule_at,
     sourcePath: row.source_path,
     state: row.state
@@ -2802,11 +2928,24 @@ function mapRoutineFiringRow(row: RoutineFiringRow): RoutineFiringStatus {
     projectName: row.project_name,
     provider: row.provider_name,
     providerCommand: row.provider_command,
+    pullRequests: [],
     routineName: row.routine_name,
     state: row.state,
     terminalReason: row.terminal_reason ?? null,
     updatedAt: row.updated_at,
     workspacePath: row.workspace_path ?? ""
+  };
+}
+
+function mapRoutinePullRequestRow(
+  row: RoutinePullRequestRow
+): RoutinePullRequestStatus {
+  return {
+    firingId: row.firing_id,
+    headSha: row.head_sha,
+    prNumber: row.pr_number,
+    projectName: row.project_name,
+    routineName: row.routine_name
   };
 }
 

--- a/src/status-dashboard.ts
+++ b/src/status-dashboard.ts
@@ -116,8 +116,8 @@ function formatRoutines(routines: RoutineStatus[]): string[] {
     return ["│   No routines configured"];
   }
   return [
-    "│   PROJECT      ROUTINE              STATE     NEXT_FIRE_AT              LAST_FIRED_AT",
-    "│   --------------------------------------------------------------------------------",
+    "│   PROJECT      ROUTINE              STATE     NEXT_FIRE_AT              LAST_FIRED_AT             PRS",
+    "│   ------------------------------------------------------------------------------------------------",
     ...routines.map((routine) =>
       [
         "│  ",
@@ -129,10 +129,18 @@ function formatRoutines(routines: RoutineStatus[]): string[] {
         " ",
         pad(truncate(routine.nextFireAt ?? "-", 25), 25),
         " ",
-        truncate(routine.lastFiredAt ?? "-", 25)
+        pad(truncate(routine.lastFiredAt ?? "-", 25), 25),
+        " ",
+        formatRoutinePullRequestNumbers(routine.pullRequestNumbers)
       ].join("")
     )
   ];
+}
+
+function formatRoutinePullRequestNumbers(numbers: number[]): string {
+  return numbers.length === 0
+    ? "-"
+    : numbers.map((number) => `#${number}`).join(",");
 }
 
 export function summarizeDashboardEvent(

--- a/src/workspace-paths.ts
+++ b/src/workspace-paths.ts
@@ -20,8 +20,8 @@ export type WorkspacePathPlan = {
 export function planWorkspacePaths(
   input: WorkspacePathInputs
 ): WorkspacePathPlan {
-  const projectSlug = slugify(input.project.name, "project");
-  const issueSlug = slugify(input.issue.title, "issue");
+  const projectSlug = slugifyWorkspaceSegment(input.project.name, "project");
+  const issueSlug = slugifyWorkspaceSegment(input.issue.title, "issue");
   const issueDirectoryName = `${input.issue.number}-${issueSlug}`;
   const workspaceRoot = path.resolve(
     input.configDir ?? process.cwd(),
@@ -38,7 +38,10 @@ export function planWorkspacePaths(
   };
 }
 
-function slugify(input: string, fallback: string): string {
+export function slugifyWorkspaceSegment(
+  input: string,
+  fallback: string
+): string {
   const asciiInput = Array.from(input.normalize("NFKD"))
     .filter((character) => character.charCodeAt(0) <= 0x7f)
     .join("");

--- a/tests/routine-declaration-loader.test.ts
+++ b/tests/routine-declaration-loader.test.ts
@@ -22,6 +22,36 @@ afterEach(async () => {
 });
 
 describe("RoutineDeclarationLoader", () => {
+  it("parses a Markdown kind: git routine", async () => {
+    const root = await makeTempRoot();
+    const routinePath = path.join(root, "dependency-update.md");
+    await writeFile(
+      routinePath,
+      [
+        "---",
+        "name: dependency-update",
+        "schedule:",
+        "  at: 2026-05-22T10:00:00.000Z",
+        "kind: git",
+        "---",
+        "Update dependencies on {{branch.name}}.",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadRoutineDeclaration(routinePath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.routine).toEqual({
+      kind: "git",
+      name: "dependency-update",
+      prompt: "Update dependencies on {{branch.name}}.\n",
+      provider: null,
+      schedule: { at: "2026-05-22T10:00:00.000Z" },
+      sourcePath: routinePath
+    });
+  });
+
   it("parses a Markdown kind: report routine with one-shot at schedule", async () => {
     const root = await makeTempRoot();
     const routinePath = path.join(root, "weekly-report.md");

--- a/tests/routine-dispatcher.test.ts
+++ b/tests/routine-dispatcher.test.ts
@@ -16,6 +16,10 @@ import type {
   PrepareRoutineWorkspaceInput
 } from "../src/routines/workspace.js";
 import { openRunStore } from "../src/run-store.js";
+import {
+  createGitWorkspaceAhead,
+  createGitWorkspaceAtBase
+} from "./helpers/git-workspace.js";
 
 const tempRoots: string[] = [];
 
@@ -36,6 +40,214 @@ afterEach(async () => {
 });
 
 describe("RoutineFiringDispatcher", () => {
+  it("succeeds a kind: git firing with commits ahead and discovers every open PR", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const workspacePath = path.join(root, "workspace");
+    const branchName = "sym/alpha/routine/dependency-update/01JABCDEFG";
+    await createGitWorkspaceAhead({ branchName, workspacePath });
+    const runStore = openRunStore({ stateRoot });
+    const providerInputs: ProviderRunInput[] = [];
+    const provider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (
+        input: ProviderRunInput
+      ): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        providerInputs.push(input);
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+    const listPullRequestsForBranch = vi.fn().mockResolvedValue([
+      {
+        head: { ref: branchName, sha: "abc123" },
+        number: 17,
+        state: "open"
+      },
+      {
+        head: { ref: branchName, sha: "def456" },
+        number: 18,
+        state: "open"
+      },
+      {
+        head: { ref: "another-branch", sha: "ignored" },
+        number: 19,
+        state: "open"
+      }
+    ]);
+    const prepareRoutineWorkspace = vi.fn(
+      (): Promise<PreparedRoutineWorkspace> =>
+        Promise.resolve({
+          branchName,
+          branchRef: `refs/heads/${branchName}`,
+          cachePath: path.join(root, ".cache", "repo.git"),
+          reused: false,
+          workspacePath
+        })
+    );
+
+    try {
+      await dispatchDueRoutines({
+        activeRuns: new ActiveRunRegistry(),
+        agentProviders: { codex: provider },
+        configDir: root,
+        createFiringId: () => "01JABCDEFGHJKMNPQRSTVWXYZ12",
+        env: { GITHUB_TOKEN: "secret-token" },
+        githubIssuesApi: {
+          listOpenIssues: vi.fn().mockResolvedValue([]),
+          listPullRequestsForBranch
+        },
+        globalConcurrency: { maxInFlight: undefined },
+        logger: pino({ enabled: false }),
+        now: new Date("2026-05-22T10:00:01.000Z"),
+        prepareRoutineWorkspace,
+        projects: new Map([
+          [
+            "alpha",
+            {
+              ...runStoreProjectFixture(),
+              routines: [
+                {
+                  kind: "git",
+                  name: "dependency-update",
+                  prompt: "Commit on {{branch.name}} ({{branch.ref}}).",
+                  provider: null,
+                  schedule: { at: "2026-05-22T10:00:00.000Z" },
+                  sourcePath: path.join(root, "dependency-update.md")
+                }
+              ]
+            }
+          ]
+        ]),
+        providersConfig: {
+          claude: { command: "claude fake" },
+          codex: { command: "codex fake" }
+        },
+        runStore,
+        stateRoot
+      });
+
+      expect(prepareRoutineWorkspace).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "git" })
+      );
+      expect(providerInputs).toEqual([
+        expect.objectContaining({ branchName, workspacePath })
+      ]);
+      expect(providerInputs[0]?.prompt).toContain(
+        `Commit on ${branchName} (refs/heads/${branchName}).`
+      );
+      expect(listPullRequestsForBranch).toHaveBeenCalledWith({
+        branch: branchName,
+        owner: "pmatos",
+        repo: "alpha",
+        token: "secret-token"
+      });
+      expect(runStore.listRoutineFirings()).toEqual([
+        expect.objectContaining({
+          id: "01JABCDEFGHJKMNPQRSTVWXYZ12",
+          pullRequests: [
+            expect.objectContaining({ prNumber: 17 }),
+            expect.objectContaining({ prNumber: 18 })
+          ],
+          state: "succeeded",
+          terminalReason: null
+        })
+      ]);
+      expect(runStore.listOpenTrackedPullRequests()).toEqual([]);
+      expect(runStore.hasPullRequestFollowupWork()).toBe(false);
+    } finally {
+      runStore.close();
+    }
+  });
+
+  it("fails a kind: git firing with no commits ahead of base", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const workspacePath = path.join(root, "workspace");
+    const branchName = "sym/alpha/routine/dependency-update/fire-zero";
+    await createGitWorkspaceAtBase({ branchName, workspacePath });
+    const runStore = openRunStore({ stateRoot });
+    const provider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex",
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi.fn().mockResolvedValue(undefined)
+    } satisfies AgentProvider;
+    const listPullRequestsForBranch = vi.fn().mockResolvedValue([]);
+
+    try {
+      await dispatchDueRoutines({
+        activeRuns: new ActiveRunRegistry(),
+        agentProviders: { codex: provider },
+        configDir: root,
+        createFiringId: () => "fire-zero",
+        env: { GITHUB_TOKEN: "secret-token" },
+        githubIssuesApi: {
+          listOpenIssues: vi.fn().mockResolvedValue([]),
+          listPullRequestsForBranch
+        },
+        globalConcurrency: { maxInFlight: undefined },
+        logger: pino({ enabled: false }),
+        now: new Date("2026-05-22T10:00:01.000Z"),
+        prepareRoutineWorkspace: () =>
+          Promise.resolve({
+            branchName,
+            branchRef: `refs/heads/${branchName}`,
+            cachePath: path.join(root, ".cache", "repo.git"),
+            reused: false,
+            workspacePath
+          }),
+        projects: new Map([
+          [
+            "alpha",
+            {
+              ...runStoreProjectFixture(),
+              routines: [
+                {
+                  kind: "git",
+                  name: "dependency-update",
+                  prompt: "Update dependencies.",
+                  provider: null,
+                  schedule: { at: "2026-05-22T10:00:00.000Z" },
+                  sourcePath: path.join(root, "dependency-update.md")
+                }
+              ]
+            }
+          ]
+        ]),
+        providersConfig: {
+          claude: { command: "claude fake" },
+          codex: { command: "codex fake" }
+        },
+        runStore,
+        stateRoot
+      });
+
+      expect(runStore.listRoutineFirings()).toEqual([
+        expect.objectContaining({
+          id: "fire-zero",
+          pullRequests: [],
+          state: "failed",
+          terminalReason: "no_workspace_changes"
+        })
+      ]);
+      expect(listPullRequestsForBranch).not.toHaveBeenCalled();
+    } finally {
+      runStore.close();
+    }
+  });
+
   it("fires a due one-shot report routine exactly once", async () => {
     const root = await makeTempRoot();
     const stateRoot = path.join(root, ".symphonika");

--- a/tests/routine-prompt-renderer.test.ts
+++ b/tests/routine-prompt-renderer.test.ts
@@ -30,6 +30,22 @@ const baseInput = {
 };
 
 describe("RoutinePromptRenderer", () => {
+  it("renders branch variables for kind: git routines", () => {
+    const rendered = renderRoutinePrompt({
+      ...baseInput,
+      branch: {
+        name: "sym/symphonika/routine/daily-report/01JABCDEF0",
+        ref: "refs/heads/sym/symphonika/routine/daily-report/01JABCDEF0"
+      },
+      routine: { ...baseInput.routine, kind: "git" },
+      template: "Work on {{branch.name}} at {{branch.ref}}."
+    });
+
+    expect(rendered.prompt).toContain(
+      "Work on sym/symphonika/routine/daily-report/01JABCDEF0 at refs/heads/sym/symphonika/routine/daily-report/01JABCDEF0."
+    );
+  });
+
   it("renders routine variables and prepends the standard autonomy preamble", () => {
     const routinePrompt = renderRoutinePrompt(baseInput);
     const issuePrompt = renderAutonomousPrompt({

--- a/tests/routine-store.test.ts
+++ b/tests/routine-store.test.ts
@@ -22,6 +22,74 @@ afterEach(async () => {
 });
 
 describe("RunStore routines", () => {
+  it("records every pull request discovered for a successful firing", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.syncRoutines("alpha", [
+        {
+          kind: "git",
+          name: "dependency-update",
+          prompt: "Update dependencies.",
+          provider: "codex",
+          schedule: { at: "2026-05-22T10:00:00.000Z" },
+          sourcePath: "/tmp/dependency-update.md"
+        }
+      ]);
+      store.createRoutineFiring({
+        id: "fire-git-1",
+        projectName: "alpha",
+        providerCommand: "codex fake",
+        providerName: "codex",
+        routineName: "dependency-update"
+      });
+
+      store.recordRoutinePullRequest({
+        firingId: "fire-git-1",
+        headSha: "abc123",
+        prNumber: 17,
+        projectName: "alpha",
+        routineName: "dependency-update"
+      });
+      store.recordRoutinePullRequest({
+        firingId: "fire-git-1",
+        headSha: "def456",
+        prNumber: 18,
+        projectName: "alpha",
+        routineName: "dependency-update"
+      });
+
+      expect(
+        store.listRoutineFirings({ routineName: "dependency-update" })
+      ).toEqual([
+        expect.objectContaining({
+          id: "fire-git-1",
+          pullRequests: [
+            {
+              firingId: "fire-git-1",
+              headSha: "abc123",
+              prNumber: 17,
+              projectName: "alpha",
+              routineName: "dependency-update"
+            },
+            {
+              firingId: "fire-git-1",
+              headSha: "def456",
+              prNumber: 18,
+              projectName: "alpha",
+              routineName: "dependency-update"
+            }
+          ]
+        })
+      ]);
+      expect(store.listRoutines()).toEqual([
+        expect.objectContaining({ pullRequestNumbers: [17, 18] })
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
   it("upserts routines and lists operator status fields", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });
@@ -45,6 +113,7 @@ describe("RunStore routines", () => {
           nextFireAt: "2026-05-22T10:00:00.000Z",
           projectName: "alpha",
           provider: null,
+          pullRequestNumbers: [],
           scheduleAt: "2026-05-22T10:00:00.000Z",
           sourcePath: "/tmp/daily-report.md",
           state: "active"

--- a/tests/routine-surfaces.test.ts
+++ b/tests/routine-surfaces.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildCli } from "../src/cli.js";
 import { createHttpApp } from "../src/http/app.js";
 import { openRunStore } from "../src/run-store.js";
+import { renderStatusDashboard } from "../src/status-dashboard.js";
 
 const tempRoots: string[] = [];
 
@@ -47,7 +48,22 @@ describe("routine operator surfaces", () => {
           name: "daily-report",
           nextFireAt: "2026-05-22T10:00:00.000Z",
           projectName: "alpha",
+          pullRequestNumbers: [42],
           state: "active"
+        })
+      ]);
+
+      const firingsResponse = await app.request(
+        "/api/routines/daily-report/firings?project=alpha"
+      );
+      const firingsBody = (await firingsResponse.json()) as {
+        firings: unknown[];
+      };
+      expect(firingsResponse.status).toBe(200);
+      expect(firingsBody.firings).toEqual([
+        expect.objectContaining({
+          id: "fire-1",
+          pullRequests: [expect.objectContaining({ prNumber: 42 })]
         })
       ]);
     } finally {
@@ -73,6 +89,38 @@ describe("routine operator surfaces", () => {
       expect(body).toContain("Routines");
       expect(body).toContain("daily-report");
       expect(body).toContain("next_fire_at");
+      expect(body).toContain("#42");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("renders linked PR numbers on the terminal status dashboard", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      seedRoutine(store);
+
+      const dashboard = renderStatusDashboard({
+        daemon: "running",
+        issueCounts: {
+          candidate: 0,
+          failed: 0,
+          filtered: 0,
+          running: 0,
+          stale: 0
+        },
+        lastPollOutcome: "ok",
+        latestEvents: new Map(),
+        projects: [],
+        reload: "ok",
+        routines: store.listRoutines(),
+        runs: [],
+        stateRoot
+      });
+
+      expect(dashboard).toContain("daily-report");
+      expect(dashboard).toContain("#42");
     } finally {
       store.close();
     }
@@ -107,10 +155,10 @@ describe("routine operator surfaces", () => {
     ]);
 
     expect(output.stdout).toContain(
-      "project  routine  state  next_fire_at  last_fired_at"
+      "project  routine  state  next_fire_at  last_fired_at  pull_requests"
     );
     expect(output.stdout).toContain(
-      "alpha  daily-report  active  2026-05-22T10:00:00.000Z  -"
+      "alpha  daily-report  active  2026-05-22T10:00:00.000Z  -  #42"
     );
   });
 });
@@ -118,7 +166,7 @@ describe("routine operator surfaces", () => {
 function seedRoutine(store: ReturnType<typeof openRunStore>): void {
   store.syncRoutines("alpha", [
     {
-      kind: "report",
+      kind: "git",
       name: "daily-report",
       prompt: "Report.",
       provider: null,
@@ -126,4 +174,23 @@ function seedRoutine(store: ReturnType<typeof openRunStore>): void {
       sourcePath: "/tmp/daily-report.md"
     }
   ]);
+  store.createRoutineFiring({
+    id: "fire-1",
+    projectName: "alpha",
+    providerCommand: "codex fake",
+    providerName: "codex",
+    routineName: "daily-report"
+  });
+  store.completeRoutineFiring({
+    id: "fire-1",
+    state: "succeeded",
+    workspacePath: "/tmp/workspace"
+  });
+  store.recordRoutinePullRequest({
+    firingId: "fire-1",
+    headSha: "abc123",
+    prNumber: 42,
+    projectName: "alpha",
+    routineName: "daily-report"
+  });
 }

--- a/tests/routine-workspace.test.ts
+++ b/tests/routine-workspace.test.ts
@@ -1,0 +1,88 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { prepareRoutineWorkspace } from "../src/routines/workspace.js";
+
+const execFileAsync = promisify(execFile);
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(
+    path.join(tmpdir(), "symphonika-routine-workspace-")
+  );
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("Routine workspace preparation", () => {
+  it("creates a deterministic kind: git branch from the project base", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "alpha");
+
+    const prepared = await prepareRoutineWorkspace({
+      configDir: root,
+      firingId: "01JABCDEFGHJKMNPQRSTVWXYZ12",
+      kind: "git",
+      project: {
+        name: "alpha",
+        workspace: {
+          git: { base_branch: "main", remote: remotePath },
+          root: workspaceRoot
+        }
+      },
+      routineName: "dependency-update"
+    });
+
+    expect(prepared).toMatchObject({
+      branchName: "sym/alpha/routine/dependency-update/01JABCDEFG",
+      branchRef: "refs/heads/sym/alpha/routine/dependency-update/01JABCDEFG",
+      reused: false,
+      workspacePath: path.join(
+        workspaceRoot,
+        "routines",
+        "dependency-update",
+        "01JABCDEFGHJKMNPQRSTVWXYZ12"
+      )
+    });
+    await expect(
+      git(["-C", prepared.workspacePath, "rev-parse", "--abbrev-ref", "HEAD"])
+    ).resolves.toBe(prepared.branchName);
+    await expect(
+      git(["-C", prepared.workspacePath, "show", "--no-patch", "--format=%s"])
+    ).resolves.toBe("Initial commit");
+  });
+});
+
+async function createRemoteRepository(root: string): Promise<string> {
+  const remotePath = path.join(root, "remote.git");
+  const seedPath = path.join(root, "seed");
+
+  await git(["init", "--bare", remotePath]);
+  await git(["init", "--initial-branch=main", seedPath]);
+  await git(["-C", seedPath, "config", "user.email", "test@example.com"]);
+  await git(["-C", seedPath, "config", "user.name", "Symphonika Test"]);
+  await writeFile(path.join(seedPath, "README.md"), "# Symphonika\n");
+  await git(["-C", seedPath, "add", "README.md"]);
+  await git(["-C", seedPath, "commit", "-m", "Initial commit"]);
+  await git(["-C", seedPath, "remote", "add", "origin", remotePath]);
+  await git(["-C", seedPath, "push", "origin", "main"]);
+  return remotePath;
+}
+
+async function git(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args);
+  return stdout.trim();
+}

--- a/tests/routine-workspace.test.ts
+++ b/tests/routine-workspace.test.ts
@@ -64,6 +64,39 @@ describe("Routine workspace preparation", () => {
       git(["-C", prepared.workspacePath, "show", "--no-patch", "--format=%s"])
     ).resolves.toBe("Initial commit");
   });
+
+  it("slugifies git-ref-hostile routine names into valid branch refs", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "alpha");
+
+    const prepared = await prepareRoutineWorkspace({
+      configDir: root,
+      firingId: "01JABCDEFGHJKMNPQRSTVWXYZ12",
+      kind: "git",
+      project: {
+        name: "alpha",
+        workspace: {
+          git: { base_branch: "main", remote: remotePath },
+          root: workspaceRoot
+        }
+      },
+      routineName: "deps..update"
+    });
+
+    expect(prepared.branchName).toBe(
+      "sym/alpha/routine/deps-update/01JABCDEFG"
+    );
+    expect(prepared.branchRef).toBe(
+      "refs/heads/sym/alpha/routine/deps-update/01JABCDEFG"
+    );
+    await expect(git(["check-ref-format", prepared.branchRef])).resolves.toBe(
+      ""
+    );
+    await expect(
+      git(["-C", prepared.workspacePath, "rev-parse", "--abbrev-ref", "HEAD"])
+    ).resolves.toBe(prepared.branchName);
+  });
 });
 
 async function createRemoteRepository(root: string): Promise<string> {


### PR DESCRIPTION
## Summary

- accept kind: git routine declarations and prepare deterministic firing branches
- grade git firings by commits ahead of base and expose branch prompt context
- discover all open PRs on successful firing branches and surface them in the run store, CLI, API, and dashboards without follow-up or auto-merge

## Verification

- npm run lint
- npm run typecheck
- NPM_CONFIG_DANGEROUSLY_ALLOW_ALL_SCRIPTS=true npm test (606 tests)
- npm run build

Closes #193