### PR TITLE
fix(reconcile): keep fresh raw_fsm runs label-immune so finished implement runs park

### DIFF
--- a/docs/adr/0046-state-advance-vs-continuation.md
+++ b/docs/adr/0046-state-advance-vs-continuation.md
@@ -55,6 +55,26 @@ State advance:
   remain the fresh-dispatch guard that prevents a second daemon polling tick from claiming the
   same issue mid-walk.
 
+The label-immunity bit (`respectsIssueLabels = false`) covers the entire in-flight walk of a
+`raw_fsm` run, **including its fresh initial state**, not only state-advance continuations. A
+`raw_fsm` agent state legitimately removes the eligibility label (`agent-ready`) as its terminal
+action — the `implement` state opens the PR, drops `agent-ready`, and exits so the run parks into
+the label-immune `wait_for_pr` state. If the initial state kept respecting labels, the daemon tick
+would run `reconcileActiveRuns` (which re-checks eligibility) while the provider is still draining,
+see `agent-ready` gone, and cancel the finished run with `ELIGIBILITY_LOSS` before it could park —
+orphaning the PR it just opened (issue #258). Two structural facts make this the only workable fix:
+`runAttemptLifecycle` unregisters the in-flight slot as the *first* action in its `finally`, so the
+run entry exists only while the provider is live (there is no "provider exited but still active"
+window to gate on); and the park itself happens asynchronously in the provider-exit path, not inside
+the reconcile pass, so reordering work within a tick cannot help. Extending the existing
+label-immunity flag to fresh `raw_fsm` runs closes the window uniformly.
+
+The trade-off: an operator can no longer abort a fresh `raw_fsm` run mid-flight by pulling
+`agent-ready` (or adding a `labels_none` entry such as `needs-human`) — the same stance already
+accepted for continuations. Aborts go through closing the issue (still honored as `CLOSED_ISSUE`) or
+an operator cancel. Markdown compatibility-graph workflows are unaffected: they are not `raw_fsm`,
+so their initial fresh dispatch keeps the label-driven behavior.
+
 Label-driven continuations remain a distinct concept. They keep the cap, the eligibility re-check,
 and the `executeContinuation` path because their purpose is to re-dispatch the same workflow when
 an operator (or the workflow itself) decides the issue should run again, not to advance the state

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -2041,15 +2041,24 @@ export class RunController {
         return;
       }
 
-      // Raw FSM continuations are state-advance runs: the FSM, not the issue
-      // labels, decides whether the agent keeps running. Computed here so both
-      // activeRuns.attachProvider and scheduleNext (in finally) carry the
-      // same label-immunity guarantee — including into retry scheduling.
-      // See ADR 0046.
-      respectsIssueLabels = !(
-        input.isContinuation &&
-        loadedWorkflow.expandedWorkflow.source.kind === "raw_fsm"
-      );
+      // Raw FSM runs are FSM-governed: the state machine, not the issue label
+      // set, decides whether the agent keeps running — for the initial state as
+      // much as for state-advance continuations. This immunity covers the whole
+      // in-flight walk, including the fresh initial state, because a raw FSM
+      // agent state legitimately removes the eligibility label (`agent-ready`)
+      // as its terminal action before the run parks into a label-immune wait
+      // state. Without covering the initial state, reconcileActiveRuns re-checks
+      // labels while the provider is still draining, sees `agent-ready` gone,
+      // and cancels the finished run as ELIGIBILITY_LOSS — orphaning its PR
+      // (issue #258). The unregister-in-finally ordering means the in-flight
+      // entry only exists while the provider is live, so gating on "provider
+      // exited" cannot close the window; label-immunity is the fix. Computed
+      // here so both activeRuns.attachProvider and scheduleNext (in finally)
+      // carry the same guarantee, including into retry scheduling. Markdown
+      // compatibility-graph workflows keep their label-driven behavior.
+      // CLOSED_ISSUE cancellation still applies. See ADR 0046.
+      respectsIssueLabels =
+        loadedWorkflow.expandedWorkflow.source.kind !== "raw_fsm";
       // For raw FSM workflows, the agent action's `prompt` field points at the
       // template file to send to the provider for this state. Resolve it here
       // so startAttempt renders the right prompt (rather than the YAML body of

--- a/tests/wait-state.test.ts
+++ b/tests/wait-state.test.ts
@@ -23,6 +23,7 @@ import type {
 } from "../src/provider.js";
 import { openRunStore } from "../src/run-store.js";
 import type { PreparedIssueWorkspace } from "../src/workspace.js";
+import { createDeferred } from "./helpers/deferred.js";
 import { createGitWorkspaceAhead } from "./helpers/git-workspace.js";
 
 const tempRoots: string[] = [];
@@ -107,6 +108,46 @@ function recordingCodexProvider(
     ): AsyncGenerator<ProviderEvent> {
       providerInputs.push(input);
       await Promise.resolve();
+      yield {
+        normalized: { exitCode: 0, type: "process_exit" },
+        raw: { code: 0, kind: "exit" }
+      };
+    }),
+    validate: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+type GatedProvider = AgentProvider & {
+  cancel: ReturnType<typeof vi.fn>;
+  ready: Promise<void>;
+  release: () => void;
+};
+
+// Provider that yields session_started, then blocks until released — modelling
+// an agent that is still "running" (e.g. mid-way through removing agent-ready
+// and opening its PR) so a reconcile tick can fire while the run is in-flight.
+// Releasing yields a clean exit 0. cancel() also releases the gate so a
+// (regressed) eligibility_loss cancel unwinds the generator instead of hanging
+// the test; the assertion that cancel was never called is what catches the bug.
+function gatedSuccessProvider(): GatedProvider {
+  const readyGate = createDeferred<void>();
+  const releaseGate = createDeferred<void>();
+  const cancel = vi.fn((): Promise<void> => {
+    releaseGate.resolve();
+    return Promise.resolve();
+  });
+  return {
+    cancel,
+    name: "codex",
+    ready: readyGate.promise,
+    release: () => releaseGate.resolve(),
+    runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+      readyGate.resolve();
+      yield {
+        normalized: { sessionId: "fake", type: "session_started" },
+        raw: { kind: "session" }
+      };
+      await releaseGate.promise;
       yield {
         normalized: { exitCode: 0, type: "process_exit" },
         raw: { code: 0, kind: "exit" }
@@ -370,6 +411,161 @@ describe("wait state lifecycle", () => {
       // Only the planning state ran a provider attempt. The wait state must
       // NOT spawn an agent.
       expect(providerInputs).toHaveLength(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("does not cancel a fresh raw FSM run whose agent removes agent-ready before it parks (issue #258)", async () => {
+    const root = await makeTempRoot();
+    await writeWaitStateProject(root);
+
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+    await createGitWorkspaceAhead(preparedWorkspace);
+
+    const eligibleIssue = issueFixture();
+    // The implement agent opens its PR and removes agent-ready as its terminal
+    // action. Every poll after dispatch therefore surfaces the issue as
+    // ineligible (labels_all no longer satisfied), landing it in
+    // pollStatus.filteredIssues where reconcileActiveRuns re-checks it. Pre-fix
+    // this cancelled the still-running run as eligibility_loss.
+    const ineligibleIssue = {
+      ...eligibleIssue,
+      labels: ["sym:claimed", "sym:running"]
+    };
+
+    let listCalls = 0;
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue({
+        ...ineligibleIssue,
+        labels: ineligibleIssue.labels.map((name) => ({ name }))
+      }),
+      getPullRequestFollowupState: vi
+        .fn()
+        .mockResolvedValue(prState({ statusCheckRollupState: "PENDING" })),
+      listOpenIssues: vi.fn(() => {
+        listCalls += 1;
+        return Promise.resolve([
+          listCalls === 1 ? eligibleIssue : ineligibleIssue
+        ]);
+      }),
+      listPullRequestsForBranch: vi.fn().mockResolvedValue([
+        {
+          draft: false,
+          head: { ref: preparedWorkspace.branchName, sha: "abc123def456" },
+          html_url: "https://github.com/pmatos/symphonika/pull/256",
+          number: 256,
+          state: "open"
+        }
+      ]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const provider = gatedSuccessProvider();
+
+    let runCounter = 0;
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRunId: () => `run-258-${++runCounter}`,
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 5 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      const databasePath = path.join(root, ".symphonika", "symphonika.db");
+
+      // Startup dispatched the implement run; it is now blocked inside the
+      // provider (agent still "running"). Its in-flight entry is registered
+      // with the label-immunity bit already resolved.
+      await provider.ready;
+
+      // Drive ticks whose polls no longer contain agent-ready. Each tick runs
+      // reconcileActiveRuns against the still-in-flight run with the issue
+      // ineligible — the exact ordering that used to cancel it.
+      await fetch(`${daemon.url}/api/poll-now`, { method: "POST" });
+      await fetch(`${daemon.url}/api/poll-now`, { method: "POST" });
+
+      expect(provider.cancel).not.toHaveBeenCalled();
+      const midRun = new Database(databasePath, { readonly: true });
+      try {
+        const row = midRun
+          .prepare("select state, cancel_reason from runs where id = ?")
+          .get("run-258-1") as
+          { state: string; cancel_reason: string | null } | undefined;
+        expect(row?.state).not.toBe("cancelled");
+        expect(row?.cancel_reason).toBeNull();
+      } finally {
+        midRun.close();
+      }
+
+      // The agent finishes: exit 0 with the branch ahead of base. The run must
+      // advance into the label-immune wait state instead of dying.
+      provider.release();
+
+      const waitingRow = await waitForWaitingRow(databasePath);
+      expect(waitingRow).toMatchObject({
+        state: "waiting",
+        current_state_id: "holding"
+      });
+      expect(waitingRow.continuation_parent_run_id).toBe("run-258-1");
+
+      // Acceptance: the implement run is recorded as succeeded (advanced to the
+      // wait state), never cancelled, with its branch persisted so PR discovery
+      // can pick it up.
+      const parentDb = new Database(databasePath, { readonly: true });
+      try {
+        const parent = parentDb
+          .prepare(
+            "select state, cancel_reason, branch_name from runs where id = ?"
+          )
+          .get("run-258-1") as {
+          state: string;
+          cancel_reason: string | null;
+          branch_name: string | null;
+        };
+        expect(parent.state).toBe("succeeded");
+        expect(parent.cancel_reason).toBeNull();
+        expect(parent.branch_name).toBe(preparedWorkspace.branchName);
+      } finally {
+        parentDb.close();
+      }
+      expect(provider.cancel).not.toHaveBeenCalled();
+
+      // Acceptance: the PR is registered in tracked_pull_requests. PR follow-up
+      // is throttled to once per second after startup, so drive ticks until the
+      // discovery loop records the row.
+      const deadline = Date.now() + 6000;
+      let tracked: Record<string, unknown> | undefined;
+      while (Date.now() < deadline) {
+        await fetch(`${daemon.url}/api/poll-now`, { method: "POST" });
+        const trackedDb = new Database(databasePath, { readonly: true });
+        try {
+          tracked = trackedDb
+            .prepare(
+              "select pr_number, branch_name, state from tracked_pull_requests limit 1"
+            )
+            .get() as Record<string, unknown> | undefined;
+        } finally {
+          trackedDb.close();
+        }
+        if (tracked !== undefined) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 60));
+      }
+      expect(tracked).toMatchObject({
+        branch_name: preparedWorkspace.branchName,
+        pr_number: 256
+      });
     } finally {
       await daemon.stop();
     }


### PR DESCRIPTION
## Summary

Successful `implement` runs were being cancelled at the finish line as `eligibility_loss`, orphaning their PRs (never registered in `tracked_pull_requests`). Root cause: a `raw_fsm` agent state removes `agent-ready` as its terminal action before the run parks into the label-immune `wait_for_pr` state, but **only state-advance continuations were label-immune** (`respectsIssueLabels = !(isContinuation && raw_fsm)`). A fresh dispatch of a `raw_fsm` workflow's initial state kept `respectsIssueLabels = true`, so `reconcileActiveRuns` re-checked labels on the still-in-flight run, saw `agent-ready` gone, and cancelled it before it could park.

The fix makes label-immunity uniform for `raw_fsm` runs: `respectsIssueLabels = source.kind !== "raw_fsm"`. This flips exactly one case (fresh raw_fsm: `true → false`); markdown-fresh, markdown-continuation, and raw_fsm-continuation are unchanged.

- `src/lifecycle/run-controller.ts` — the one-line predicate change (+ rationale comment).
- `docs/adr/0046-state-advance-vs-continuation.md` — records the extended immunity and the reasoning below.
- `tests/wait-state.test.ts` — regression test (verified failing on the pre-fix code at the `provider.cancel` assertion).

## Why not the issue's options 1 / 2

- **Option 1 ("don't cancel a run whose provider has exited")** can't work: `runAttemptLifecycle` unregisters the in-flight slot as the *first* action in its `finally`, so the entry exists in `activeRuns` *only while the provider is still live*. There is no "exited but still active" window to gate on — the cancel fires while the agent is genuinely still draining after removing `agent-ready`.
- **Option 2 ("reorder within the tick")** can't work either: parking happens asynchronously in the provider-exit path (the `launchWork` dispatch promise), not inside the reconcile pass, so reordering work within a tick cannot help.

Extending the existing label-immunity flag closes the window uniformly, which is why it's the surgical fix.

## Behavior change (please review)

Fresh `raw_fsm` runs are now label-immune for their **entire** in-flight walk. An operator can no longer abort such a run mid-flight by pulling `agent-ready` **or** by adding a `labels_none` label (e.g. `needs-human`). Aborts now go through **closing the issue** (still honored as `CLOSED_ISSUE`) or an **operator cancel**. This is the same stance ADR 0046 already accepted for continuations, now made uniform. Markdown compatibility-graph workflows are unaffected.

Closes #258

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 600 passing (66 files)
- [x] `npm run build` — clean
- [x] New regression test fails on the reverted fix (cancel fired) and passes with it