### PR TITLE
feat: expose watchdog state in CLI and HTTP API

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -844,9 +844,14 @@ signal to advance and must not accrue idle time; rows in `state = "waiting"` are
 wait-state path. A `running` Run that already carries `cancel_requested` is also skipped, so the
 Watchdog does not overwrite a more specific in-flight cancellation with `no_progress`.
 
-For each sampled Run, Symphonika records one durable `watchdog_samples` row keyed by `run_id`:
-`sampled_at`, `last_tool_call_at`, `last_message_at`, `workspace_mtime_max`, `turn_id_set_size`,
-`output_tokens_total`, `normalized_log_offset`, `normalized_log_path`, and `idle_since`. `idle_since`
+For each sampled Run, Symphonika records one durable latest `watchdog_samples` row keyed by
+`run_id` and an append-only `watchdog_sample_history` row keyed by `(run_id, sampled_at)`. Both
+contain `sampled_at`, `last_tool_call_at`, `last_message_at`, `workspace_mtime_max`,
+`turn_id_set_size`, `output_tokens_total`, `normalized_log_offset`, `normalized_log_path`, and
+`idle_since`. The latest row keeps reconciliation reads bounded; the history supports operator
+rolling-window calculations. In particular, `show-run` computes output-token growth over the final
+sample's five-minute window by walking persisted cumulative totals (and treating a normalized-log
+path change as a counter reset), never by re-scanning the Normalized Event Log. `idle_since`
 survives daemon restart, so a Run that was already observed idle resumes its grace window from the
 first idle observation rather than from process boot. It is cleared on entry to `waiting` (so an
 unsampled wait excursion does not accrue idle time) and reset on attempt change (so a transient
@@ -1022,6 +1027,11 @@ frame, but caches the full `doctor` validation path for 5000 ms by default so pa
 not continuously re-run provider probes or GitHub validation reads. `--doctor-ttl-ms 0` disables that
 cache when an operator explicitly wants every frame to perform full validation.
 
+`show-run` renders the latest persisted Watchdog Progress Signal, including tool-call and workspace
+mtime ages, observed turn-id count, five-minute output-token growth, and `idle_since` plus effective
+grace remaining when idle. `status` and its dashboard render an idle indicator only for active Runs
+whose latest sample has `idle_since` set.
+
 `routines` lists routine status per Project with `state`, `next_fire_at`, and `last_fired_at`.
 
 `clear-stale` removes `sym:stale`, `sym:claimed`, and `sym:running` only after explicit confirmation.
@@ -1061,6 +1071,11 @@ uses the normal daemon scheduler path.
 
 The HTTP API exposes `GET /api/routines` with the same routine status shape as the CLI and
 dashboard.
+
+`GET /api/runs/:id` exposes the latest sample as a camel-cased top-level `watchdog` object, including
+the effective `graceMs` and server-computed `graceRemainingMs`. `GET /api/status` adds a `watchdog`
+object to each active Run with `idleSince` and `graceRemainingMs` when idle. When the effective
+Watchdog policy is disabled, both endpoints return exactly `{ "enabled": false }` for that object.
 
 Label creation, stale-claim reset, and workspace cleanup remain CLI-only.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,9 +22,10 @@ import type { InitOptions, InitProvider, InitReport } from "./init.js";
 import { runInit } from "./init.js";
 import type { ProjectIssuePollReport } from "./issue-polling.js";
 import {
+  resolveWatchdogConfig,
   RuntimeConfigReloader,
   type RuntimeReloadStatus,
-  type WatchdogConfig
+  type WatchdogServiceConfig
 } from "./reload.js";
 import type {
   ListRunsFilter,
@@ -596,11 +597,13 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
                 ? ({ error: "not configured", kind: "unavailable" } as const)
                 : await fetchDaemonStatus(fetcher, daemonUrl, stateRoot);
             const all = store.listRuns();
-            const watchdogConfig = await loadWatchdogConfig(state.configPath);
+            const watchdogService = await loadWatchdogServiceConfig(
+              state.configPath
+            );
             const watchdogByRun = collectWatchdogIdleStatuses(
               store,
               all,
-              watchdogConfig,
+              watchdogService,
               Date.now()
             );
             const byState = new Map<string, number>();
@@ -953,10 +956,12 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
               );
             }
           }
