### PR TITLE
feat(service): preserve explicit daemon config in generated unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ journalctl --user -u symphonika -f
 
 `service install` writes `symphonika.service` and `symphonika.slice` into `~/.config/systemd/user/` and runs `systemctl --user daemon-reload` for you. It derives the unit from the running process — the `node` runtime executing the resolved `dist/cli.js` — so the unit matches your install (npm global, nvm, pnpm, or a source checkout) instead of a hardcoded bin path. Re-run it after a `node` upgrade to refresh a version-pinned path; pass `--force` to overwrite existing units or `--print` to review the generated units without writing them.
 
+The generated unit uses the daemon's normal config discovery by default. To run the service with a non-default config, install it with `symphonika service install --config <path>`; relative paths are resolved when the unit is generated and the absolute path is baked into `ExecStart`.
+
 What the generated units give you:
 
 - **`symphonika.slice`** owns the daemon and every process it spawns. `MemoryHigh=` / `MemoryMax=` cap the whole tree so a runaway tool is killed *inside* the slice instead of triggering a global OOM. The generated caps assume a large workstation (see [`systemd/symphonika.slice`](systemd/symphonika.slice)); edit the installed `~/.config/systemd/user/symphonika.slice` to match your host (re-running `service install --force` overwrites it).

--- a/SPEC.md
+++ b/SPEC.md
@@ -989,6 +989,7 @@ Bootstrap CLI commands:
 - `symphonika doctor [--config <path>]`
 - `symphonika init-project [--config <path>] --yes`
 - `symphonika daemon [--config <path>] [--port <port>]`
+- `symphonika service install [--config <path>] [--force] [--print] [--no-reload]`
 - `symphonika status [--config <path>] [--dashboard] [--watch] [--interval-ms <ms>] [--doctor-ttl-ms <ms>]`
 - `symphonika poll-now [--config <path>]`
 - `symphonika runs [--config <path>]`
@@ -1014,6 +1015,10 @@ config path and points the operator to `symphonika init`.
 
 `init` writes local files only and never mutates GitHub. `init-project` creates missing operational
 labels only after explicit confirmation.
+
+`service install --config <path>` resolves the selected Service Config to an absolute path and
+bakes it into the generated unit as `daemon --config <absolute-path>`. Omitting `--config` keeps the
+unit on the daemon's normal project-local/user-config discovery path.
 
 `status --dashboard` renders a compact terminal status dashboard from the run store and daemon
 `/api/status` endpoint. `status --watch` refreshes that read-only dashboard in place; it must not

--- a/docs/adr/0055-generated-systemd-unit.md
+++ b/docs/adr/0055-generated-systemd-unit.md
@@ -20,6 +20,12 @@ units from the running process instead of shipping a fixed template:
   binary the operator is already running, so it is correct for every install layout and sidesteps the
   version-manager bin directory that the old `%h/.npm-global/bin` path got wrong. `node dist/cli.js
   daemon` is equivalent to the `symphonika` bin, which is `dist/cli.js` plus a shebang.
+- Operators using a non-default Service Config can pass `service install --config <path>`. The CLI
+  resolves the path to an absolute path and adds `--config <absolute-path>` to the generated daemon
+  command. The config is passed as a separately quoted shell positional argument so paths containing
+  whitespace survive both systemd and shell parsing. Omitting the option preserves the daemon's
+  normal project-local/user-config discovery instead of freezing the discovered default into the
+  unit.
 - `Environment=PATH` is captured from the environment that ran `service install`, with the `node`
   runtime's directory prepended and empty/relative entries dropped, so `node` and the spawned
   providers resolve under `systemd --user` regardless of version manager.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -392,6 +392,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .description(
       "generate systemd --user unit files matching the current runtime and daemon-reload"
     )
