### PR TITLE
fix: guard missing routine provider configuration

### DIFF
--- a/src/routines/dispatcher.ts
+++ b/src/routines/dispatcher.ts
@@ -94,8 +94,10 @@ export async function dispatchDueRoutines(
       }
       const providerName = routine.provider ?? project.agent.provider;
       const provider = input.agentProviders[providerName];
-      const providerCommand = input.providersConfig[providerName].command;
-      if (provider === undefined) {
+      const providerCommand = (
+        input.providersConfig as Partial<RunControllerProvidersConfig>
+      )[providerName]?.command;
+      if (provider === undefined || providerCommand === undefined) {
         skipped.push({
           projectName: project.name,
           reason: `provider_not_registered: ${providerName}`,

--- a/tests/routine-dispatcher.test.ts
+++ b/tests/routine-dispatcher.test.ts
@@ -5,6 +5,7 @@ import pino from "pino";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ActiveRunRegistry } from "../src/lifecycle/active-runs.js";
+import type { RunControllerProvidersConfig } from "../src/lifecycle/run-controller.js";
 import type {
   AgentProvider,
   ProviderEvent,
@@ -296,7 +297,84 @@ describe("RoutineFiringDispatcher", () => {
       runStore.close();
     }
   });
+
+  it.each(["providers config", "agent provider registry"] as const)(
+    "skips a due routine when its provider is missing from the %s",
+    async (missingFrom) => {
+      const root = await makeTempRoot();
+      const stateRoot = path.join(root, ".symphonika");
+      const runStore = openRunStore({ stateRoot });
+      const provider = {
+        cancel: vi.fn().mockResolvedValue(undefined),
+        name: "claude",
+        runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+          await Promise.resolve();
+          yield {
+            normalized: { exitCode: 0, type: "process_exit" },
+            raw: { code: 0, kind: "exit" }
+          };
+        }),
+        validate: vi.fn().mockResolvedValue(undefined)
+      } satisfies AgentProvider;
+      const providersConfig =
+        missingFrom === "providers config"
+          ? { codex: { command: "codex fake" } }
+          : {
+              claude: { command: "claude fake" },
+              codex: { command: "codex fake" }
+            };
+
+      try {
+        const result = await dispatchDueRoutines({
+          activeRuns: new ActiveRunRegistry(),
+          agentProviders:
+            missingFrom === "agent provider registry"
+              ? {}
+              : { claude: provider },
+          configDir: root,
+          globalConcurrency: { maxInFlight: undefined },
+          now: new Date("2026-05-22T10:00:01.000Z"),
+          prepareRoutineWorkspace: vi.fn(),
+          projects: new Map([
+            ["alpha", dueRoutineProjectFixture(root, "claude")]
+          ]),
+          providersConfig: providersConfig as RunControllerProvidersConfig,
+          runStore,
+          stateRoot
+        });
+
+        expect(result).toEqual({
+          fired: [],
+          skipped: [
+            {
+              projectName: "alpha",
+              reason: "provider_not_registered: claude",
+              routineName: "daily-report"
+            }
+          ]
+        });
+      } finally {
+        runStore.close();
+      }
+    }
+  );
 });
+
+function dueRoutineProjectFixture(root: string, provider: "codex" | "claude") {
+  return {
+    ...runStoreProjectFixture(),
+    routines: [
+      {
+        kind: "report" as const,
+        name: "daily-report",
+        prompt: "Routine {{routine.name}} for {{project.name}}.",
+        provider,
+        schedule: { at: "2026-05-22T10:00:00.000Z" },
+        sourcePath: path.join(root, "daily-report.md")
+      }
+    ]
+  };
+}
 
 function runStoreProjectFixture() {
   return {


### PR DESCRIPTION
## Summary

- guard routine provider-command lookup when the selected provider is absent from Service Config
- skip consistently when either the provider command or Agent Provider registration is missing
- add dispatcher coverage for both incomplete-registration paths

## Testing

- npm run lint
- npm run typecheck
- npm test (601 tests)
- npm run build

Closes #206