-          const watchdogConfig = await loadWatchdogConfig(state.configPath);
+          const watchdogService = await loadWatchdogServiceConfig(
+            state.configPath
+          );
           const nowMs = Date.now();
           const watchdog = buildWatchdogStatus({
-            config: watchdogConfig,
+            config: resolveWatchdogConfig(watchdogService, detail.project),
             nowMs,
             runId: detail.id,
             runStore: store
@@ -1665,12 +1670,12 @@ function formatArtifactKinds(artifacts: RunArtifactDescriptor[]): string {
   return present.length === 0 ? "(none)" : present.join(", ");
 }
 
-async function loadWatchdogConfig(
+async function loadWatchdogServiceConfig(
   configPath: string
-): Promise<ReturnType<RuntimeConfigReloader["watchdogConfig"]>> {
+): Promise<WatchdogServiceConfig> {
   const reloader = new RuntimeConfigReloader({ configPath });
   await reloader.reload();
-  return reloader.watchdogConfig();
+  return reloader.watchdogServiceConfig();
 }
 
 function formatProgressSignal(
@@ -1720,7 +1725,7 @@ function formatAge(
 function collectWatchdogIdleStatuses(
   store: RunStore,
   runs: RunStatus[],
-  config: Pick<WatchdogConfig, "enabled" | "graceMinutes">,
+  serviceConfig: WatchdogServiceConfig,
   nowMs: number
 ): Map<string, WatchdogIdleStatus> {
   const statuses = new Map<string, WatchdogIdleStatus>();
@@ -1731,7 +1736,7 @@ function collectWatchdogIdleStatuses(
     statuses.set(
       run.id,
       buildWatchdogIdleStatus({
-        config,
+        config: resolveWatchdogConfig(serviceConfig, run.project),
         nowMs,
         runId: run.id,
         runStore: store

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,11 @@ import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
 import type { InitOptions, InitProvider, InitReport } from "./init.js";
 import { runInit } from "./init.js";
 import type { ProjectIssuePollReport } from "./issue-polling.js";
-import { RuntimeConfigReloader, type RuntimeReloadStatus } from "./reload.js";
+import {
+  RuntimeConfigReloader,
+  type RuntimeReloadStatus,
+  type WatchdogConfig
+} from "./reload.js";
 import type {
   ListRunsFilter,
   OpenRunStoreOptions,
@@ -58,6 +62,13 @@ import {
   planWorkspacePaths,
   type WorkspacePathPlan
 } from "./workspace-paths.js";
+import {
+  buildWatchdogIdleStatus,
+  buildWatchdogStatus,
+  formatWatchdogDuration,
+  type WatchdogIdleStatus,
+  type WatchdogStatus
+} from "./watchdog-status.js";
 
 export type CliDependencies = {
   fetch?: FetchFn;
@@ -574,9 +585,8 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
           dashboard: boolean,
           redrawState?: { previousLineCount: number }
         ): Promise<void> => {
-          const stateRoot = resolveStateRoot(
-            withConfigPath(options.config)
-          ).stateRoot;
+          const state = resolveStateRoot(withConfigPath(options.config));
+          const stateRoot = state.stateRoot;
           const store = openRunStore({ stateRoot });
           try {
             const report = await refreshDoctorReport();
@@ -586,6 +596,13 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
                 ? ({ error: "not configured", kind: "unavailable" } as const)
                 : await fetchDaemonStatus(fetcher, daemonUrl, stateRoot);
             const all = store.listRuns();
+            const watchdogConfig = await loadWatchdogConfig(state.configPath);
+            const watchdogByRun = collectWatchdogIdleStatuses(
+              store,
+              all,
+              watchdogConfig,
+              Date.now()
+            );
             const byState = new Map<string, number>();
             for (const run of all) {
               byState.set(run.state, (byState.get(run.state) ?? 0) + 1);
@@ -609,7 +626,8 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
                 reload: formatReloadOutcome(daemonStatus),
                 routines: store.listRoutines(),
                 runs: all,
-                stateRoot
+                stateRoot,
+                watchdogByRun
               });
               if (redrawState !== undefined) {
                 const frame = renderStatusDashboardRedrawFrame(
@@ -688,6 +706,12 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
                   program,
                   `  ${run.id}  ${run.project}  #${run.issueNumber}  ${run.state}  ${run.provider}${suffix}\n`
                 );
+                const watchdogLine = formatWatchdogIdleLine(
+                  watchdogByRun.get(run.id)
+                );
+                if (watchdogLine !== undefined) {
+                  writeOut(program, `    ${watchdogLine}\n`);
+                }
               }
             }
             printStaleSection(program, report.projects);
@@ -928,6 +952,24 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
               );
             }
           }
+          const watchdogConfig = await loadWatchdogConfig(state.configPath);
+          const nowMs = Date.now();
+          const watchdog = buildWatchdogStatus({
+            config: watchdogConfig,
+            nowMs,
+            runId: detail.id,
+            runStore: store
+          });
+          const growth =
+            watchdog.enabled && watchdog.sampledAt !== undefined
+              ? store.watchdogOutputTokenGrowth(
+                  detail.id,
+                  new Date(
+                    Date.parse(watchdog.sampledAt) - 5 * 60_000
+                  ).toISOString()
+                )
+              : 0;
+          writeOut(program, formatProgressSignal(watchdog, growth, nowMs));
           const events = store.listProviderEvents(id, {
             limit: options.events
           });
@@ -1614,6 +1656,96 @@ function formatArtifactKinds(artifacts: RunArtifactDescriptor[]): string {
         : `${artifact.kind}(${artifact.sizeBytes} bytes)`
     );
   return present.length === 0 ? "(none)" : present.join(", ");
+}
+
+async function loadWatchdogConfig(
+  configPath: string
+): Promise<ReturnType<RuntimeConfigReloader["watchdogConfig"]>> {
+  const reloader = new RuntimeConfigReloader({ configPath });
+  await reloader.reload();
+  return reloader.watchdogConfig();
+}
+
+function formatProgressSignal(
+  watchdog: WatchdogStatus,
+  outputTokenGrowth5m: number,
+  nowMs: number
+): string {
+  if (!watchdog.enabled) {
+    return "\nProgress Signal:\n  watchdog: disabled\n";
+  }
+  if (watchdog.sampledAt === undefined) {
+    return "\nProgress Signal:\n  (no sample persisted)\n";
+  }
+
+  const lines = [
+    "",
+    "Progress Signal:",
+    `  last tool_call: ${formatAge(watchdog.lastToolCallAt, nowMs)}`,
+    `  workspace mtime: ${formatAge(watchdog.workspaceMtimeMax, nowMs)}`,
+    `  turn_ids observed: ${watchdog.turnIdSetSize ?? 0}`,
+    `  output tokens / 5m: ${outputTokenGrowth5m === 0 ? "0" : `+${outputTokenGrowth5m}`}`
+  ];
+  if (watchdog.idleSince !== undefined) {
+    lines.push(`  idle_since: ${watchdog.idleSince}`);
+  }
+  if (watchdog.graceRemainingMs !== undefined) {
+    lines.push(
+      `  grace remaining: ${formatWatchdogDuration(watchdog.graceRemainingMs)}`
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function formatAge(
+  timestamp: string | null | undefined,
+  nowMs: number
+): string {
+  if (timestamp === null || timestamp === undefined) {
+    return "never";
+  }
+  const ageMs = nowMs - Date.parse(timestamp);
+  return ageMs < 0
+    ? `in ${formatWatchdogDuration(-ageMs)}`
+    : `${formatWatchdogDuration(ageMs)} ago`;
+}
+
+function collectWatchdogIdleStatuses(
+  store: RunStore,
+  runs: RunStatus[],
+  config: Pick<WatchdogConfig, "enabled" | "graceMinutes">,
+  nowMs: number
+): Map<string, WatchdogIdleStatus> {
+  const statuses = new Map<string, WatchdogIdleStatus>();
+  for (const run of runs) {
+    if (!statusDashboardShowsLatestEvent(run.state)) {
+      continue;
+    }
+    statuses.set(
+      run.id,
+      buildWatchdogIdleStatus({
+        config,
+        nowMs,
+        runId: run.id,
+        runStore: store
+      })
+    );
+  }
+  return statuses;
+}
+
+function formatWatchdogIdleLine(
+  watchdog: WatchdogIdleStatus | undefined
+): string | undefined {
+  if (
+    watchdog === undefined ||
+    !watchdog.enabled ||
+    watchdog.idleSince === undefined ||
+    watchdog.graceRemainingMs === undefined
+  ) {
+    return undefined;
+  }
+  return `watchdog idle since ${watchdog.idleSince} (grace remaining ${formatWatchdogDuration(watchdog.graceRemainingMs)})`;
 }
 
 async function fillMissingRunDisplayPaths(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -42,7 +42,7 @@ import {
   runPullRequestFollowup,
   type PullRequestFollowupPolicy
 } from "./pull-request-followup.js";
-import { RuntimeConfigReloader } from "./reload.js";
+import { resolveWatchdogConfig, RuntimeConfigReloader } from "./reload.js";
 import {
   INPUT_REQUIRED_LEGACY_BACKFILL_GRACE_MS,
   openRunStore,
@@ -642,7 +642,8 @@ export async function startDaemon(
       };
     },
     getRuns: () => runStore.listRuns(),
-    getWatchdogConfig: () => runtimeConfig.watchdogConfig(),
+    getWatchdogConfig: (projectName) =>
+      resolveWatchdogConfig(runtimeConfig.watchdogServiceConfig(), projectName),
     getScheduled: () => activeRuns.peekDelayed(),
     getStatusSnapshot: () =>
       buildStatusSnapshot({

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -635,6 +635,7 @@ export async function startDaemon(
       };
     },
     getRuns: () => runStore.listRuns(),
+    getWatchdogConfig: () => runtimeConfig.watchdogConfig(),
     getScheduled: () => activeRuns.peekDelayed(),
     getStatusSnapshot: () =>
       buildStatusSnapshot({

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -7,7 +7,11 @@ import type {
   ProjectIssuePollReport
 } from "../issue-polling.js";
 import { emptyIssuePollStatus } from "../issue-polling.js";
-import type { RuntimeReloadStatus } from "../reload.js";
+import {
+  DEFAULT_WATCHDOG_CONFIG,
+  type RuntimeReloadStatus,
+  type WatchdogConfig
+} from "../reload.js";
 import type { StatusSnapshot } from "../status.js";
 import type {
   ListRunsFilter,
@@ -16,6 +20,10 @@ import type {
   RunStatus,
   RunStore
 } from "../run-store.js";
+import {
+  buildWatchdogIdleStatus,
+  buildWatchdogStatus
+} from "../watchdog-status.js";
 import { registerPages } from "./pages.js";
 
 type CancelRunFn = (
@@ -76,6 +84,9 @@ export type HttpAppOptions = {
     runId: string;
   }>;
   getStatusSnapshot?: () => StatusSnapshot;
+  getWatchdogConfig?: (
+    projectName: string
+  ) => Pick<WatchdogConfig, "enabled" | "graceMinutes">;
   issuePollStatus?: IssuePollStatus;
   now?: () => number;
   pollNow?: PollNowFn;
@@ -148,7 +159,21 @@ export function createHttpApp(options: HttpAppOptions): Hono {
 
   app.get("/api/status", (context) =>
     context.json({
-      active: getActiveRuns(),
+      active: getActiveRuns().map((run) =>
+        runStore === undefined
+          ? run
+          : {
+              ...run,
+              watchdog: buildWatchdogIdleStatus({
+                config:
+                  options.getWatchdogConfig?.(run.projectName) ??
+                  DEFAULT_WATCHDOG_CONFIG,
+                nowMs: now(),
+                runId: run.runId,
+                runStore
+              })
+            }
+      ),
       candidateIssues: issuePollStatus.candidateIssues,
       filteredIssues: issuePollStatus.filteredIssues,
       issuePolling: {
@@ -228,7 +253,14 @@ export function createHttpApp(options: HttpAppOptions): Hono {
         attempts,
         events,
         run,
-        transitions
+        transitions,
+        watchdog: buildWatchdogStatus({
+          config:
+            options.getWatchdogConfig?.(run.project) ?? DEFAULT_WATCHDOG_CONFIG,
+          nowMs: now(),
+          runId: run.id,
+          runStore
+        })
       });
     });
 

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -248,8 +248,11 @@ export class RuntimeConfigReloader {
     return this.snapshot?.globalConcurrency ?? { maxInFlight: undefined };
   }
 
-  watchdogConfig(): WatchdogConfig {
-    return this.snapshot?.watchdog ?? DEFAULT_WATCHDOG_CONFIG;
+  watchdogServiceConfig(): WatchdogServiceConfig {
+    return {
+      projects: this.snapshot?.projects ?? [],
+      watchdog: this.snapshot?.watchdog ?? DEFAULT_WATCHDOG_CONFIG
+    };
   }
 
   async reload(): Promise<RuntimeConfigSnapshot | undefined> {

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -68,7 +68,7 @@ export type WatchdogConfig = {
   sampleIntervalSeconds: number;
 };
 
-const DEFAULT_WATCHDOG_CONFIG: WatchdogConfig = {
+export const DEFAULT_WATCHDOG_CONFIG: WatchdogConfig = {
   enabled: true,
   graceMinutes: 30,
   mtimeIgnore: [],

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -2393,17 +2393,6 @@ export class RunStore {
         foreign key (run_id) references runs(id)
       );
 
-      insert or ignore into watchdog_sample_history (
-        run_id, sampled_at, last_tool_call_at, last_message_at,
-        workspace_mtime_max, turn_id_set_size, output_tokens_total,
-        normalized_log_offset, normalized_log_path, idle_since
-      )
-      select
-        run_id, sampled_at, last_tool_call_at, last_message_at,
-        workspace_mtime_max, turn_id_set_size, output_tokens_total,
-        normalized_log_offset, normalized_log_path, idle_since
-      from watchdog_samples;
-
       create table if not exists routines (
         project_name text not null,
         name text not null,
@@ -2475,6 +2464,23 @@ export class RunStore {
       }
     });
     apply();
+
+    // Runs after the ensureColumn additions above so databases created before
+    // watchdog_samples gained normalized_log_path/last_message_at have those
+    // columns before the history backfill reads them.
+    this.database.exec(`
+      insert or ignore into watchdog_sample_history (
+        run_id, sampled_at, last_tool_call_at, last_message_at,
+        workspace_mtime_max, turn_id_set_size, output_tokens_total,
+        normalized_log_offset, normalized_log_path, idle_since
+      )
+      select
+        run_id, sampled_at, last_tool_call_at, last_message_at,
+        workspace_mtime_max, turn_id_set_size, output_tokens_total,
+        normalized_log_offset, normalized_log_path, idle_since
+      from watchdog_samples;
+    `);
+
     this.backfillAttemptMetadataPaths();
   }
 

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -384,6 +384,12 @@ type WatchdogSampleRow = {
   workspace_mtime_max: number;
 };
 
+type WatchdogTokenSampleRow = {
+  normalized_log_path: string;
+  output_tokens_total: number;
+  sampled_at: string;
+};
+
 type PullRequestDiscoveryRunRow = {
   branch_name: string;
   id: string;
@@ -770,42 +776,99 @@ export class RunStore {
   }
 
   upsertWatchdogSample(sample: WatchdogSample): void {
-    this.database
+    const values = {
+      idle_since: sample.idleSince,
+      last_message_at: sample.lastMessageAt,
+      last_tool_call_at: sample.lastToolCallAt,
+      normalized_log_offset: sample.normalizedLogOffset,
+      normalized_log_path: sample.normalizedLogPath,
+      output_tokens_total: sample.outputTokensTotal,
+      run_id: sample.runId,
+      sampled_at: sample.sampledAt,
+      turn_id_set_size: sample.turnIdSetSize,
+      workspace_mtime_max: sample.workspaceMtimeMax
+    };
+    const latest = this.database.prepare(
+      [
+        "insert into watchdog_samples (",
+        "run_id, sampled_at, last_tool_call_at, last_message_at,",
+        "workspace_mtime_max, turn_id_set_size, output_tokens_total,",
+        "normalized_log_offset, normalized_log_path, idle_since",
+        ") values (",
+        "@run_id, @sampled_at, @last_tool_call_at, @last_message_at,",
+        "@workspace_mtime_max, @turn_id_set_size, @output_tokens_total,",
+        "@normalized_log_offset, @normalized_log_path, @idle_since",
+        ")",
+        "on conflict(run_id) do update set",
+        "sampled_at = excluded.sampled_at,",
+        "last_tool_call_at = excluded.last_tool_call_at,",
+        "last_message_at = excluded.last_message_at,",
+        "workspace_mtime_max = excluded.workspace_mtime_max,",
+        "turn_id_set_size = excluded.turn_id_set_size,",
+        "output_tokens_total = excluded.output_tokens_total,",
+        "normalized_log_offset = excluded.normalized_log_offset,",
+        "normalized_log_path = excluded.normalized_log_path,",
+        "idle_since = excluded.idle_since"
+      ].join(" ")
+    );
+    const history = this.database.prepare(
+      [
+        "insert or replace into watchdog_sample_history (",
+        "run_id, sampled_at, last_tool_call_at, last_message_at,",
+        "workspace_mtime_max, turn_id_set_size, output_tokens_total,",
+        "normalized_log_offset, normalized_log_path, idle_since",
+        ") values (",
+        "@run_id, @sampled_at, @last_tool_call_at, @last_message_at,",
+        "@workspace_mtime_max, @turn_id_set_size, @output_tokens_total,",
+        "@normalized_log_offset, @normalized_log_path, @idle_since",
+        ")"
+      ].join(" ")
+    );
+    this.database.transaction(() => {
+      latest.run(values);
+      history.run(values);
+    })();
+  }
+
+  watchdogOutputTokenGrowth(runId: string, windowStart: string): number {
+    const baseline = this.database
       .prepare(
         [
-          "insert into watchdog_samples (",
-          "run_id, sampled_at, last_tool_call_at, last_message_at,",
-          "workspace_mtime_max, turn_id_set_size, output_tokens_total,",
-          "normalized_log_offset, normalized_log_path, idle_since",
-          ") values (",
-          "@run_id, @sampled_at, @last_tool_call_at, @last_message_at,",
-          "@workspace_mtime_max, @turn_id_set_size, @output_tokens_total,",
-          "@normalized_log_offset, @normalized_log_path, @idle_since",
-          ")",
-          "on conflict(run_id) do update set",
-          "sampled_at = excluded.sampled_at,",
-          "last_tool_call_at = excluded.last_tool_call_at,",
-          "last_message_at = excluded.last_message_at,",
-          "workspace_mtime_max = excluded.workspace_mtime_max,",
-          "turn_id_set_size = excluded.turn_id_set_size,",
-          "output_tokens_total = excluded.output_tokens_total,",
-          "normalized_log_offset = excluded.normalized_log_offset,",
-          "normalized_log_path = excluded.normalized_log_path,",
-          "idle_since = excluded.idle_since"
+          "select sampled_at, output_tokens_total, normalized_log_path",
+          "from watchdog_sample_history",
+          "where run_id = ? and sampled_at <= ?",
+          "order by sampled_at desc limit 1"
         ].join(" ")
       )
-      .run({
-        idle_since: sample.idleSince,
-        last_message_at: sample.lastMessageAt,
-        last_tool_call_at: sample.lastToolCallAt,
-        normalized_log_offset: sample.normalizedLogOffset,
-        normalized_log_path: sample.normalizedLogPath,
-        output_tokens_total: sample.outputTokensTotal,
-        run_id: sample.runId,
-        sampled_at: sample.sampledAt,
-        turn_id_set_size: sample.turnIdSetSize,
-        workspace_mtime_max: sample.workspaceMtimeMax
-      });
+      .get(runId, windowStart) as WatchdogTokenSampleRow | undefined;
+    const inWindow = this.database
+      .prepare(
+        [
+          "select sampled_at, output_tokens_total, normalized_log_path",
+          "from watchdog_sample_history",
+          "where run_id = ? and sampled_at > ?",
+          "order by sampled_at asc"
+        ].join(" ")
+      )
+      .all(runId, windowStart) as WatchdogTokenSampleRow[];
+    const samples = baseline === undefined ? inWindow : [baseline, ...inWindow];
+    if (samples.length < 2) {
+      return 0;
+    }
+
+    let growth = 0;
+    let previous = samples[0]!;
+    for (const current of samples.slice(1)) {
+      growth +=
+        current.normalized_log_path === previous.normalized_log_path
+          ? Math.max(
+              0,
+              current.output_tokens_total - previous.output_tokens_total
+            )
+          : Math.max(0, current.output_tokens_total);
+      previous = current;
+    }
+    return growth;
   }
 
   rememberWatchdogTurnIds(runId: string, turnIds: Iterable<string>): number {
@@ -2308,12 +2371,38 @@ export class RunStore {
         foreign key (run_id) references runs(id)
       );
 
+      create table if not exists watchdog_sample_history (
+        run_id text not null,
+        sampled_at text not null,
+        last_tool_call_at text,
+        workspace_mtime_max real not null,
+        turn_id_set_size integer not null,
+        output_tokens_total integer not null,
+        normalized_log_offset integer not null,
+        idle_since text,
+        normalized_log_path text not null default '',
+        last_message_at text,
+        primary key (run_id, sampled_at),
+        foreign key (run_id) references runs(id)
+      );
+
       create table if not exists watchdog_turn_ids (
         run_id text not null,
         turn_id text not null,
         primary key (run_id, turn_id),
         foreign key (run_id) references runs(id)
       );
+
+      insert or ignore into watchdog_sample_history (
+        run_id, sampled_at, last_tool_call_at, last_message_at,
+        workspace_mtime_max, turn_id_set_size, output_tokens_total,
+        normalized_log_offset, normalized_log_path, idle_since
+      )
+      select
+        run_id, sampled_at, last_tool_call_at, last_message_at,
+        workspace_mtime_max, turn_id_set_size, output_tokens_total,
+        normalized_log_offset, normalized_log_path, idle_since
+      from watchdog_samples;
 
       create table if not exists routines (
         project_name text not null,

--- a/src/status-dashboard.ts
+++ b/src/status-dashboard.ts
@@ -2,6 +2,10 @@ import type { DoctorProjectReport } from "./doctor.js";
 import type { NormalizedProviderEvent } from "./provider.js";
 import type { ProviderEventRecord, RunState, RunStatus } from "./run-store.js";
 import type { RoutineStatus } from "./routines/types.js";
+import {
+  formatWatchdogDuration,
+  type WatchdogIdleStatus
+} from "./watchdog-status.js";
 
 type DashboardIssueCounts = {
   candidate: number;
@@ -27,6 +31,7 @@ export type StatusDashboardInput = {
   routines?: RoutineStatus[];
   runs: RunStatus[];
   stateRoot: string;
+  watchdogByRun?: ReadonlyMap<string, WatchdogIdleStatus>;
 };
 
 export type StatusDashboardRedrawFrame = {
@@ -98,7 +103,11 @@ export function renderStatusDashboard(input: StatusDashboardInput): string {
     `│ Runs: active ${activeRuns.length} | succeeded ${runCounts.succeeded ?? 0} | failed ${runCounts.failed ?? 0} | cancelled ${runCounts.cancelled ?? 0} | total ${input.runs.length}`,
     `│ Last poll: ${input.lastPollOutcome}`,
     "├─ Active runs",
-    ...formatActiveRuns(activeRuns, input.latestEvents),
+    ...formatActiveRuns(
+      activeRuns,
+      input.latestEvents,
+      input.watchdogByRun ?? new Map()
+    ),
     "├─ Attention",
     ...formatAttention(input.projects, attentionRuns),
     "├─ Routines",
@@ -160,7 +169,8 @@ function countRunsByState(
 
 function formatActiveRuns(
   runs: RunStatus[],
-  latestEvents: ReadonlyMap<string, DashboardEventSummary>
+  latestEvents: ReadonlyMap<string, DashboardEventSummary>,
+  watchdogByRun: ReadonlyMap<string, WatchdogIdleStatus>
 ): string[] {
   if (runs.length === 0) {
     return ["│   No active runs"];
@@ -169,22 +179,35 @@ function formatActiveRuns(
   return [
     "│   ID           PROJECT      ISSUE   STATE                PROVIDER  EVENT",
     "│   -------------------------------------------------------------------------------",
-    ...runs.map((run) => {
+    ...runs.flatMap((run) => {
       const event = latestEvents.get(run.id);
-      return [
-        "│  ",
-        pad(truncate(run.id, 12), 12),
-        " ",
-        pad(truncate(run.project, 12), 12),
-        " ",
-        pad(`#${run.issueNumber}`, 7),
-        " ",
-        pad(run.state, 20),
-        " ",
-        pad(run.provider || "-", 8),
-        " ",
-        truncate(eventSummary(event), 42)
-      ].join("");
+      const lines = [
+        [
+          "│  ",
+          pad(truncate(run.id, 12), 12),
+          " ",
+          pad(truncate(run.project, 12), 12),
+          " ",
+          pad(`#${run.issueNumber}`, 7),
+          " ",
+          pad(run.state, 20),
+          " ",
+          pad(run.provider || "-", 8),
+          " ",
+          truncate(eventSummary(event), 42)
+        ].join("")
+      ];
+      const watchdog = watchdogByRun.get(run.id);
+      if (
+        watchdog?.enabled === true &&
+        watchdog.idleSince !== undefined &&
+        watchdog.graceRemainingMs !== undefined
+      ) {
+        lines.push(
+          `│      watchdog idle since ${watchdog.idleSince} (grace remaining ${formatWatchdogDuration(watchdog.graceRemainingMs)})`
+        );
+      }
+      return lines;
     })
   ];
 }

--- a/src/watchdog-status.ts
+++ b/src/watchdog-status.ts
@@ -1,0 +1,109 @@
+import type { WatchdogConfig } from "./reload.js";
+import type { RunStore } from "./run-store.js";
+
+export type WatchdogStatus =
+  | { enabled: false }
+  | {
+      enabled: true;
+      graceMs: number;
+      graceRemainingMs?: number;
+      idleSince?: string;
+      lastToolCallAt?: string | null;
+      outputTokensTotal?: number;
+      sampledAt?: string;
+      turnIdSetSize?: number;
+      workspaceMtimeMax?: string | null;
+    };
+
+export type WatchdogIdleStatus =
+  | { enabled: false }
+  | {
+      enabled: true;
+      graceRemainingMs?: number;
+      idleSince?: string;
+    };
+
+export function buildWatchdogStatus(input: {
+  config: Pick<WatchdogConfig, "enabled" | "graceMinutes">;
+  nowMs: number;
+  runId: string;
+  runStore: RunStore;
+}): WatchdogStatus {
+  if (!input.config.enabled) {
+    return { enabled: false };
+  }
+
+  const graceMs = input.config.graceMinutes * 60_000;
+  const sample = input.runStore.getWatchdogSample(input.runId);
+  if (sample === undefined) {
+    return { enabled: true, graceMs };
+  }
+
+  return {
+    enabled: true,
+    graceMs,
+    ...(sample.idleSince === null
+      ? {}
+      : {
+          graceRemainingMs:
+            Date.parse(sample.idleSince) + graceMs - input.nowMs,
+          idleSince: sample.idleSince
+        }),
+    lastToolCallAt: sample.lastToolCallAt,
+    outputTokensTotal: sample.outputTokensTotal,
+    sampledAt: sample.sampledAt,
+    turnIdSetSize: sample.turnIdSetSize,
+    workspaceMtimeMax: timestampFromEpochMs(sample.workspaceMtimeMax)
+  };
+}
+
+export function buildWatchdogIdleStatus(input: {
+  config: Pick<WatchdogConfig, "enabled" | "graceMinutes">;
+  nowMs: number;
+  runId: string;
+  runStore: RunStore;
+}): WatchdogIdleStatus {
+  const status = buildWatchdogStatus(input);
+  if (!status.enabled) {
+    return status;
+  }
+  if (status.idleSince === undefined || status.graceRemainingMs === undefined) {
+    return { enabled: true };
+  }
+  return {
+    enabled: true,
+    graceRemainingMs: status.graceRemainingMs,
+    idleSince: status.idleSince
+  };
+}
+
+export function formatWatchdogDuration(durationMs: number): string {
+  const sign = durationMs < 0 ? "-" : "";
+  const totalSeconds = Math.floor(Math.abs(durationMs) / 1_000);
+  const units: Array<[string, number]> = [
+    ["d", 86_400],
+    ["h", 3_600],
+    ["m", 60],
+    ["s", 1]
+  ];
+  let remaining = totalSeconds;
+  const parts: string[] = [];
+  for (const [label, seconds] of units) {
+    const value = Math.floor(remaining / seconds);
+    if (value > 0) {
+      parts.push(`${value}${label}`);
+      remaining %= seconds;
+    }
+    if (parts.length === 2) {
+      break;
+    }
+  }
+  return `${sign}${parts.length === 0 ? "0s" : parts.join(" ")}`;
+}
+
+function timestampFromEpochMs(value: number): string | null {
+  if (!Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return new Date(value).toISOString();
+}

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { buildCli } from "../src/cli.js";
 import type { DoctorReport } from "../src/doctor.js";
@@ -65,6 +65,15 @@ function captureProgram(
   return { output, program };
 }
 
+function progressSignalBlock(output: string): string {
+  const start = output.indexOf("Progress Signal:");
+  if (start < 0) {
+    return "(missing)";
+  }
+  const end = output.indexOf("\nnormalized events", start);
+  return output.slice(start, end < 0 ? undefined : end).trimEnd();
+}
+
 describe("CLI run commands", () => {
   it("status prints state-root and counts grouped by lifecycle", async () => {
     const stateRoot = await makeTempRoot();
@@ -101,6 +110,69 @@ describe("CLI run commands", () => {
     expect(output.stdout).toContain("failed: 1");
     expect(output.stdout).toContain("r-running");
     expect(output.stdout).toContain("r-failed");
+  });
+
+  it("status identifies only active runs inside the watchdog grace window", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    for (const [id, issueNumber] of [
+      ["idle-active", 202],
+      ["progressing-active", 203]
+    ] as const) {
+      store.createRun({
+        id,
+        issue: sampleIssue({ number: issueNumber }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      store.updateRunState(id, "running");
+    }
+    store.upsertWatchdogSample({
+      idleSince: "2026-05-22T11:45:00.000Z",
+      lastMessageAt: null,
+      lastToolCallAt: null,
+      normalizedLogOffset: 0,
+      normalizedLogPath: "",
+      outputTokensTotal: 0,
+      runId: "idle-active",
+      sampledAt: "2026-05-22T11:59:00.000Z",
+      turnIdSetSize: 0,
+      workspaceMtimeMax: 0
+    });
+    store.upsertWatchdogSample({
+      idleSince: null,
+      lastMessageAt: "2026-05-22T11:59:00.000Z",
+      lastToolCallAt: "2026-05-22T11:59:00.000Z",
+      normalizedLogOffset: 0,
+      normalizedLogPath: "",
+      outputTokensTotal: 10,
+      runId: "progressing-active",
+      sampledAt: "2026-05-22T11:59:00.000Z",
+      turnIdSetSize: 1,
+      workspaceMtimeMax: 0
+    });
+    store.close();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T12:00:00.000Z"));
+    try {
+      const { output, program } = captureProgram(stateRoot);
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "status",
+        "--config",
+        path.join(stateRoot, "symphonika.yml")
+      ]);
+
+      expect(output.stdout).toContain(
+        "watchdog idle since 2026-05-22T11:45:00.000Z (grace remaining 15m)"
+      );
+      expect(output.stdout.match(/watchdog idle since/g)).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("status prints project validation, issue counts, and last poll outcome", async () => {
@@ -242,6 +314,18 @@ describe("CLI run commands", () => {
       runId: "dash-run",
       sequence: 1
     });
+    store.upsertWatchdogSample({
+      idleSince: "2026-05-13T08:45:00.000Z",
+      lastMessageAt: null,
+      lastToolCallAt: null,
+      normalizedLogOffset: 0,
+      normalizedLogPath: "/tmp/normalized.jsonl",
+      outputTokensTotal: 0,
+      runId: "dash-run",
+      sampledAt: "2026-05-13T08:59:00.000Z",
+      turnIdSetSize: 0,
+      workspaceMtimeMax: 0
+    });
     store.close();
 
     const { output, program } = captureProgram(stateRoot, {
@@ -308,6 +392,9 @@ describe("CLI run commands", () => {
     expect(output.stdout).toContain("dash-run");
     expect(output.stdout).toContain("#17");
     expect(output.stdout).toContain("hello from dashboard");
+    expect(output.stdout).toContain(
+      "watchdog idle since 2026-05-13T08:45:00.000Z"
+    );
     expect(output.stdout).toContain("No failed, input-required, or stale work");
   });
 
@@ -778,6 +865,183 @@ describe("CLI run commands", () => {
     expect(present.output.stdout).toContain("normalized events");
     expect(present.output.stdout).toContain("hello from provider");
     expect(present.output.stdout).toContain("<not yet recorded>");
+  });
+
+  it("show-run renders a not-yet-idle Progress Signal from persisted samples", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "progress-active",
+      issue: sampleIssue({ number: 202, title: "Watchdog surface" }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("progress-active", "running");
+    for (const sample of [
+      { at: "2026-05-22T11:54:00.000Z", outputTokensTotal: 100 },
+      { at: "2026-05-22T11:56:00.000Z", outputTokensTotal: 130 },
+      { at: "2026-05-22T11:59:00.000Z", outputTokensTotal: 175 }
+    ]) {
+      store.upsertWatchdogSample({
+        idleSince: null,
+        lastMessageAt: "2026-05-22T11:58:45.000Z",
+        lastToolCallAt: "2026-05-22T11:58:00.000Z",
+        normalizedLogOffset: 0,
+        normalizedLogPath: "/tmp/provider.normalized.jsonl",
+        outputTokensTotal: sample.outputTokensTotal,
+        runId: "progress-active",
+        sampledAt: sample.at,
+        turnIdSetSize: 2,
+        workspaceMtimeMax: Date.parse("2026-05-22T11:58:30.000Z")
+      });
+    }
+    store.close();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T12:00:00.000Z"));
+    try {
+      const present = captureProgram(stateRoot);
+      await present.program.parseAsync([
+        "node",
+        "symphonika",
+        "show-run",
+        "progress-active",
+        "--config",
+        path.join(stateRoot, "symphonika.yml")
+      ]);
+
+      expect(progressSignalBlock(present.output.stdout)).toMatchInlineSnapshot(`
+        "Progress Signal:
+          last tool_call: 2m ago
+          workspace mtime: 1m 30s ago
+          turn_ids observed: 2
+          output tokens / 5m: +75"
+      `);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("show-run renders an idle Progress Signal within its grace window", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "progress-idle",
+      issue: sampleIssue({ number: 202, title: "Watchdog surface" }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("progress-idle", "running");
+    for (const sample of [
+      { at: "2026-05-22T11:54:00.000Z", outputTokensTotal: 50 },
+      { at: "2026-05-22T11:59:00.000Z", outputTokensTotal: 70 }
+    ]) {
+      store.upsertWatchdogSample({
+        idleSince: "2026-05-22T11:45:00.000Z",
+        lastMessageAt: "2026-05-22T11:41:00.000Z",
+        lastToolCallAt: "2026-05-22T11:40:00.000Z",
+        normalizedLogOffset: 0,
+        normalizedLogPath: "/tmp/provider.normalized.jsonl",
+        outputTokensTotal: sample.outputTokensTotal,
+        runId: "progress-idle",
+        sampledAt: sample.at,
+        turnIdSetSize: 1,
+        workspaceMtimeMax: Date.parse("2026-05-22T11:41:00.000Z")
+      });
+    }
+    store.close();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T12:00:00.000Z"));
+    try {
+      const present = captureProgram(stateRoot);
+      await present.program.parseAsync([
+        "node",
+        "symphonika",
+        "show-run",
+        "progress-idle",
+        "--config",
+        path.join(stateRoot, "symphonika.yml")
+      ]);
+
+      expect(progressSignalBlock(present.output.stdout)).toMatchInlineSnapshot(`
+        "Progress Signal:
+          last tool_call: 20m ago
+          workspace mtime: 19m ago
+          turn_ids observed: 1
+          output tokens / 5m: +20
+          idle_since: 2026-05-22T11:45:00.000Z
+          grace remaining: 15m"
+      `);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("show-run preserves the final Progress Signal after watchdog termination", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "progress-terminated",
+      issue: sampleIssue({ number: 202, title: "Watchdog surface" }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("progress-terminated", "running");
+    for (const sampledAt of [
+      "2026-05-22T13:56:00.000Z",
+      "2026-05-22T14:01:00.000Z"
+    ]) {
+      store.upsertWatchdogSample({
+        idleSince: "2026-05-22T11:25:30.000Z",
+        lastMessageAt: "2026-05-22T11:25:15.000Z",
+        lastToolCallAt: "2026-05-22T11:25:00.000Z",
+        normalizedLogOffset: 123,
+        normalizedLogPath: "/tmp/provider.normalized.jsonl",
+        outputTokensTotal: 36_365,
+        runId: "progress-terminated",
+        sampledAt,
+        turnIdSetSize: 1,
+        workspaceMtimeMax: Date.parse("2026-05-22T11:25:30.000Z")
+      });
+    }
+    expect(
+      store.markRunNoProgressStale(
+        "progress-terminated",
+        "2026-05-22T14:01:00.000Z"
+      )
+    ).toBe(true);
+    store.close();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T14:01:00.000Z"));
+    try {
+      const present = captureProgram(stateRoot);
+      await present.program.parseAsync([
+        "node",
+        "symphonika",
+        "show-run",
+        "progress-terminated",
+        "--config",
+        path.join(stateRoot, "symphonika.yml")
+      ]);
+
+      expect(present.output.stdout).toContain("terminal:     no_progress");
+      expect(progressSignalBlock(present.output.stdout)).toMatchInlineSnapshot(`
+        "Progress Signal:
+          last tool_call: 2h 36m ago
+          workspace mtime: 2h 35m ago
+          turn_ids observed: 1
+          output tokens / 5m: 0
+          idle_since: 2026-05-22T11:25:30.000Z
+          grace remaining: -2h 5m"
+      `);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("show-run fills missing branch and workspace fields from the deterministic path plan", async () => {

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -980,6 +980,103 @@ describe("CLI run commands", () => {
     }
   });
 
+  it("show-run resolves the per-project watchdog grace override", async () => {
+    const stateRoot = await makeTempRoot();
+    await writeFile(
+      path.join(stateRoot, "WORKFLOW.md"),
+      "Work on {{issue.title}}.\n",
+      "utf8"
+    );
+    await writeFile(
+      path.join(stateRoot, "symphonika.yml"),
+      [
+        "state:",
+        "  root: ./.symphonika",
+        "polling:",
+        "  interval_ms: 1000",
+        "watchdog:",
+        "  grace_minutes: 20",
+        "providers:",
+        "  codex:",
+        '    command: "codex -p symphonika"',
+        "  claude:",
+        '    command: "claude -p"',
+        "projects:",
+        "  - name: alpha",
+        "    disabled: false",
+        "    weight: 1",
+        "    watchdog:",
+        "      grace_minutes: 60",
+        "    tracker:",
+        "      kind: github",
+        "      owner: pmatos",
+        "      repo: symphonika",
+        '      token: "$GITHUB_TOKEN"',
+        "    issue_filters:",
+        '      states: ["open"]',
+        '      labels_all: ["agent-ready"]',
+        '      labels_none: ["blocked"]',
+        "    priority:",
+        "      labels: {}",
+        "      default: 99",
+        "    workspace:",
+        "      root: ./.symphonika/workspaces/alpha",
+        "      git:",
+        "        remote: git@github.com:pmatos/symphonika.git",
+        "        base_branch: main",
+        "    agent:",
+        "      provider: codex",
+        "    workflow: ./WORKFLOW.md",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "override-idle",
+      issue: sampleIssue({ number: 909, title: "Override grace" }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.updateRunState("override-idle", "running");
+    store.upsertWatchdogSample({
+      idleSince: "2026-05-22T11:45:00.000Z",
+      lastMessageAt: null,
+      lastToolCallAt: null,
+      normalizedLogOffset: 0,
+      normalizedLogPath: "",
+      outputTokensTotal: 0,
+      runId: "override-idle",
+      sampledAt: "2026-05-22T11:59:00.000Z",
+      turnIdSetSize: 0,
+      workspaceMtimeMax: 0
+    });
+    store.close();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T12:00:00.000Z"));
+    try {
+      const { output, program } = captureProgram(stateRoot);
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "show-run",
+        "override-idle",
+        "--config",
+        path.join(stateRoot, "symphonika.yml")
+      ]);
+
+      // Idle for 15m. Project "alpha" overrides grace to 60m, so 45m remain.
+      // Before the fix these surfaces used the global 20m grace and showed 5m.
+      expect(output.stdout).toContain("grace remaining: 45m");
+      expect(output.stdout).not.toContain("grace remaining: 5m");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("show-run preserves the final Progress Signal after watchdog termination", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });

--- a/tests/http-app-runs.test.ts
+++ b/tests/http-app-runs.test.ts
@@ -182,6 +182,94 @@ describe("HTTP app — runs API and pages", () => {
     }
   });
 
+  it("exposes the persisted watchdog sample on /api/runs/:id", async () => {
+    const test = await setup();
+    try {
+      test.runStore.createRun({
+        id: "watchdog-detail",
+        issue: sampleIssue({ number: 202 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("watchdog-detail", "running");
+      test.runStore.upsertWatchdogSample({
+        idleSince: "2026-05-22T11:25:30.000Z",
+        lastMessageAt: "2026-05-22T11:25:45.000Z",
+        lastToolCallAt: "2026-05-22T11:25:00.000Z",
+        normalizedLogOffset: 123,
+        normalizedLogPath: "/tmp/provider.normalized.jsonl",
+        outputTokensTotal: 36_365,
+        runId: "watchdog-detail",
+        sampledAt: "2026-05-22T14:01:00.000Z",
+        turnIdSetSize: 1,
+        workspaceMtimeMax: Date.parse("2026-05-22T11:25:30.000Z")
+      });
+
+      const app = createHttpApp({
+        now: () => Date.parse("2026-05-22T14:01:00.000Z"),
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+      const response = await app.request("/api/runs/watchdog-detail");
+      const body = (await response.json()) as Record<string, unknown>;
+
+      expect(response.status).toBe(200);
+      expect(body.watchdog).toEqual({
+        enabled: true,
+        graceMs: 1_800_000,
+        graceRemainingMs: -7_530_000,
+        idleSince: "2026-05-22T11:25:30.000Z",
+        lastToolCallAt: "2026-05-22T11:25:00.000Z",
+        outputTokensTotal: 36_365,
+        sampledAt: "2026-05-22T14:01:00.000Z",
+        turnIdSetSize: 1,
+        workspaceMtimeMax: "2026-05-22T11:25:30.000Z"
+      });
+    } finally {
+      test.cleanup();
+    }
+  });
+
+  it("omits watchdog sample fields when the watchdog is disabled", async () => {
+    const test = await setup();
+    try {
+      test.runStore.createRun({
+        id: "watchdog-disabled",
+        issue: sampleIssue({ number: 202 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.upsertWatchdogSample({
+        idleSince: "2026-05-22T11:45:00.000Z",
+        lastMessageAt: null,
+        lastToolCallAt: "2026-05-22T11:40:00.000Z",
+        normalizedLogOffset: 0,
+        normalizedLogPath: "",
+        outputTokensTotal: 10,
+        runId: "watchdog-disabled",
+        sampledAt: "2026-05-22T11:59:00.000Z",
+        turnIdSetSize: 1,
+        workspaceMtimeMax: Date.parse("2026-05-22T11:41:00.000Z")
+      });
+
+      const app = createHttpApp({
+        getWatchdogConfig: () => ({ enabled: false, graceMinutes: 30 }),
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+      const response = await app.request("/api/runs/watchdog-disabled");
+      const body = (await response.json()) as { watchdog?: unknown };
+
+      expect(body.watchdog).toEqual({ enabled: false });
+    } finally {
+      test.cleanup();
+    }
+  });
+
   it("streams /api/runs/:id/files/provider_raw only for artifacts inside the run evidence dir", async () => {
     const test = await setup();
     try {

--- a/tests/http-app.test.ts
+++ b/tests/http-app.test.ts
@@ -178,6 +178,135 @@ describe("HTTP app", () => {
     }
   });
 
+  it("exposes watchdog idle timing on active runs in status", async () => {
+    const stateRoot = await makeTempRoot();
+    const runStore = openRunStore({ stateRoot });
+    try {
+      runStore.createRun({
+        id: "idle-run",
+        issue: {
+          body: "",
+          created_at: "",
+          id: 202,
+          labels: [],
+          number: 202,
+          priority: 99,
+          state: "open",
+          title: "Watchdog surface",
+          updated_at: "",
+          url: ""
+        },
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      runStore.updateRunState("idle-run", "running");
+      runStore.upsertWatchdogSample({
+        idleSince: "2026-05-22T11:45:00.000Z",
+        lastMessageAt: null,
+        lastToolCallAt: null,
+        normalizedLogOffset: 0,
+        normalizedLogPath: "",
+        outputTokensTotal: 0,
+        runId: "idle-run",
+        sampledAt: "2026-05-22T11:59:00.000Z",
+        turnIdSetSize: 0,
+        workspaceMtimeMax: 0
+      });
+
+      const app = createHttpApp({
+        getActiveRuns: () => [
+          {
+            cancelReason: null,
+            cancelRequested: false,
+            issueNumber: 202,
+            projectName: "alpha",
+            runId: "idle-run"
+          }
+        ],
+        now: () => Date.parse("2026-05-22T12:00:00.000Z"),
+        runStore,
+        stateRoot,
+        version: "0.1.0"
+      });
+
+      const response = await app.request("/api/status");
+      const body = (await response.json()) as {
+        active: Array<{ watchdog?: unknown }>;
+      };
+
+      expect(body.active[0]?.watchdog).toEqual({
+        enabled: true,
+        graceRemainingMs: 900_000,
+        idleSince: "2026-05-22T11:45:00.000Z"
+      });
+    } finally {
+      runStore.close();
+    }
+  });
+
+  it("reports only enabled false for active runs when the watchdog is disabled", async () => {
+    const stateRoot = await makeTempRoot();
+    const runStore = openRunStore({ stateRoot });
+    try {
+      runStore.createRun({
+        id: "disabled-run",
+        issue: {
+          body: "",
+          created_at: "",
+          id: 202,
+          labels: [],
+          number: 202,
+          priority: 99,
+          state: "open",
+          title: "Watchdog surface",
+          updated_at: "",
+          url: ""
+        },
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      runStore.updateRunState("disabled-run", "running");
+      runStore.upsertWatchdogSample({
+        idleSince: "2026-05-22T11:45:00.000Z",
+        lastMessageAt: null,
+        lastToolCallAt: null,
+        normalizedLogOffset: 0,
+        normalizedLogPath: "",
+        outputTokensTotal: 0,
+        runId: "disabled-run",
+        sampledAt: "2026-05-22T11:59:00.000Z",
+        turnIdSetSize: 0,
+        workspaceMtimeMax: 0
+      });
+
+      const app = createHttpApp({
+        getActiveRuns: () => [
+          {
+            cancelReason: null,
+            cancelRequested: false,
+            issueNumber: 202,
+            projectName: "alpha",
+            runId: "disabled-run"
+          }
+        ],
+        getWatchdogConfig: () => ({ enabled: false, graceMinutes: 30 }),
+        runStore,
+        stateRoot,
+        version: "0.1.0"
+      });
+      const response = await app.request("/api/status");
+      const body = (await response.json()) as {
+        active: Array<{ watchdog?: unknown }>;
+      };
+
+      expect(body.active[0]?.watchdog).toEqual({ enabled: false });
+    } finally {
+      runStore.close();
+    }
+  });
+
   it("POST /api/poll-now invokes the daemon trigger and returns a poll summary", async () => {
     let calls = 0;
     const app = createHttpApp({

--- a/tests/run-store-lifecycle.test.ts
+++ b/tests/run-store-lifecycle.test.ts
@@ -954,4 +954,82 @@ describe("run-store schema migration", () => {
       database.close();
     }
   });
+
+  it("backfills sample history when upgrading a pre-history watchdog_samples table", async () => {
+    const root = await makeTempRoot();
+    const dbPath = databasePath(root);
+    const writer = new Database(dbPath);
+    try {
+      writer.exec(`
+        create table runs (
+          id text primary key,
+          project_name text not null,
+          issue_number integer not null,
+          issue_title text not null,
+          state text not null,
+          issue_snapshot_json text not null,
+          metadata_path text,
+          created_at text not null,
+          updated_at text not null
+        );
+        create table watchdog_samples (
+          run_id text primary key,
+          sampled_at text not null,
+          last_tool_call_at text,
+          workspace_mtime_max real not null,
+          turn_id_set_size integer not null,
+          output_tokens_total integer not null,
+          normalized_log_offset integer not null,
+          idle_since text,
+          foreign key (run_id) references runs(id)
+        );
+        insert into runs (
+          id, project_name, issue_number, issue_title, state,
+          issue_snapshot_json, created_at, updated_at
+        ) values (
+          'legacy-watchdog', 'symphonika', 99, 't', 'queued', '{}',
+          '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z'
+        );
+        insert into watchdog_samples (
+          run_id, sampled_at, last_tool_call_at, workspace_mtime_max,
+          turn_id_set_size, output_tokens_total, normalized_log_offset, idle_since
+        ) values (
+          'legacy-watchdog', '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z',
+          1234.5, 3, 100, 7, null
+        );
+      `);
+    } finally {
+      writer.close();
+    }
+
+    const store = openRunStore({ stateRoot: root });
+    store.close();
+
+    const reader = new Database(dbPath, { readonly: true });
+    try {
+      expect(columnNames(reader, "watchdog_samples")).toEqual(
+        expect.arrayContaining(["normalized_log_path", "last_message_at"])
+      );
+      const history = reader
+        .prepare(
+          "select run_id, output_tokens_total, normalized_log_path, last_message_at from watchdog_sample_history where run_id = ?"
+        )
+        .get("legacy-watchdog") as
+        | {
+            last_message_at: string | null;
+            normalized_log_path: string;
+            output_tokens_total: number;
+            run_id: string;
+          }
+        | undefined;
+      expect(history).toEqual({
+        last_message_at: null,
+        normalized_log_path: "",
+        output_tokens_total: 100,
+        run_id: "legacy-watchdog"
+      });
+    } finally {
+      reader.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- render persisted watchdog Progress Signals in `show-run` and idle grace indicators in `status`/dashboard
- expose the pinned watchdog contract from run detail and active-run status APIs, including disabled-policy behavior
- persist watchdog sample history and compute five-minute output-token growth without rescanning normalized logs
- update the implementation contract and add CLI goldens plus HTTP contract coverage

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm test` (607 tests; npm 12 local-link test run with its per-command install-script switch)
- `npm run build`
- `npm run format:check`

Closes #202