+    .option("--config <path>", "service config path for the daemon")
     .option("--force", "overwrite existing unit files")
     .option(
       "--print",
@@ -400,11 +401,19 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
     .option("--no-reload", "skip systemctl --user daemon-reload after writing")
     .action(
       async (options: {
+        config?: string;
         force?: boolean;
         print?: boolean;
         reload?: boolean;
       }) => {
         const report = await serviceInstall({
+          ...(options.config === undefined
+            ? {}
+            : {
+                configPath: resolveServiceConfigPath({
+                  configPath: options.config
+                }).configPath
+              }),
           force: options.force === true,
           print: options.print === true,
           reload: options.reload !== false

--- a/src/service.ts
+++ b/src/service.ts
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 const execFile = promisify(execFileCallback);
 
 export type ServiceInstallOptions = {
+  configPath?: string;
   env?: NodeJS.ProcessEnv;
   execPath?: string;
   force?: boolean;
@@ -35,6 +36,7 @@ export type ServiceInstallReport = {
 };
 
 export type ServiceUnitInput = {
+  configPath?: string;
   execPath: string;
   path: string;
   scriptPath: string;
@@ -61,6 +63,11 @@ const SLICE_UNIT = [
 // sidestep the version-manager bin directory entirely, which is what the
 // hardcoded ~/.npm-global path got wrong (see docs/adr/0055).
 export function renderServiceUnit(input: ServiceUnitInput): string {
+  const daemonConfigOption =
+    input.configPath === undefined ? "" : ` --config "$3"`;
+  const configArgument =
+    input.configPath === undefined ? "" : ` ${systemdArg(input.configPath)}`;
+
   return [
     "[Unit]",
     "Description=Symphonika orchestrator daemon",
@@ -92,8 +99,9 @@ export function renderServiceUnit(input: ServiceUnitInput): string {
     "# the unit matches the actual install (npm-global, nvm, pnpm, source",
     "# checkout) instead of a fixed bin path. The runtime and script are",
     "# passed as positional args and re-quoted inside the shell so paths",
-    "# containing spaces survive.",
-    `ExecStart=/bin/sh -c 't=$(gh auth token); [ -n "$t" ] || { echo "ERROR: gh auth token returned empty"; exit 1; }; export GITHUB_TOKEN="$t"; exec "$1" "$2" daemon' symphonika ${systemdArg(input.execPath)} ${systemdArg(input.scriptPath)}`,
+    "# containing spaces survive. An explicitly selected config uses the",
+    "# same positional-argument path.",
+    `ExecStart=/bin/sh -c 't=$(gh auth token); [ -n "$t" ] || { echo "ERROR: gh auth token returned empty"; exit 1; }; export GITHUB_TOKEN="$t"; exec "$1" "$2" daemon${daemonConfigOption}' symphonika ${systemdArg(input.execPath)} ${systemdArg(input.scriptPath)}${configArgument}`,
     "",
     "# Keep the daemon and everything it spawns in its own cgroup slice.",
     "# A scope-wide OOM in a spawned tool (compiler, verifier, ...) no",
@@ -156,7 +164,14 @@ export async function runServiceInstall(
 
   const files: ServiceUnitFile[] = [
     {
-      content: renderServiceUnit({ execPath, path: daemonPath, scriptPath }),
+      content: renderServiceUnit({
+        ...(options.configPath === undefined
+          ? {}
+          : { configPath: options.configPath }),
+        execPath,
+        path: daemonPath,
+        scriptPath
+      }),
       path: path.join(unitDir, "symphonika.service")
     },
     {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -294,6 +294,21 @@ describe("runServiceInstall", () => {
     await expect(access(path.join(home, ".config"))).rejects.toThrow();
   });
 
+  it("prints an explicit daemon config as a quoted ExecStart argument", async () => {
+    const configPath = "/opt/Symphonika Config/daemon.yml";
+
+    const report = await runServiceInstall({
+      ...baseOptions,
+      configPath,
+      print: true
+    });
+
+    expect(report.files[0]?.content).toContain(
+      `exec "$1" "$2" daemon --config "$3"`
+    );
+    expect(report.files[0]?.content).toContain(`"${configPath}"`);
+  });
+
   it("skips daemon-reload when reload is false but still writes units", async () => {
     const home = await makeTempHome();
     let reloadCalls = 0;
@@ -412,6 +427,37 @@ describe("CLI service install", () => {
     expect(received?.force).toBe(true);
     expect(received?.print).toBe(false);
     expect(received?.reload).toBe(false);
+  });
+
+  it("prints --config as an absolute daemon config path", async () => {
+    const output = { stderr: "", stdout: "" };
+    const program = buildCli({
+      registerSignalHandlers: false
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "service",
+      "install",
+      "--print",
+      "--config",
+      "configs/daemon.yml"
+    ]);
+
+    expect(output.stderr).toBe("");
+    expect(output.stdout).toContain(`exec "$1" "$2" daemon --config "$3"`);
+    expect(output.stdout).toContain(
+      `"${path.resolve("configs", "daemon.yml")}"`
+    );
   });
 
   it("streams unit contents to stdout when --print is passed", async () => {


### PR DESCRIPTION
## Summary

- add `service install --config <path>` and resolve relative inputs to an absolute Service Config path
- pass the selected config through the generated systemd `ExecStart` using a separately quoted positional argument
- preserve bare daemon config discovery when `--config` is omitted
- document the operator behavior in SPEC, ADR 0055, and README

## Test plan

- `npm run lint`
- `npm run typecheck`
- `npm test` (601 tests)
- `npm run build`

Closes #240