### PR TITLE
ci: enforce Conventional Commits (PR titles + commitlint)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v7.0.0
         with:
           node-version: lts/*

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,26 @@
+# Lints commit messages against Conventional Commits on pushes to the default branch.
+# Direct pushes are what the PR-title check can't see; PRs are covered by lint-pr-title.yml.
+name: Lint commits
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: lts/*
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+      - name: Lint pushed commits
+        if: github.event.before != '0000000000000000000000000000000000000000'
+        run: npx commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --verbose

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,23 @@
+# Enforces that PR titles follow the Conventional Commits spec.
+# https://www.conventionalcommits.org/  |  https://github.com/amannn/action-semantic-pull-request
+name: Lint PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -21,3 +21,12 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Mirrors commitlint's default subject-case rule (commitlint.config.cjs), which
+          # rejects sentence-case/start-case/pascal-case/upper-case subjects — all of which
+          # start with an uppercase letter — so a squash-merged title can't pass this check
+          # and then fail the push-time commitlint job on main.
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: >-
+            The subject must not start with an uppercase letter, to match this repo's
+            commitlint subject-case rule.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -54,11 +54,11 @@ Stay on this branch for all commits. Do not switch branches or open new ones.
 
    ```sh
    gh pr create --base main --head {{branch.name}} \
-     --title "<conventional title>" \
+     --title "<type>: <subject>" \
      --body "<summary>\n\nCloses #{{issue.number}}"
    ```
 
-   Use a conventional title that describes the change (for example, "Add project README"); do not prefix the title with an agent name such as `[codex]` or `[claude]`. Do not use `--web`, `--draft`, or any other flag that opens a browser, waits for input, or downgrades the PR.
+   Use a Conventional Commits title (`type: subject`, lower-case subject — for example, "feat: add project readme") that describes the change; do not prefix the title with an agent name such as `[codex]` or `[claude]`. Do not use `--web`, `--draft`, or any other flag that opens a browser, waits for input, or downgrades the PR.
 7. On successful completion, remove `agent-ready` from the issue with `gh issue edit {{issue.number}} --remove-label agent-ready` so the orchestrator does not schedule a redundant continuation (per SPEC §9.3 and §12.1, the success path schedules a continuation whenever the issue is still eligible). The PR opened in step 6 carries the work into review; the operator owns any further label transitions on PR open and merge.
 8. If the work cannot proceed at all, post an explanatory comment with `gh issue comment {{issue.number}} --body "<what blocked you and what would unblock it>"`, then exit cleanly. Do not apply `needs-human` or any other handoff label as an exit strategy — the operator decides how to triage. Also write an `EVIDENCE.md` at `{{workspace.path}}/EVIDENCE.md` recording the same explanation for the workspace record.
 9. Update `SPEC.md`, `CONTEXT.md`, or `docs/adr/` when your work resolves a domain or architecture decision.

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -4,7 +4,8 @@ module.exports = {
   extends: ["@commitlint/config-conventional"],
   // commitlint's defaultIgnores also skips amend!/fixup!/squash! commits, which would let an
   // unsquashed autosquash commit land on main without being linted. Disable defaultIgnores and
-  // replace it with the same list minus that one entry, keeping the merge/revert/release
+  // replace it with the same list minus that one entry (and minus the semver/release-version
+  // matcher, since this repo has no version-bump or release tooling), keeping the merge/revert
   // exceptions this repo's history actually relies on.
   defaultIgnores: false,
   ignores: [

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,5 @@
+/* Conventional Commits ruleset for commitlint.
+ * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module". */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,5 +1,5 @@
 /* Conventional Commits ruleset for commitlint.
  * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module". */
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
+  extends: ["@commitlint/config-conventional"]
 };

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,5 +1,32 @@
 /* Conventional Commits ruleset for commitlint.
  * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module". */
 module.exports = {
-  extends: ["@commitlint/config-conventional"]
+  extends: ["@commitlint/config-conventional"],
+  // commitlint's defaultIgnores also skips amend!/fixup!/squash! commits, which would let an
+  // unsquashed autosquash commit land on main without being linted. Disable defaultIgnores and
+  // replace it with the same list minus that one entry, keeping the merge/revert/release
+  // exceptions this repo's history actually relies on.
+  defaultIgnores: false,
+  ignores: [
+    /** @param {string} message */
+    (message) =>
+      /^((Merge pull request)|(Merge (.*?) into (.*?)|(Merge branch (.*?)))(?:\r?\n)*$)/m.test(
+        message
+      ),
+    /** @param {string} message */
+    (message) => /^(Merge tag (.*?))(?:\r?\n)*$/m.test(message),
+    /** @param {string} message */
+    (message) => /^(R|r)evert (.*)/.test(message),
+    /** @param {string} message */
+    (message) => /^(R|r)eapply (.*)/.test(message),
+    /** @param {string} message */
+    (message) =>
+      /^(Merged (.*?)(in|into) (.*)|Merged PR (.*): (.*))/.test(message),
+    /** @param {string} message */
+    (message) => /^Merge remote-tracking branch(\s*)(.*)/.test(message),
+    /** @param {string} message */
+    (message) => /^Automatic merge(.*)/.test(message),
+    /** @param {string} message */
+    (message) => /^Auto-merged (.*?) into (.*)/.test(message)
+  ]
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["*.mjs", "fuzz/*.mjs"]
+          allowDefaultProject: ["*.mjs", "fuzz/*.mjs", "commitlint.config.cjs"]
         },
         tsconfigRootDir: import.meta.dirname
       }
@@ -36,6 +36,16 @@ export default tseslint.config(
     rules: {
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-member-access": "off"
+    }
+  },
+  {
+    files: ["commitlint.config.cjs"],
+    languageOptions: {
+      sourceType: "commonjs",
+      globals: {
+        module: "writable",
+        require: "readonly"
+      }
     }
   },
   eslintConfigPrettier


### PR DESCRIPTION
Standardizes this repository on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

### Adds
- `.github/workflows/lint-pr-title.yml` — validates **PR titles** with [`amannn/action-semantic-pull-request@v6`](https://github.com/amannn/action-semantic-pull-request).
- `.github/workflows/commitlint.yml` — lints **commit messages** on pushes to `main` (covers direct pushes the PR-title check can't see).
- `commitlint.config.cjs` — the Conventional Commits ruleset (`.cjs` so it loads under `"type":"module"` too).

### Notes
- For the PR-title check to feed clean history, enable **Settings → Pull Requests → Allow squash merging** with *"Default to PR title for squash-merge commits"*.
- `commitlint.yml` only lints commits going forward — it does not fail on existing history.

_Part of a cross-repo standardization pass. Review and merge, or close if unwanted._
