### PR TITLE
fix: verify generated font integrity

### DIFF
--- a/docs/specs/2026-07-19-font-generator-integrity-design.md
+++ b/docs/specs/2026-07-19-font-generator-integrity-design.md
@@ -1,0 +1,48 @@
+# Font Generator Integrity Design
+
+## Context
+
+`scripts/gen-fonts.mjs` is the developer-facing generator behind `npm run gen:fonts`. It downloads
+three IBM Plex Mono WOFF2 files and emits the self-contained `src/http/fonts.ts` module. Fontsource
+is already pinned to `ibm-plex-mono@5.2.7`, but the downloaded bytes currently reach a filesystem
+write after only a WOFF2 magic-byte check. CodeQL consequently reports `js/http-to-file-access`.
+
+## Approaches considered
+
+1. Dismiss the alert as a contextual false positive because the script is developer-only and uses a
+   fixed HTTPS CDN URL. This leaves the generator vulnerable to an unexpected or compromised CDN
+   response and does not provide reproducible-byte evidence.
+2. Verify expected SHA-256 digests and retain the alert. This hardens the behavior, but CodeQL's
+   generic query does not model a project-specific digest comparison as a sanitizer, so the known
+   and reviewed flow remains reported.
+3. Verify expected SHA-256 digests and place a query-specific suppression immediately before the
+   reviewed write. This preserves the portable Node generator, makes every accepted payload
+   content-addressed, and documents why only this sink is intentionally suppressed.
+
+Approach 3 is selected. Refactoring the command to shell redirection was rejected because a failed
+generation could truncate the checked-in output before validation completes and would make the
+write less portable and less explicit.
+
+## Design
+
+The generator keeps one immutable source record per weight: weight, the pinned Fontsource URL, and
+the full expected SHA-256 digest. Each response must pass, in order, the existing HTTP-status check,
+the existing WOFF2 magic-byte check, and an exact SHA-256 comparison. A mismatch names the URL,
+expected digest, and actual digest in the error. The output module is written only after all three
+weights have passed validation.
+
+The write retains a query-specific `codeql[js/http-to-file-access]` suppression with an adjacent
+explanation. The suppression is justified by the fixed URL and full digest allowlist, not merely by
+the script being developer-only.
+
+## Test seam
+
+Tests exercise the public CLI command by copying the script into a temporary `scripts/` directory
+and preloading a deterministic `fetch` replacement. Known-good fixtures come from the currently
+bundled font module; each weight is tampered independently while preserving the `wOF2` magic bytes.
+For every tampered weight, the command must fail with a SHA-256 mismatch and must not create its
+temporary output file. The preload also rejects any URL outside the pinned `5.2.7` artifact set.
+
+The normal regeneration command is run once after implementation to confirm the real pinned CDN
+artifacts still reproduce `src/http/fonts.ts` byte-for-byte. No runtime behavior, domain term, or
+architecture decision changes, so `SPEC.md`, `CONTEXT.md`, and the ADR set remain unchanged.

--- a/scripts/gen-fonts.mjs
+++ b/scripts/gen-fonts.mjs
@@ -18,13 +18,28 @@ import { createHash } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-const WEIGHTS = ["400", "500", "600"];
 // Pinned so regeneration is reproducible; bump to adopt a newer Fontsource build.
 const FONT_VERSION = "5.2.7";
 const CDN = `https://cdn.jsdelivr.net/fontsource/fonts/ibm-plex-mono@${FONT_VERSION}`;
+// Full digests for the exact Fontsource release artifacts. Update these only
+// after reviewing the new font bytes when bumping FONT_VERSION.
+const FONT_SOURCES = [
+  {
+    weight: "400",
+    sha256: "08949f728dc52d528e69b1667d15c89a5686a4ee9a296ff90983985f99c380f7"
+  },
+  {
+    weight: "500",
+    sha256: "01d285447409c8a588692162439a038b8cbd7871309ee20267b0d2d91c6e8e22"
+  },
+  {
+    weight: "600",
+    sha256: "0d1f0b8d0722224e32e9f28261bdc86c79115be73444ae5eceb73976a1bcdf83"
+  }
+];
 const OUT = fileURLToPath(new URL("../src/http/fonts.ts", import.meta.url));
 
-async function fetchWoff2(weight) {
+async function fetchWoff2({ weight, sha256: expectedSha256 }) {
   const url = `${CDN}/latin-${weight}-normal.woff2`;
   const res = await fetch(url);
   if (!res.ok) {
@@ -34,16 +49,23 @@ async function fetchWoff2(weight) {
   if (bytes.subarray(0, 4).toString("latin1") !== "wOF2") {
     throw new Error(`fetched ${url} is not a woff2 file`);
   }
-  return bytes;
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  if (sha256 !== expectedSha256) {
+    throw new Error(
+      `${url} SHA-256 mismatch: expected ${expectedSha256}, got ${sha256}`
+    );
+  }
+  return { bytes, sha256 };
 }
 
 const fonts = [];
-for (const weight of WEIGHTS) {
-  const bytes = await fetchWoff2(weight);
+for (const source of FONT_SOURCES) {
+  const { weight } = source;
+  const { bytes, sha256 } = await fetchWoff2(source);
   fonts.push({
     weight,
     base64: bytes.toString("base64"),
-    hash: createHash("sha256").update(bytes).digest("hex").slice(0, 8)
+    hash: sha256.slice(0, 8)
   });
   console.log(
     `fetched ${weight}: ${bytes.length} bytes, hash ${fonts.at(-1).hash}`
@@ -139,5 +161,7 @@ L.push("  return bytes;");
 L.push("}");
 L.push("");
 
+// Every remote payload reaching this sink matched its pinned full SHA-256 above.
+// codeql[js/http-to-file-access]
 writeFileSync(OUT, L.join("\n"));
 console.log(`wrote ${OUT}`);

--- a/tests/gen-fonts.test.ts
+++ b/tests/gen-fonts.test.ts
@@ -1,0 +1,173 @@
+import { execFile as execFileCallback } from "node:child_process";
+import {
+  access,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { BUNDLED_FONTS, getBundledFont } from "../src/http/fonts.js";
+
+const execFile = promisify(execFileCallback);
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const generatorPath = path.join(repoRoot, "scripts/gen-fonts.mjs");
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("font generator", () => {
+  it("reproduces the bundled module from the pinned artifacts", async () => {
+    const { outputPath, preloadPath, scriptPath, fixturesPath } =
+      await prepareGenerator();
+
+    await execFile(process.execPath, ["--import", preloadPath, scriptPath], {
+      env: {
+        ...process.env,
+        SYMPHONIKA_FONT_FIXTURES: fixturesPath
+      }
+    });
+
+    const [actual, expected] = await Promise.all([
+      readFile(outputPath, "utf8"),
+      readFile(path.join(repoRoot, "src/http/fonts.ts"), "utf8")
+    ]);
+    expect(actual).toBe(expected);
+  });
+
+  it.each(BUNDLED_FONTS)(
+    "rejects a changed $weight artifact before writing output",
+    async ({ weight: changedWeight }) => {
+      const { outputPath, preloadPath, scriptPath, fixturesPath } =
+        await prepareGenerator(changedWeight);
+
+      const stderr = await failedGeneratorStderr({
+        fixturesPath,
+        preloadPath,
+        scriptPath
+      });
+      expect(stderr).toContain(
+        `latin-${changedWeight}-normal.woff2 SHA-256 mismatch`
+      );
+      await expect(access(outputPath)).rejects.toThrow();
+    }
+  );
+});
+
+async function prepareGenerator(changedWeight?: string): Promise<{
+  fixturesPath: string;
+  outputPath: string;
+  preloadPath: string;
+  scriptPath: string;
+}> {
+  const root = await makeTempRoot();
+  const scriptPath = path.join(root, "scripts/gen-fonts.mjs");
+  const outputPath = path.join(root, "src/http/fonts.ts");
+  const preloadPath = path.join(root, "intercept-font-fetch.mjs");
+  const fixturesPath = path.join(root, "font-fixtures.json");
+
+  await mkdir(path.dirname(scriptPath), { recursive: true });
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await copyFile(generatorPath, scriptPath);
+  await writeFile(fixturesPath, fontFixtures(changedWeight), "utf8");
+  await writeFile(preloadPath, fetchInterceptorSource(), "utf8");
+
+  return { fixturesPath, outputPath, preloadPath, scriptPath };
+}
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-font-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+async function failedGeneratorStderr(input: {
+  fixturesPath: string;
+  preloadPath: string;
+  scriptPath: string;
+}): Promise<string> {
+  try {
+    await execFile(
+      process.execPath,
+      ["--import", input.preloadPath, input.scriptPath],
+      {
+        env: {
+          ...process.env,
+          SYMPHONIKA_FONT_FIXTURES: input.fixturesPath
+        }
+      }
+    );
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      "stderr" in error &&
+      typeof error.stderr === "string"
+    ) {
+      return error.stderr;
+    }
+    throw error;
+  }
+  throw new Error("font generator unexpectedly succeeded");
+}
+
+function fontFixtures(changedWeight?: string): string {
+  const fixtures = Object.fromEntries(
+    BUNDLED_FONTS.map(({ weight }) => {
+      const bundled = getBundledFont(weight);
+      if (bundled === undefined) {
+        throw new Error(`missing bundled font fixture for weight ${weight}`);
+      }
+      const bytes = Buffer.from(new Uint8Array(bundled));
+      if (weight === changedWeight) {
+        const lastIndex = bytes.length - 1;
+        const lastByte = bytes[lastIndex];
+        if (lastByte === undefined) {
+          throw new Error(`empty bundled font fixture for weight ${weight}`);
+        }
+        bytes[lastIndex] = lastByte ^ 1;
+      }
+      return [weight, bytes.toString("base64")];
+    })
+  );
+  return JSON.stringify(fixtures);
+}
+
+function fetchInterceptorSource(): string {
+  return String.raw`
+import { readFile } from "node:fs/promises";
+
+const fixturesPath = process.env.SYMPHONIKA_FONT_FIXTURES;
+if (fixturesPath === undefined) {
+  throw new Error("SYMPHONIKA_FONT_FIXTURES is required");
+}
+
+const fixtures = JSON.parse(await readFile(fixturesPath, "utf8"));
+const pinnedUrls = {
+  "400": "https://cdn.jsdelivr.net/fontsource/fonts/ibm-plex-mono@5.2.7/latin-400-normal.woff2",
+  "500": "https://cdn.jsdelivr.net/fontsource/fonts/ibm-plex-mono@5.2.7/latin-500-normal.woff2",
+  "600": "https://cdn.jsdelivr.net/fontsource/fonts/ibm-plex-mono@5.2.7/latin-600-normal.woff2"
+};
+
+globalThis.fetch = async (input) => {
+  const url = String(input);
+  const entry = Object.entries(pinnedUrls).find(([, expected]) => expected === url);
+  if (entry === undefined) {
+    throw new Error("unexpected font URL: " + url);
+  }
+  const [weight] = entry;
+  return new Response(Buffer.from(fixtures[weight], "base64"));
+};
+`;
+}


### PR DESCRIPTION
## Summary

- bind the pinned Fontsource 5.2.7 artifacts to reviewed full SHA-256 digests for weights 400, 500, and 600
- reject any changed payload before writing the generated font module
- document the narrow CodeQL suppression at the verified write sink
- test the public generator CLI with pinned, deterministic fetch fixtures and per-weight tampering

## Validation

- npm run lint
- npm run typecheck
- npm test (603 tests)
- npm run build
- npm run gen:fonts reproduces src/http/fonts.ts byte-for-byte from the real pinned CDN artifacts

Closes #243