### PR TITLE
feat: add routine catch-up and overlap policies

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -129,6 +129,12 @@ One durable execution attempt of a Routine, with its own workspace, provider log
 and lifecycle state.
 _Avoid_: run when specifically referring to non-issue scheduled execution
 
+**Routine Skip**:
+An operator-visible clock attempt that did not create a Routine Firing because of a catch-up window,
+an overlapping non-terminal firing, or a concurrency cap. It updates the Routine's latest skip
+evidence and rolling counters but creates no `routine_firings` row.
+_Avoid_: Routine Firing when no provider execution was launched
+
 **Routine Pull Request**:
 An informational association discovered from a succeeded `kind: git` Routine Firing's deterministic
 branch. It records the PR number and head SHA but never enters PR Follow-up, review re-dispatch, or
@@ -227,6 +233,7 @@ _Avoid_: chat session
 - A **Run Store** records durable orchestration state across process restarts
 - A **Run** can succeed even when its **Issue** remains open
 - A **Routine** belongs to one **Project** and may create zero or more **Routine Firings**
+- A **Routine** may record **Routine Skips** without creating Routine Firings
 - A **Routine Firing** consumes the same Project/global in-flight capacity as issue **Runs**
 - A succeeded `kind: git` **Routine Firing** may link zero or more read-only **Routine Pull Requests**
 - A **Run Lifecycle** consumes **Lifecycle Events** and chooses **Planned Steps**

--- a/SPEC.md
+++ b/SPEC.md
@@ -177,6 +177,8 @@ Markdown routine files with YAML front matter:
 - exactly one schedule shape: `schedule.at` or `schedule.cron` with optional `schedule.tz`
 - `kind: report` or `kind: git`
 - optional `provider`
+- optional `catch_up: fire_once_if_missed` (omitted means missed clock events are skipped)
+- optional `allow_overlap: true` (omitted means overlapping firings are skipped)
 
 Recurring schedules use five-field POSIX cron. They accept the `hourly`, `daily`, `weekly`,
 `monthly`, and `yearly` aliases with or without an `@` prefix. `schedule.tz` defaults to `Etc/UTC`.
@@ -195,6 +197,10 @@ workspace path, prompt evidence, provider logs, terminal reason, lifecycle state
 requests discovered from a `kind: git` firing branch. A one-shot `schedule.at` Routine becomes
 `expired` after its firing is claimed and must not fire again on daemon restart. A recurring Routine
 remains active and advances to its next clock event after every firing.
+
+A clock event skipped for catch-up policy, overlap, or a concurrency cap is not a Routine Firing:
+no `routine_firings` row is created. The Routine instead records `last_attempted_at`,
+`last_skip_reason`, and `last_skip_at`, together with rolling 24-hour counts for each skip reason.
 
 ## 5. Config Files
 
@@ -387,6 +393,8 @@ Routine schedules must define exactly one of:
 
 Supplying both shapes, neither shape, an invalid cron expression, or an invalid timezone is a
 deterministic declaration-load error. `tz` is valid only with `cron` and defaults to `Etc/UTC`.
+`catch_up`, when present, must be `fire_once_if_missed`; `allow_overlap`, when present, must be a
+boolean. Their omitted defaults are missed-event skip and `false`, respectively.
 
 ## 6. Credentials
 
@@ -443,6 +451,7 @@ SQLite stores durable orchestration state:
 - raw log file paths
 - routines
 - routine firings
+- exact-timestamp Routine skip counters used to compute rolling 24-hour per-reason totals
 
 The run store is not a replacement for GitHub as the canonical tracker. It is durable runtime
 evidence and restart state.
@@ -600,13 +609,18 @@ more commits succeeds. On the succeeded transition, Symphonika lists every open 
 head is the firing branch and records its PR number and head SHA. Routine PR discovery is
 informational only: it never enters PR Follow-up, review re-dispatch, or auto-merge.
 
-On daemon startup, recurring `next_fire_at` values are recomputed from the current clock. Missed
-ticks are not caught up in this slice. Timezone and DST behavior comes from `cron-parser`; the
-Orchestrator does not implement separate DST rules.
+On daemon startup, a recurring Routine with `catch_up: fire_once_if_missed` preserves a due
+`next_fire_at` and fires at most once even when the outage spans several clock events. The claim
+then advances `next_fire_at` strictly beyond the current clock. Without the opt-in, startup advances
+past the missed window without firing and records a `catch_up_window` skip. Timezone and DST
+behavior comes from `cron-parser`; the Orchestrator does not implement separate DST rules.
 
 Routine Firings consume the same per-Project and global `max_in_flight` slots as issue Runs. If a
-cap is already full, or an earlier firing of the same Routine overlaps, the daemon skips that clock
-event and logs the skip; no firing row is written. Persisted skip reasons and counters are deferred.
+cap is already full, the daemon records a `concurrency_cap` skip. If an earlier firing of the same
+Routine remains non-terminal, the daemon records an `overlap` skip unless `allow_overlap: true` is
+configured; overlap opt-in does not bypass concurrency caps. Every skip atomically advances the
+clock event, updates the Routine's latest-attempt/skip fields and rolling counter evidence, writes no
+Routine Firing row, and emits `routine.skipped` with `reason`, `routine`, and `scheduled_at` fields.
 
 ## 9. GitHub Tracker Behavior
 
@@ -1099,8 +1113,9 @@ mtime ages, observed turn-id count, five-minute output-token growth, and `idle_s
 grace remaining when idle. `status` and its dashboard render an idle indicator only for active Runs
 whose latest sample has `idle_since` set.
 
-`routines` lists Routine status per Project with `state`, `next_fire_at`, `last_fired_at`, and PR
-numbers discovered for the latest firing. Inactive Routines are hidden by default;
+`routines` lists Routine status per Project with `state`, `next_fire_at`, `last_fired_at`,
+`last_attempted_at`, `last_skip_reason`, `last_skip_at`, rolling 24-hour skip counts per reason, and
+PR numbers discovered for the latest firing. Inactive Routines are hidden by default;
 `--include-inactive` includes them.
 
 `clear-stale` removes `sym:stale`, `sym:claimed`, and `sym:running` only after explicit confirmation.
@@ -1128,7 +1143,8 @@ The UI is primarily read-only. It shows:
 - raw log links or content
 - rendered prompt links
 - retry and continuation state
-- routines with `state`, `next_fire_at`, `last_fired_at`, and discovered PR numbers
+- routines with firing/attempt timestamps, latest skip evidence, rolling 24-hour skip counts, and
+  discovered PR numbers
 - a per-run interactive workflow graph
 
 Operator pages stay server-rendered and primarily read-only, but a page may embed a
@@ -1146,7 +1162,8 @@ The v1 mutating web actions are explicit active-run cancellation and a manual po
 uses the normal daemon scheduler path.
 
 The HTTP API exposes `GET /api/routines` with the same Routine status shape as the CLI and
-dashboard. Inactive Routines are hidden by default; `?include_inactive=true` includes them, and the
+dashboard, including latest-attempt/skip fields and per-reason `skipCounts24h`. Inactive Routines
+are hidden by default; `?include_inactive=true` includes them, and the
 server-rendered dashboard accepts the same query parameter. `GET /api/routines/:id/firings` returns
 firing history and linked PRs for the named Routine; callers use `?project=<name>` to disambiguate
 the same Routine name across Projects and `?include_inactive=true` to resolve an inactive Routine and

--- a/docs/adr/0058-routine-catch-up-overlap-and-skip-accounting.md
+++ b/docs/adr/0058-routine-catch-up-overlap-and-skip-accounting.md
@@ -1,0 +1,41 @@
+# Routine catch-up, overlap, and skip accounting
+
+Recurring Routines need explicit policy for daemon outages and long-running prior firings. A clock
+match that cannot launch must also remain visible to operators without being confused with a
+Routine Firing.
+
+## Decision
+
+Routine declarations accept two optional top-level fields:
+
+```yaml
+catch_up: fire_once_if_missed
+allow_overlap: true
+```
+
+Omitting `catch_up` skips clock events missed while the daemon was offline. Opting in preserves one
+due event on startup and launches at most one catch-up firing, then advances `next_fire_at` strictly
+beyond the current clock even when several events were missed. Omitting `allow_overlap` skips a due
+event while an earlier firing of the same Routine is non-terminal. Opting in bypasses only the
+same-Routine overlap gate; global and per-Project concurrency caps still apply.
+
+The three policy skip reasons are `catch_up_window`, `overlap`, and `concurrency_cap`. A skip:
+
+- creates no `routine_firings` row;
+- atomically advances or expires the matched clock event;
+- updates `last_attempted_at`, `last_skip_reason`, and `last_skip_at` on the Routine;
+- increments an exact-timestamp row in `routine_skip_counts`; and
+- emits `routine.skipped` with `reason`, `routine`, and `scheduled_at`.
+
+`routine_skip_counts` is counter evidence, not a firing/event lifecycle. Status readers sum rows in
+the exact trailing 24-hour interval and return zero for reasons with no samples. Keeping timestamps
+allows an accurate rolling window without turning a skipped clock match into a Routine Firing.
+
+## Consequences
+
+- Restart catch-up cannot create a thundering herd; one Routine launches at most once per restart.
+- Overlap and cap skips never replay retroactively because their matched clock event advances.
+- Operators see the latest skip and per-reason pressure in the CLI, dashboards, and
+  `GET /api/routines`.
+- Skip counter evidence grows with skipped clock attempts and can be compacted by a later retention
+  policy without changing Routine Firing semantics.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
 import type { InitOptions, InitProvider, InitReport } from "./init.js";
 import { runInit } from "./init.js";
 import type { ProjectIssuePollReport } from "./issue-polling.js";
+import type { RoutineStatus } from "./routines/types.js";
 import {
   resolveWatchdogConfig,
   RuntimeConfigReloader,
@@ -864,7 +865,7 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
         }
         writeOut(
           program,
-          "project  routine  state  next_fire_at  last_fired_at  pull_requests\n"
+          "project  routine  state  next_fire_at  last_fired_at  last_attempted_at  last_skip_reason  last_skip_at  skips_24h  pull_requests\n"
         );
         for (const routine of routines) {
           writeOut(
@@ -875,6 +876,10 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
               routine.state,
               routine.nextFireAt ?? "-",
               routine.lastFiredAt ?? "-",
+              routine.lastAttemptedAt ?? "-",
+              routine.lastSkipReason ?? "-",
+              routine.lastSkipAt ?? "-",
+              formatRoutineSkipCounts(routine.skipCounts24h),
               formatRoutinePullRequestNumbers(routine.pullRequestNumbers)
             ].join("  ") + "\n"
           );
@@ -1662,6 +1667,12 @@ function formatRoutinePullRequestNumbers(numbers: number[]): string {
   return numbers.length === 0
     ? "-"
     : numbers.map((number) => `#${number}`).join(",");
+}
+
+function formatRoutineSkipCounts(
+  counts: RoutineStatus["skipCounts24h"]
+): string {
+  return `overlap=${counts.overlap},concurrency_cap=${counts.concurrency_cap},catch_up_window=${counts.catch_up_window}`;
 }
 
 function parseNonNegativeInt(value: string): number {

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -765,13 +765,13 @@ function renderRoutinesTable(routines: RoutineStatus[]): string {
   const rows = routines
     .map(
       (routine) =>
-        `<tr><td>${escapeHtml(routine.projectName)}</td><td>${escapeHtml(routine.name)}</td><td>${escapeHtml(routine.state)}</td><td><code>${escapeHtml(routine.nextFireAt ?? "-")}</code></td><td><code>${escapeHtml(routine.lastFiredAt ?? "-")}</code></td><td>${escapeHtml(formatRoutinePullRequestNumbers(routine.pullRequestNumbers))}</td></tr>`
+        `<tr><td>${escapeHtml(routine.projectName)}</td><td>${escapeHtml(routine.name)}</td><td>${escapeHtml(routine.state)}</td><td><code>${escapeHtml(routine.nextFireAt ?? "-")}</code></td><td><code>${escapeHtml(routine.lastFiredAt ?? "-")}</code></td><td><code>${escapeHtml(routine.lastAttemptedAt ?? "-")}</code></td><td>${escapeHtml(routine.lastSkipReason ?? "-")}</td><td><code>${escapeHtml(routine.lastSkipAt ?? "-")}</code></td><td>${escapeHtml(formatRoutineSkipCounts(routine.skipCounts24h))}</td><td>${escapeHtml(formatRoutinePullRequestNumbers(routine.pullRequestNumbers))}</td></tr>`
     )
     .join("");
   return tableSection(
     "Routines",
     routines.length,
-    "<tr><th>Project</th><th>Routine</th><th>State</th><th>next_fire_at</th><th>last_fired_at</th><th>Pull requests</th></tr>",
+    "<tr><th>Project</th><th>Routine</th><th>State</th><th>next_fire_at</th><th>last_fired_at</th><th>last_attempted_at</th><th>last_skip_reason</th><th>last_skip_at</th><th>skips_24h</th><th>Pull requests</th></tr>",
     rows
   );
 }
@@ -780,6 +780,12 @@ function formatRoutinePullRequestNumbers(numbers: number[]): string {
   return numbers.length === 0
     ? "-"
     : numbers.map((number) => `#${number}`).join(", ");
+}
+
+function formatRoutineSkipCounts(
+  counts: RoutineStatus["skipCounts24h"]
+): string {
+  return `overlap=${counts.overlap},concurrency_cap=${counts.concurrency_cap},catch_up_window=${counts.catch_up_window}`;
 }
 
 function renderRunsTable(title: string, runs: RunStatus[]): string {

--- a/src/routines/declaration-loader.ts
+++ b/src/routines/declaration-loader.ts
@@ -102,6 +102,23 @@ function parseRoutineDeclaration(
   const schedule = recordField(frontMatter, "schedule");
   const parsedSchedule = parseRoutineSchedule(schedule, routinePath, errors);
 
+  const catchUpValue = stringField(frontMatter, "catch_up");
+  if (
+    Object.hasOwn(frontMatter, "catch_up") &&
+    catchUpValue !== "fire_once_if_missed"
+  ) {
+    errors.push(
+      `routine at ${routinePath} catch_up must be fire_once_if_missed`
+    );
+  }
+  const allowOverlapValue = frontMatter.allow_overlap;
+  if (
+    Object.hasOwn(frontMatter, "allow_overlap") &&
+    typeof allowOverlapValue !== "boolean"
+  ) {
+    errors.push(`routine at ${routinePath} allow_overlap must be a boolean`);
+  }
+
   if (prompt.trim().length === 0) {
     errors.push(`routine at ${routinePath} prompt body must not be empty`);
   }
@@ -113,6 +130,10 @@ function parseRoutineDeclaration(
   return {
     errors: [],
     routine: {
+      allowOverlap:
+        typeof allowOverlapValue === "boolean" ? allowOverlapValue : false,
+      catchUp:
+        catchUpValue === "fire_once_if_missed" ? "fire_once_if_missed" : "skip",
       kind: kind as RoutineKind,
       name: name!,
       prompt,

--- a/src/routines/dispatcher.ts
+++ b/src/routines/dispatcher.ts
@@ -24,6 +24,7 @@ import type {
 import type { RunStore } from "../run-store.js";
 import {
   evaluateRoutineSchedule,
+  nextRecurringFireAt,
   type RoutineScheduleEvaluation
 } from "./schedule.js";
 import {
@@ -84,6 +85,49 @@ export async function dispatchDueRoutines(
       input.runStore.markRoutinesInactiveForProject(project.name);
       continue;
     }
+    if (input.recomputeSchedulesFromNow === true) {
+      const declarations = new Map(
+        (project.routines ?? []).map((routine) => [routine.name, routine])
+      );
+      for (const persisted of input.runStore.listRoutines({
+        project: project.name
+      })) {
+        const declaration = declarations.get(persisted.name);
+        if (
+          declaration === undefined ||
+          !("cron" in declaration.schedule) ||
+          (declaration.catchUp ?? "skip") !== "skip" ||
+          persisted.state !== "active" ||
+          persisted.nextFireAt === null ||
+          new Date(persisted.nextFireAt).getTime() > now.getTime() ||
+          persisted.scheduleCron !== declaration.schedule.cron ||
+          persisted.scheduleTz !== declaration.schedule.tz
+        ) {
+          continue;
+        }
+        const nextFireAt = nextRecurringFireAt(declaration.schedule, now);
+        if (
+          input.runStore.skipRoutineFiring({
+            attemptedAt: now.toISOString(),
+            name: persisted.name,
+            nextFireAt,
+            projectName: project.name,
+            reason: "catch_up_window"
+          })
+        ) {
+          logRoutineSkip(input.logger, {
+            reason: "catch_up_window",
+            routine: persisted.name,
+            scheduledAt: persisted.nextFireAt
+          });
+          skipped.push({
+            projectName: project.name,
+            reason: "catch_up_window",
+            routineName: persisted.name
+          });
+        }
+      }
+    }
     input.runStore.syncRoutines(project.name, project.routines ?? [], {
       now,
       recomputeRecurring: input.recomputeSchedulesFromNow === true
@@ -111,26 +155,32 @@ export async function dispatchDueRoutines(
         continue;
       }
       if (
+        !routine.allowOverlap &&
         input.runStore.hasActiveRoutineFiring({
           name: routine.name,
           projectName: project.name
         })
       ) {
-        advanceSkippedRecurringRoutine(input.runStore, {
-          evaluation,
-          now,
-          projectName: project.name,
-          routineName: routine.name
-        });
-        input.logger?.info(
-          { project: project.name, routine: routine.name },
-          "symphonika routine firing skipped by overlap"
-        );
-        skipped.push({
-          projectName: project.name,
-          reason: "routine overlap",
-          routineName: routine.name
-        });
+        if (
+          recordDueRoutineSkip(input.runStore, {
+            evaluation,
+            now,
+            projectName: project.name,
+            reason: "overlap",
+            routine
+          })
+        ) {
+          logRoutineSkip(input.logger, {
+            reason: "overlap",
+            routine: routine.name,
+            scheduledAt: routine.nextFireAt ?? now.toISOString()
+          });
+          skipped.push({
+            projectName: project.name,
+            reason: "overlap",
+            routineName: routine.name
+          });
+        }
         continue;
       }
       const providerName = routine.provider ?? project.agent.provider;
@@ -152,21 +202,26 @@ export async function dispatchDueRoutines(
         project
       );
       if (capReason !== null) {
-        advanceSkippedRecurringRoutine(input.runStore, {
-          evaluation,
-          now,
-          projectName: project.name,
-          routineName: routine.name
-        });
-        input.logger?.info(
-          { project: project.name, reason: capReason, routine: routine.name },
-          "symphonika routine firing skipped by concurrency cap"
-        );
-        skipped.push({
-          projectName: project.name,
-          reason: capReason,
-          routineName: routine.name
-        });
+        if (
+          recordDueRoutineSkip(input.runStore, {
+            evaluation,
+            now,
+            projectName: project.name,
+            reason: "concurrency_cap",
+            routine
+          })
+        ) {
+          logRoutineSkip(input.logger, {
+            reason: "concurrency_cap",
+            routine: routine.name,
+            scheduledAt: routine.nextFireAt ?? now.toISOString()
+          });
+          skipped.push({
+            projectName: project.name,
+            reason: "concurrency_cap",
+            routineName: routine.name
+          });
+        }
         continue;
       }
 
@@ -685,24 +740,43 @@ function routineSchedule(routine: RoutineStatus): RoutineSchedule {
   return { at: routine.scheduleAt };
 }
 
-function advanceSkippedRecurringRoutine(
+function recordDueRoutineSkip(
   runStore: RunStore,
   input: {
     evaluation: Extract<RoutineScheduleEvaluation, { kind: "fire_now" }>;
     now: Date;
     projectName: string;
-    routineName: string;
+    reason: "overlap" | "concurrency_cap";
+    routine: RoutineStatus;
+  }
+): boolean {
+  return runStore.skipRoutineFiring({
+    attemptedAt: input.now.toISOString(),
+    name: input.routine.name,
+    ...(input.evaluation.nextAt === undefined
+      ? {}
+      : { nextFireAt: input.evaluation.nextAt }),
+    projectName: input.projectName,
+    reason: input.reason
+  });
+}
+
+function logRoutineSkip(
+  logger: Logger | undefined,
+  input: {
+    reason: "overlap" | "concurrency_cap" | "catch_up_window";
+    routine: string;
+    scheduledAt: string;
   }
 ): void {
-  if (input.evaluation.nextAt === undefined) {
-    return;
-  }
-  runStore.advanceRecurringRoutine({
-    name: input.routineName,
-    nextFireAt: input.evaluation.nextAt,
-    projectName: input.projectName,
-    skippedAt: input.now.toISOString()
-  });
+  logger?.info(
+    {
+      reason: input.reason,
+      routine: input.routine,
+      scheduled_at: input.scheduledAt
+    },
+    "routine.skipped"
+  );
 }
 
 async function appendJsonl(filePath: string, value: unknown): Promise<void> {

--- a/src/routines/types.ts
+++ b/src/routines/types.ts
@@ -12,9 +12,16 @@ export type RoutineFiringState =
   | "failed"
   | "cancelled";
 
+export type RoutineCatchUpPolicy = "skip" | "fire_once_if_missed";
+
+export type RoutineSkipReason =
+  "overlap" | "concurrency_cap" | "catch_up_window";
+
 export type RoutineSchedule = { at: string } | { cron: string; tz: string };
 
 export type RoutineDeclaration = {
+  allowOverlap?: boolean;
+  catchUp?: RoutineCatchUpPolicy;
   kind: RoutineKind;
   name: string;
   prompt: string;
@@ -32,8 +39,13 @@ export type RoutinePullRequestStatus = {
 };
 
 export type RoutineStatus = {
+  allowOverlap: boolean;
+  catchUp: RoutineCatchUpPolicy;
   kind: RoutineKind;
+  lastAttemptedAt: string | null;
   lastFiredAt: string | null;
+  lastSkipAt: string | null;
+  lastSkipReason: RoutineSkipReason | null;
   name: string;
   nextFireAt: string | null;
   projectName: string;
@@ -42,6 +54,7 @@ export type RoutineStatus = {
   scheduleAt: string | null;
   scheduleCron: string | null;
   scheduleTz: string | null;
+  skipCounts24h: Record<RoutineSkipReason, number>;
   sourcePath: string;
   state: RoutineState;
 };

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -1419,8 +1419,8 @@ export class RunStore {
         .prepare(
           [
             "update routines set",
-            "state = case when schedule_cron is null then 'expired' else 'active' end,",
-            "next_fire_at = case when schedule_cron is null then null else @next_fire_at end,",
+            "state = 'active',",
+            "next_fire_at = coalesce(@next_fire_at, next_fire_at),",
             "last_attempted_at = @attempted_at,",
             "last_skip_reason = @reason,",
             "last_skip_at = @attempted_at,",

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -10,9 +10,11 @@ import type { AgentProviderName, NormalizedProviderEvent } from "./provider.js";
 import { nextRecurringFireAt } from "./routines/schedule.js";
 import type {
   RoutineDeclaration,
+  RoutineCatchUpPolicy,
   RoutineFiringState,
   RoutineKind,
   RoutinePullRequestStatus,
+  RoutineSkipReason,
   RoutineState,
   RoutineStatus
 } from "./routines/types.js";
@@ -440,9 +442,14 @@ type ProjectStateRow = {
 };
 
 type RoutineRow = {
+  allow_overlap: number;
+  catch_up: RoutineCatchUpPolicy;
   created_at: string;
   kind: RoutineKind;
+  last_attempted_at: string | null;
   last_fired_at: string | null;
+  last_skip_at: string | null;
+  last_skip_reason: RoutineSkipReason | null;
   name: string;
   next_fire_at: string | null;
   project_name: string;
@@ -1170,19 +1177,21 @@ export class RunStore {
     const upsert = this.database.prepare(
       [
         "insert into routines (",
-        "project_name, name, source_path, kind, provider_name, schedule_at, schedule_cron, schedule_tz, next_fire_at, prompt_body, state, created_at, updated_at",
+        "project_name, name, source_path, kind, provider_name, schedule_at, schedule_cron, schedule_tz, next_fire_at, prompt_body, state, allow_overlap, catch_up, created_at, updated_at",
         ") values (",
-        "@project_name, @name, @source_path, @kind, @provider_name, @schedule_at, @schedule_cron, @schedule_tz, @next_fire_at, @prompt_body, 'active', @created_at, @updated_at",
+        "@project_name, @name, @source_path, @kind, @provider_name, @schedule_at, @schedule_cron, @schedule_tz, @next_fire_at, @prompt_body, 'active', @allow_overlap, @catch_up, @created_at, @updated_at",
         ")",
         "on conflict(project_name, name) do update set",
         "source_path = excluded.source_path,",
         "kind = excluded.kind,",
         "provider_name = excluded.provider_name,",
+        "allow_overlap = excluded.allow_overlap,",
+        "catch_up = excluded.catch_up,",
         "schedule_at = excluded.schedule_at,",
         "schedule_cron = excluded.schedule_cron,",
         "schedule_tz = excluded.schedule_tz,",
         "next_fire_at = case",
-        "when @recompute_recurring = 1 and excluded.schedule_cron is not null then excluded.next_fire_at",
+        "when @recompute_recurring = 1 and excluded.schedule_cron is not null and excluded.catch_up = 'skip' then excluded.next_fire_at",
         "when routines.schedule_at is not excluded.schedule_at or routines.schedule_cron is not excluded.schedule_cron or routines.schedule_tz is not excluded.schedule_tz then excluded.next_fire_at",
         "when routines.next_fire_at is null and routines.state != 'expired' then excluded.next_fire_at",
         "else routines.next_fire_at end,",
@@ -1232,6 +1241,8 @@ export class RunStore {
                 scheduleTz: null
               };
         upsert.run({
+          allow_overlap: routine.allowOverlap === true ? 1 : 0,
+          catch_up: routine.catchUp ?? "skip",
           created_at: now,
           kind: routine.kind,
           name: routine.name,
@@ -1281,7 +1292,7 @@ export class RunStore {
   }
 
   listRoutines(
-    filter: { includeInactive?: boolean; project?: string } = {}
+    filter: { includeInactive?: boolean; now?: Date; project?: string } = {}
   ): RoutineStatus[] {
     const conditions: string[] =
       filter.includeInactive === true ? [] : ["state != 'inactive'"];
@@ -1295,7 +1306,7 @@ export class RunStore {
     const rows = this.database
       .prepare(
         [
-          "select project_name, name, source_path, kind, provider_name, schedule_at, schedule_cron, schedule_tz, next_fire_at, state, last_fired_at, created_at, updated_at",
+          "select project_name, name, source_path, kind, provider_name, schedule_at, schedule_cron, schedule_tz, next_fire_at, state, allow_overlap, catch_up, last_fired_at, last_attempted_at, last_skip_reason, last_skip_at, created_at, updated_at",
           "from routines",
           where,
           "order by project_name asc, name asc"
@@ -1304,13 +1315,48 @@ export class RunStore {
           .join(" ")
       )
       .all(params) as RoutineRow[];
+    const countsNow = filter.now ?? new Date();
     return rows.map((row) => ({
       ...mapRoutineRow(row),
       pullRequestNumbers: this.latestRoutinePullRequestNumbers(
         row.project_name,
         row.name
+      ),
+      skipCounts24h: this.routineSkipCounts24h(
+        row.project_name,
+        row.name,
+        countsNow
       )
     }));
+  }
+
+  private routineSkipCounts24h(
+    projectName: string,
+    routineName: string,
+    now: Date
+  ): Record<RoutineSkipReason, number> {
+    const counts: Record<RoutineSkipReason, number> = {
+      catch_up_window: 0,
+      concurrency_cap: 0,
+      overlap: 0
+    };
+    const cutoff = new Date(now.getTime() - 24 * 60 * 60 * 1_000).toISOString();
+    const rows = this.database
+      .prepare(
+        [
+          "select reason, sum(count) as count from routine_skip_counts",
+          "where project_name = ? and routine_name = ?",
+          "and skipped_at >= ? and skipped_at <= ? group by reason"
+        ].join(" ")
+      )
+      .all(projectName, routineName, cutoff, now.toISOString()) as Array<{
+      count: number;
+      reason: RoutineSkipReason;
+    }>;
+    for (const row of rows) {
+      counts[row.reason] = row.count;
+    }
+    return counts;
   }
 
   getRoutine(input: {
@@ -1320,7 +1366,7 @@ export class RunStore {
     const row = this.database
       .prepare(
         [
-          "select project_name, name, source_path, kind, provider_name, schedule_at, schedule_cron, schedule_tz, next_fire_at, state, last_fired_at, created_at, updated_at, prompt_body",
+          "select project_name, name, source_path, kind, provider_name, schedule_at, schedule_cron, schedule_tz, next_fire_at, state, allow_overlap, catch_up, last_fired_at, last_attempted_at, last_skip_reason, last_skip_at, created_at, updated_at, prompt_body",
           "from routines where project_name = ? and name = ? and state != 'inactive'"
         ].join(" ")
       )
@@ -1334,6 +1380,11 @@ export class RunStore {
       pullRequestNumbers: this.latestRoutinePullRequestNumbers(
         row.project_name,
         row.name
+      ),
+      skipCounts24h: this.routineSkipCounts24h(
+        row.project_name,
+        row.name,
+        new Date()
       ),
       prompt: row.prompt_body
     };
@@ -1356,29 +1407,58 @@ export class RunStore {
     return row !== undefined;
   }
 
-  advanceRecurringRoutine(input: {
-    nextFireAt: string;
+  skipRoutineFiring(input: {
+    attemptedAt: string;
     name: string;
+    nextFireAt?: string;
     projectName: string;
-    skippedAt: string;
+    reason: RoutineSkipReason;
   }): boolean {
-    const result = this.database
-      .prepare(
-        [
-          "update routines set next_fire_at = @next_fire_at, updated_at = @updated_at",
-          "where project_name = @project_name and name = @name",
-          "and state = 'active' and schedule_cron is not null",
-          "and next_fire_at is not null and next_fire_at <= @skipped_at"
-        ].join(" ")
-      )
-      .run({
-        name: input.name,
-        next_fire_at: input.nextFireAt,
-        project_name: input.projectName,
-        skipped_at: input.skippedAt,
-        updated_at: timestamp()
-      });
-    return result.changes > 0;
+    const apply = this.database.transaction(() => {
+      const result = this.database
+        .prepare(
+          [
+            "update routines set",
+            "state = case when schedule_cron is null then 'expired' else 'active' end,",
+            "next_fire_at = case when schedule_cron is null then null else @next_fire_at end,",
+            "last_attempted_at = @attempted_at,",
+            "last_skip_reason = @reason,",
+            "last_skip_at = @attempted_at,",
+            "updated_at = @updated_at",
+            "where project_name = @project_name and name = @name and state = 'active'",
+            "and next_fire_at is not null and next_fire_at <= @attempted_at",
+            "and (schedule_cron is null or @next_fire_at is not null)"
+          ].join(" ")
+        )
+        .run({
+          attempted_at: input.attemptedAt,
+          name: input.name,
+          next_fire_at: input.nextFireAt ?? null,
+          project_name: input.projectName,
+          reason: input.reason,
+          updated_at: timestamp()
+        });
+      if (result.changes === 0) {
+        return false;
+      }
+      this.database
+        .prepare(
+          [
+            "insert into routine_skip_counts (project_name, routine_name, reason, skipped_at, count)",
+            "values (@project_name, @routine_name, @reason, @skipped_at, 1)",
+            "on conflict(project_name, routine_name, reason, skipped_at)",
+            "do update set count = count + 1"
+          ].join(" ")
+        )
+        .run({
+          project_name: input.projectName,
+          reason: input.reason,
+          routine_name: input.name,
+          skipped_at: input.attemptedAt
+        });
+      return true;
+    });
+    return apply();
   }
 
   markRoutineExpired(input: {
@@ -1454,6 +1534,7 @@ export class RunStore {
             "state = case when schedule_cron is null then 'expired' else 'active' end,",
             "next_fire_at = case when schedule_cron is null then null else @next_fire_at end,",
             "last_fired_at = @fired_at,",
+            "last_attempted_at = @fired_at,",
             "updated_at = @updated_at",
             "where project_name = @project_name and name = @routine_name and state = 'active'",
             "and next_fire_at is not null and next_fire_at <= @fired_at",
@@ -2659,10 +2740,25 @@ export class RunStore {
         next_fire_at text,
         prompt_body text not null,
         state text not null,
+        allow_overlap integer not null default 0,
+        catch_up text not null default 'skip',
         last_fired_at text,
+        last_attempted_at text,
+        last_skip_reason text,
+        last_skip_at text,
         created_at text not null,
         updated_at text not null,
         primary key (project_name, name)
+      );
+
+      create table if not exists routine_skip_counts (
+        project_name text not null,
+        routine_name text not null,
+        reason text not null,
+        skipped_at text not null,
+        count integer not null,
+        primary key (project_name, routine_name, reason, skipped_at),
+        foreign key (project_name, routine_name) references routines(project_name, name) on delete cascade
       );
 
       create table if not exists routine_firings (
@@ -2727,6 +2823,11 @@ export class RunStore {
       ["routines", "schedule_cron", "text"],
       ["routines", "schedule_tz", "text"],
       ["routines", "next_fire_at", "text"],
+      ["routines", "allow_overlap", "integer not null default 0"],
+      ["routines", "catch_up", "text not null default 'skip'"],
+      ["routines", "last_attempted_at", "text"],
+      ["routines", "last_skip_reason", "text"],
+      ["routines", "last_skip_at", "text"],
       ["routine_firings", "prompt_path", "text"],
       ["routine_firings", "raw_log_path", "text"],
       ["routine_firings", "normalized_log_path", "text"]
@@ -3169,8 +3270,13 @@ function mapProjectStateRow(row: ProjectStateRow): ProjectState {
 
 function mapRoutineRow(row: RoutineRow): RoutineStatus {
   return {
+    allowOverlap: row.allow_overlap === 1,
+    catchUp: row.catch_up,
     kind: row.kind,
+    lastAttemptedAt: row.last_attempted_at ?? null,
     lastFiredAt: row.last_fired_at ?? null,
+    lastSkipAt: row.last_skip_at ?? null,
+    lastSkipReason: row.last_skip_reason ?? null,
     name: row.name,
     nextFireAt: row.state === "active" ? row.next_fire_at : null,
     projectName: row.project_name,
@@ -3179,6 +3285,11 @@ function mapRoutineRow(row: RoutineRow): RoutineStatus {
     scheduleAt: row.schedule_at.length === 0 ? null : row.schedule_at,
     scheduleCron: row.schedule_cron ?? null,
     scheduleTz: row.schedule_tz ?? null,
+    skipCounts24h: {
+      catch_up_window: 0,
+      concurrency_cap: 0,
+      overlap: 0
+    },
     sourcePath: row.source_path,
     state: row.state
   };

--- a/src/status-dashboard.ts
+++ b/src/status-dashboard.ts
@@ -125,8 +125,8 @@ function formatRoutines(routines: RoutineStatus[]): string[] {
     return ["│   No routines configured"];
   }
   return [
-    "│   PROJECT      ROUTINE              STATE     NEXT_FIRE_AT              LAST_FIRED_AT             PRS",
-    "│   ------------------------------------------------------------------------------------------------",
+    "│   PROJECT      ROUTINE              STATE     NEXT_FIRE_AT              LAST_FIRED_AT             LAST_ATTEMPTED_AT         LAST_SKIP_REASON   LAST_SKIP_AT              SKIPS_24H                                                        PRS",
+    "│   -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------",
     ...routines.map((routine) =>
       [
         "│  ",
@@ -140,6 +140,14 @@ function formatRoutines(routines: RoutineStatus[]): string[] {
         " ",
         pad(truncate(routine.lastFiredAt ?? "-", 25), 25),
         " ",
+        pad(truncate(routine.lastAttemptedAt ?? "-", 25), 25),
+        " ",
+        pad(truncate(routine.lastSkipReason ?? "-", 18), 18),
+        " ",
+        pad(truncate(routine.lastSkipAt ?? "-", 25), 25),
+        " ",
+        formatRoutineSkipCounts(routine.skipCounts24h),
+        " ",
         formatRoutinePullRequestNumbers(routine.pullRequestNumbers)
       ].join("")
     )
@@ -150,6 +158,12 @@ function formatRoutinePullRequestNumbers(numbers: number[]): string {
   return numbers.length === 0
     ? "-"
     : numbers.map((number) => `#${number}`).join(",");
+}
+
+function formatRoutineSkipCounts(
+  counts: RoutineStatus["skipCounts24h"]
+): string {
+  return `overlap=${counts.overlap},concurrency_cap=${counts.concurrency_cap},catch_up_window=${counts.catch_up_window}`;
 }
 
 export function summarizeDashboardEvent(

--- a/tests/routine-daemon.test.ts
+++ b/tests/routine-daemon.test.ts
@@ -305,6 +305,71 @@ describe("daemon routine firing", () => {
       await daemon.stop();
     }
   });
+
+  it("fires exactly one missed recurring event on restart with catch-up enabled", async () => {
+    const root = await makeTempRoot();
+    const routine = {
+      catchUp: "fire_once_if_missed" as const,
+      kind: "report" as const,
+      name: "yearly-report",
+      prompt: "Report.",
+      provider: null,
+      schedule: { cron: "0 0 1 1 *", tz: "Etc/UTC" },
+      sourcePath: path.join(root, "yearly-report.md")
+    };
+    await writeRecurringRoutineProject(root, true);
+    const seededStore = openRunStore({
+      stateRoot: path.join(root, ".symphonika")
+    });
+    seededStore.syncRoutines("alpha", [routine], {
+      now: new Date("2020-06-01T00:00:00.000Z")
+    });
+    seededStore.close();
+    const providerInputs: ProviderRunInput[] = [];
+    const provider = quietProvider();
+    vi.mocked(provider.runAttempt).mockImplementation(async function* (input) {
+      await Promise.resolve();
+      providerInputs.push(input);
+      yield {
+        normalized: { exitCode: 0, type: "process_exit" },
+        raw: { code: 0, kind: "exit" }
+      };
+    });
+    const startedAt = Date.now();
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRoutineFiringId: () => "catch-up-fire",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi: {
+        addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareRoutineWorkspace: vi.fn().mockResolvedValue({
+        branchName: "main",
+        branchRef: "refs/remotes/origin/main",
+        cachePath: path.join(root, ".cache", "repo.git"),
+        reused: false,
+        workspacePath: path.join(root, "catch-up-workspace")
+      })
+    });
+
+    try {
+      await waitForProviderInputs(providerInputs, 1);
+      const routines = await waitForRoutine(daemon.url, "active");
+      expect(routines[0]?.lastFiredAt).toEqual(expect.any(String));
+      expect(new Date(routines[0]?.nextFireAt ?? 0).getTime()).toBeGreaterThan(
+        startedAt
+      );
+      await fetch(`${daemon.url}/api/poll-now`, { method: "POST" });
+      expect(providerInputs).toHaveLength(1);
+    } finally {
+      await daemon.stop();
+    }
+  });
 });
 
 function quietProvider(): AgentProvider {
@@ -344,7 +409,10 @@ async function writeRoutineProject(
   await writeProjectConfig(root, "alpha", ["./daily-report.md"]);
 }
 
-async function writeRecurringRoutineProject(root: string): Promise<void> {
+async function writeRecurringRoutineProject(
+  root: string,
+  catchUp = false
+): Promise<void> {
   await mkdir(root, { recursive: true });
   await writeFile(path.join(root, "WORKFLOW.md"), "Work.");
   await writeFile(
@@ -355,6 +423,7 @@ async function writeRecurringRoutineProject(root: string): Promise<void> {
       "schedule:",
       "  cron: yearly",
       "kind: report",
+      ...(catchUp ? ["catch_up: fire_once_if_missed"] : []),
       "---",
       "Report.",
       ""

--- a/tests/routine-declaration-loader.test.ts
+++ b/tests/routine-declaration-loader.test.ts
@@ -22,6 +22,65 @@ afterEach(async () => {
 });
 
 describe("RoutineDeclarationLoader", () => {
+  it("parses catch-up and overlap policy opt-ins", async () => {
+    const root = await makeTempRoot();
+    const routinePath = path.join(root, "catch-up-report.md");
+    await writeFile(
+      routinePath,
+      [
+        "---",
+        "name: catch-up-report",
+        "schedule:",
+        "  cron: daily",
+        "kind: report",
+        "catch_up: fire_once_if_missed",
+        "allow_overlap: true",
+        "---",
+        "Report.",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadRoutineDeclaration(routinePath);
+
+    expect(result.errors).toEqual([]);
+    expect(result.routine).toMatchObject({
+      allowOverlap: true,
+      catchUp: "fire_once_if_missed"
+    });
+  });
+
+  it.each([
+    [
+      "catch_up",
+      "catch_up: replay_all",
+      "catch_up must be fire_once_if_missed"
+    ],
+    ["allow_overlap", "allow_overlap: yes", "allow_overlap must be a boolean"]
+  ])("rejects an invalid %s policy", async (_policy, field, expectedError) => {
+    const root = await makeTempRoot();
+    const routinePath = path.join(root, "invalid-policy.md");
+    await writeFile(
+      routinePath,
+      [
+        "---",
+        "name: invalid-policy",
+        "schedule:",
+        "  cron: daily",
+        "kind: report",
+        field,
+        "---",
+        "Report.",
+        ""
+      ].join("\n")
+    );
+
+    const result = await loadRoutineDeclaration(routinePath);
+
+    expect(result.routine).toBeNull();
+    expect(result.errors.join("\n")).toContain(expectedError);
+  });
+
   it("parses a Markdown kind: git routine", async () => {
     const root = await makeTempRoot();
     const routinePath = path.join(root, "dependency-update.md");
@@ -43,6 +102,8 @@ describe("RoutineDeclarationLoader", () => {
 
     expect(result.errors).toEqual([]);
     expect(result.routine).toEqual({
+      allowOverlap: false,
+      catchUp: "skip",
       kind: "git",
       name: "dependency-update",
       prompt: "Update dependencies on {{branch.name}}.\n",
@@ -74,6 +135,8 @@ describe("RoutineDeclarationLoader", () => {
 
     expect(result.errors).toEqual([]);
     expect(result.routine).toEqual({
+      allowOverlap: false,
+      catchUp: "skip",
       kind: "report",
       name: "weekly-report",
       prompt: "Summarize {{project.name}} from {{workspace.path}}.\n",

--- a/tests/routine-dispatcher.test.ts
+++ b/tests/routine-dispatcher.test.ts
@@ -525,6 +525,212 @@ describe("RoutineFiringDispatcher", () => {
     }
   });
 
+  it.each([
+    {
+      expectedFires: [],
+      expectedNextFireAt: "2026-05-22T10:01:00.000Z",
+      gap: "shorter than the interval",
+      now: "2026-05-22T10:00:30.000Z"
+    },
+    {
+      expectedFires: ["catch-up-fire"],
+      expectedNextFireAt: "2026-05-22T10:02:00.000Z",
+      gap: "long enough to miss one interval",
+      now: "2026-05-22T10:01:30.000Z"
+    }
+  ])(
+    "handles a restart gap $gap",
+    async ({ expectedFires, expectedNextFireAt, now }) => {
+      const root = await makeTempRoot();
+      const stateRoot = path.join(root, ".symphonika");
+      const runStore = openRunStore({ stateRoot });
+      const provider = quietProvider();
+      const routine = {
+        ...minuteRoutine(root),
+        catchUp: "fire_once_if_missed" as const
+      };
+      runStore.syncRoutines("alpha", [routine], {
+        now: new Date("2026-05-22T09:59:30.000Z")
+      });
+      expect(
+        runStore.claimRoutineFiring({
+          firedAt: "2026-05-22T10:00:00.000Z",
+          firingId: "previous-fire",
+          nextFireAt: "2026-05-22T10:01:00.000Z",
+          projectName: "alpha",
+          providerCommand: "codex fake",
+          providerName: "codex",
+          routineName: "minute-report"
+        })
+      ).toBe(true);
+      runStore.completeRoutineFiring({
+        id: "previous-fire",
+        state: "succeeded"
+      });
+
+      try {
+        const result = await dispatchDueRoutines({
+          ...recurringDispatchInput({
+            activeRuns: new ActiveRunRegistry(),
+            provider,
+            root,
+            routine,
+            runStore
+          }),
+          createFiringId: () => "catch-up-fire",
+          now: new Date(now),
+          recomputeSchedulesFromNow: true
+        });
+
+        expect(result.fired).toEqual(expectedFires);
+        expect(provider.runAttempt).toHaveBeenCalledTimes(expectedFires.length);
+        expect(runStore.listRoutines()[0]?.nextFireAt).toBe(expectedNextFireAt);
+      } finally {
+        runStore.close();
+      }
+    }
+  );
+
+  it("fires one catch-up after restart when multiple recurring ticks were missed", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const runStore = openRunStore({ stateRoot });
+    const provider = quietProvider();
+    const routine = {
+      ...minuteRoutine(root),
+      catchUp: "fire_once_if_missed" as const
+    };
+    runStore.syncRoutines("alpha", [routine], {
+      now: new Date("2026-05-22T09:59:30.000Z")
+    });
+    expect(
+      runStore.claimRoutineFiring({
+        firedAt: "2026-05-22T10:00:00.000Z",
+        firingId: "previous-fire",
+        nextFireAt: "2026-05-22T10:01:00.000Z",
+        projectName: "alpha",
+        providerCommand: "codex fake",
+        providerName: "codex",
+        routineName: "minute-report"
+      })
+    ).toBe(true);
+    runStore.completeRoutineFiring({
+      id: "previous-fire",
+      state: "succeeded"
+    });
+
+    try {
+      const input = {
+        ...recurringDispatchInput({
+          activeRuns: new ActiveRunRegistry(),
+          provider,
+          root,
+          routine,
+          runStore
+        }),
+        createFiringId: () => "catch-up-fire",
+        now: new Date("2026-05-22T10:03:30.000Z"),
+        recomputeSchedulesFromNow: true
+      };
+
+      const first = await dispatchDueRoutines(input);
+      const second = await dispatchDueRoutines({
+        ...input,
+        createFiringId: () => "unexpected-fire",
+        recomputeSchedulesFromNow: false
+      });
+
+      expect(first.fired).toEqual(["catch-up-fire"]);
+      expect(second.fired).toEqual([]);
+      expect(provider.runAttempt).toHaveBeenCalledTimes(1);
+      expect(runStore.listRoutineFirings().map((firing) => firing.id)).toEqual([
+        "catch-up-fire",
+        "previous-fire"
+      ]);
+      expect(runStore.listRoutines()[0]).toMatchObject({
+        lastFiredAt: "2026-05-22T10:03:30.000Z",
+        nextFireAt: "2026-05-22T10:04:00.000Z"
+      });
+    } finally {
+      runStore.close();
+    }
+  });
+
+  it("records a catch-up window skip on restart when catch-up is omitted", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const runStore = openRunStore({ stateRoot });
+    const provider = quietProvider();
+    const routine = minuteRoutine(root);
+    const logger = pino({ enabled: false });
+    const logInfo = vi.spyOn(logger, "info");
+    runStore.syncRoutines("alpha", [routine], {
+      now: new Date("2026-05-22T09:59:30.000Z")
+    });
+    expect(
+      runStore.claimRoutineFiring({
+        firedAt: "2026-05-22T10:00:00.000Z",
+        firingId: "previous-fire",
+        nextFireAt: "2026-05-22T10:01:00.000Z",
+        projectName: "alpha",
+        providerCommand: "codex fake",
+        providerName: "codex",
+        routineName: "minute-report"
+      })
+    ).toBe(true);
+    runStore.completeRoutineFiring({
+      id: "previous-fire",
+      state: "succeeded"
+    });
+
+    try {
+      const result = await dispatchDueRoutines({
+        ...recurringDispatchInput({
+          activeRuns: new ActiveRunRegistry(),
+          provider,
+          root,
+          routine,
+          runStore
+        }),
+        logger,
+        now: new Date("2026-05-22T10:01:30.000Z"),
+        recomputeSchedulesFromNow: true
+      });
+
+      expect(result.fired).toEqual([]);
+      expect(result.skipped).toEqual([
+        {
+          projectName: "alpha",
+          reason: "catch_up_window",
+          routineName: "minute-report"
+        }
+      ]);
+      expect(runStore.listRoutineFirings().map((firing) => firing.id)).toEqual([
+        "previous-fire"
+      ]);
+      expect(
+        runStore.listRoutines({ now: new Date("2026-05-22T10:01:30.000Z") })[0]
+      ).toMatchObject({
+        lastAttemptedAt: "2026-05-22T10:01:30.000Z",
+        lastSkipAt: "2026-05-22T10:01:30.000Z",
+        lastSkipReason: "catch_up_window",
+        nextFireAt: "2026-05-22T10:02:00.000Z",
+        skipCounts24h: { catch_up_window: 1 }
+      });
+      expect(logInfo).toHaveBeenCalledWith(
+        {
+          reason: "catch_up_window",
+          routine: "minute-report",
+          scheduled_at: "2026-05-22T10:01:00.000Z"
+        },
+        "routine.skipped"
+      );
+      expect(provider.runAttempt).not.toHaveBeenCalled();
+    } finally {
+      runStore.close();
+    }
+  });
+
   it("skips a recurring tick at the concurrency cap and advances its schedule", async () => {
     const root = await makeTempRoot();
     const stateRoot = path.join(root, ".symphonika");
@@ -538,32 +744,51 @@ describe("RoutineFiringDispatcher", () => {
     });
     const provider = quietProvider();
     const routine = minuteRoutine(root);
+    const logger = pino({ enabled: false });
+    const logInfo = vi.spyOn(logger, "info");
     runStore.syncRoutines("alpha", [routine], {
       now: new Date("2026-05-22T09:59:30.000Z")
     });
 
     try {
-      const result = await dispatchDueRoutines(
-        recurringDispatchInput({
+      const result = await dispatchDueRoutines({
+        ...recurringDispatchInput({
           activeRuns,
           provider,
           root,
           routine,
           runStore
-        })
-      );
+        }),
+        logger
+      });
 
       expect(result.fired).toEqual([]);
       expect(result.skipped).toEqual([
         {
           projectName: "alpha",
-          reason: "project alpha max_in_flight (1) reached",
+          reason: "concurrency_cap",
           routineName: "minute-report"
         }
       ]);
       expect(runStore.listRoutineFirings()).toEqual([]);
       expect(runStore.listRoutines()[0]?.nextFireAt).toBe(
         "2026-05-22T10:01:00.000Z"
+      );
+      expect(
+        runStore.listRoutines({ now: new Date("2026-05-22T10:00:00.000Z") })[0]
+      ).toMatchObject({
+        lastAttemptedAt: "2026-05-22T10:00:00.000Z",
+        lastSkipAt: "2026-05-22T10:00:00.000Z",
+        lastSkipReason: "concurrency_cap",
+        skipCounts24h: { concurrency_cap: 1 }
+      });
+      expect(logInfo).toHaveBeenCalledWith(
+        {
+          reason: "concurrency_cap",
+          routine: "minute-report",
+          scheduled_at: "2026-05-22T10:00:00.000Z"
+        },
+        "routine.skipped"
       );
     } finally {
       activeRuns.unregister("issue-run");
@@ -577,6 +802,8 @@ describe("RoutineFiringDispatcher", () => {
     const runStore = openRunStore({ stateRoot });
     const provider = quietProvider();
     const routine = minuteRoutine(root);
+    const logger = pino({ enabled: false });
+    const logInfo = vi.spyOn(logger, "info");
     runStore.syncRoutines("alpha", [routine], {
       now: new Date("2026-05-22T09:59:30.000Z")
     });
@@ -589,21 +816,22 @@ describe("RoutineFiringDispatcher", () => {
     });
 
     try {
-      const result = await dispatchDueRoutines(
-        recurringDispatchInput({
+      const result = await dispatchDueRoutines({
+        ...recurringDispatchInput({
           activeRuns: new ActiveRunRegistry(),
           provider,
           root,
           routine,
           runStore
-        })
-      );
+        }),
+        logger
+      });
 
       expect(result.fired).toEqual([]);
       expect(result.skipped).toEqual([
         {
           projectName: "alpha",
-          reason: "routine overlap",
+          reason: "overlap",
           routineName: "minute-report"
         }
       ]);
@@ -614,7 +842,100 @@ describe("RoutineFiringDispatcher", () => {
         "2026-05-22T10:01:00.000Z"
       );
       expect(provider.runAttempt).not.toHaveBeenCalled();
+      expect(
+        runStore.listRoutines({ now: new Date("2026-05-22T10:00:00.000Z") })[0]
+      ).toMatchObject({
+        lastAttemptedAt: "2026-05-22T10:00:00.000Z",
+        lastSkipAt: "2026-05-22T10:00:00.000Z",
+        lastSkipReason: "overlap",
+        skipCounts24h: { overlap: 1 }
+      });
+      expect(logInfo).toHaveBeenCalledWith(
+        {
+          reason: "overlap",
+          routine: "minute-report",
+          scheduled_at: "2026-05-22T10:00:00.000Z"
+        },
+        "routine.skipped"
+      );
+      runStore.completeRoutineFiring({
+        id: "previous-fire",
+        state: "succeeded"
+      });
+      const beforeNextClock = await dispatchDueRoutines({
+        ...recurringDispatchInput({
+          activeRuns: new ActiveRunRegistry(),
+          provider,
+          root,
+          routine,
+          runStore
+        }),
+        now: new Date("2026-05-22T10:00:30.000Z")
+      });
+      const nextClock = await dispatchDueRoutines({
+        ...recurringDispatchInput({
+          activeRuns: new ActiveRunRegistry(),
+          provider,
+          root,
+          routine,
+          runStore
+        }),
+        now: new Date("2026-05-22T10:01:00.000Z")
+      });
+      expect(beforeNextClock.fired).toEqual([]);
+      expect(nextClock.fired).toEqual(["new-fire"]);
     } finally {
+      runStore.close();
+    }
+  });
+
+  it("fires an overlapping recurring tick when overlap is allowed", async () => {
+    const root = await makeTempRoot();
+    const stateRoot = path.join(root, ".symphonika");
+    const runStore = openRunStore({ stateRoot });
+    const provider = quietProvider();
+    const routine = { ...minuteRoutine(root), allowOverlap: true };
+    const activeRuns = new ActiveRunRegistry();
+    activeRuns.reserveSlot({
+      issueNumber: -1,
+      projectName: "alpha",
+      respectsIssueLabels: false,
+      runId: "previous-fire"
+    });
+    runStore.syncRoutines("alpha", [routine], {
+      now: new Date("2026-05-22T09:59:30.000Z")
+    });
+    runStore.createRoutineFiring({
+      id: "previous-fire",
+      projectName: "alpha",
+      providerCommand: "codex fake",
+      providerName: "codex",
+      routineName: "minute-report"
+    });
+
+    try {
+      const dispatchInput = recurringDispatchInput({
+        activeRuns,
+        provider,
+        root,
+        routine,
+        runStore
+      });
+      const project = dispatchInput.projects.get("alpha")!;
+      dispatchInput.projects = new Map([
+        ["alpha", { ...project, max_in_flight: 2 }]
+      ]);
+      const result = await dispatchDueRoutines(dispatchInput);
+
+      expect(result.fired).toEqual(["new-fire"]);
+      expect(result.skipped).toEqual([]);
+      expect(runStore.listRoutineFirings()).toEqual([
+        expect.objectContaining({ id: "new-fire", state: "succeeded" }),
+        expect.objectContaining({ id: "previous-fire", state: "queued" })
+      ]);
+      expect(provider.runAttempt).toHaveBeenCalledTimes(1);
+    } finally {
+      activeRuns.unregister("previous-fire");
       runStore.close();
     }
   });

--- a/tests/routine-store.test.ts
+++ b/tests/routine-store.test.ts
@@ -107,8 +107,13 @@ describe("RunStore routines", () => {
 
       expect(store.listRoutines()).toEqual([
         {
+          allowOverlap: false,
+          catchUp: "skip",
           kind: "report",
+          lastAttemptedAt: null,
           lastFiredAt: null,
+          lastSkipAt: null,
+          lastSkipReason: null,
           name: "daily-report",
           nextFireAt: "2026-05-22T10:00:00.000Z",
           projectName: "alpha",
@@ -117,6 +122,11 @@ describe("RunStore routines", () => {
           scheduleAt: "2026-05-22T10:00:00.000Z",
           scheduleCron: null,
           scheduleTz: null,
+          skipCounts24h: {
+            catch_up_window: 0,
+            concurrency_cap: 0,
+            overlap: 0
+          },
           sourcePath: "/tmp/daily-report.md",
           state: "active"
         }
@@ -150,8 +160,13 @@ describe("RunStore routines", () => {
 
       expect(store.listRoutines()).toEqual([
         {
+          allowOverlap: false,
+          catchUp: "skip",
           kind: "report",
+          lastAttemptedAt: null,
           lastFiredAt: null,
+          lastSkipAt: null,
+          lastSkipReason: null,
           name: "daily-report",
           nextFireAt: "2026-03-28T01:30:00.000Z",
           projectName: "alpha",
@@ -160,10 +175,70 @@ describe("RunStore routines", () => {
           scheduleAt: null,
           scheduleCron: "30 1 * * *",
           scheduleTz: "Europe/Lisbon",
+          skipCounts24h: {
+            catch_up_window: 0,
+            concurrency_cap: 0,
+            overlap: 0
+          },
           sourcePath: "/tmp/daily-report.md",
           state: "active"
         }
       ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("records a skipped clock attempt and exposes rolling 24-hour counts", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.syncRoutines(
+        "alpha",
+        [
+          {
+            allowOverlap: true,
+            catchUp: "fire_once_if_missed",
+            kind: "report",
+            name: "minute-report",
+            prompt: "Report.",
+            provider: null,
+            schedule: { cron: "* * * * *", tz: "Etc/UTC" },
+            sourcePath: "/tmp/minute-report.md"
+          }
+        ],
+        { now: new Date("2026-05-23T09:59:30.000Z") }
+      );
+
+      const skipped = store.skipRoutineFiring({
+        attemptedAt: "2026-05-23T10:00:00.000Z",
+        name: "minute-report",
+        nextFireAt: "2026-05-23T10:01:00.000Z",
+        projectName: "alpha",
+        reason: "overlap"
+      });
+
+      expect(skipped).toBe(true);
+      expect(store.listRoutineFirings()).toEqual([]);
+      expect(
+        store.listRoutines({ now: new Date("2026-05-23T10:00:00.000Z") })[0]
+      ).toMatchObject({
+        allowOverlap: true,
+        catchUp: "fire_once_if_missed",
+        lastAttemptedAt: "2026-05-23T10:00:00.000Z",
+        lastSkipAt: "2026-05-23T10:00:00.000Z",
+        lastSkipReason: "overlap",
+        nextFireAt: "2026-05-23T10:01:00.000Z",
+        skipCounts24h: {
+          catch_up_window: 0,
+          concurrency_cap: 0,
+          overlap: 1
+        }
+      });
+      expect(
+        store.listRoutines({ now: new Date("2026-05-24T10:00:00.001Z") })[0]
+          ?.skipCounts24h.overlap
+      ).toBe(0);
     } finally {
       store.close();
     }

--- a/tests/routine-store.test.ts
+++ b/tests/routine-store.test.ts
@@ -244,6 +244,75 @@ describe("RunStore routines", () => {
     }
   });
 
+  it("keeps a one-shot routine active and due after an overlap or concurrency-cap skip", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.syncRoutines("alpha", [
+        {
+          kind: "report",
+          name: "daily-report",
+          prompt: "Report.",
+          provider: "codex",
+          schedule: { at: "2026-05-22T10:00:00.000Z" },
+          sourcePath: "/tmp/daily-report.md"
+        }
+      ]);
+
+      const overlapSkipped = store.skipRoutineFiring({
+        attemptedAt: "2026-05-22T10:00:00.000Z",
+        name: "daily-report",
+        projectName: "alpha",
+        reason: "overlap"
+      });
+      expect(overlapSkipped).toBe(true);
+      expect(
+        store.listRoutines({ now: new Date("2026-05-22T10:00:01.000Z") })[0]
+      ).toEqual(
+        expect.objectContaining({
+          lastSkipReason: "overlap",
+          nextFireAt: "2026-05-22T10:00:00.000Z",
+          state: "active"
+        })
+      );
+
+      const capSkipped = store.skipRoutineFiring({
+        attemptedAt: "2026-05-22T10:00:01.000Z",
+        name: "daily-report",
+        projectName: "alpha",
+        reason: "concurrency_cap"
+      });
+      expect(capSkipped).toBe(true);
+      expect(
+        store.listRoutines({ now: new Date("2026-05-22T10:00:02.000Z") })[0]
+      ).toEqual(
+        expect.objectContaining({
+          lastSkipReason: "concurrency_cap",
+          nextFireAt: "2026-05-22T10:00:00.000Z",
+          skipCounts24h: {
+            catch_up_window: 0,
+            concurrency_cap: 1,
+            overlap: 1
+          },
+          state: "active"
+        })
+      );
+
+      store.createRoutineFiring({
+        id: "fire-1",
+        projectName: "alpha",
+        providerCommand: "codex fake",
+        providerName: "codex",
+        routineName: "daily-report"
+      });
+      expect(store.listRoutineFirings()).toEqual([
+        expect.objectContaining({ id: "fire-1", routineName: "daily-report" })
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
   it("removes routines that are no longer configured for the project", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });

--- a/tests/routine-surfaces.test.ts
+++ b/tests/routine-surfaces.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { buildCli } from "../src/cli.js";
 import { createHttpApp } from "../src/http/app.js";
+import { nextRecurringFireAt } from "../src/routines/schedule.js";
 import { openRunStore } from "../src/run-store.js";
 import { renderStatusDashboard } from "../src/status-dashboard.js";
 
@@ -27,6 +28,109 @@ afterEach(async () => {
 });
 
 describe("routine operator surfaces", () => {
+  it("shows skip metadata and 24-hour counts on every routine status surface", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    const now = new Date();
+    const schedule = { cron: "* * * * *", tz: "Etc/UTC" };
+    store.syncRoutines(
+      "alpha",
+      [
+        {
+          kind: "report",
+          name: "minute-report",
+          prompt: "Report.",
+          provider: null,
+          schedule,
+          sourcePath: "/tmp/minute-report.md"
+        }
+      ],
+      { now: new Date(now.getTime() - 2 * 60_000) }
+    );
+    expect(
+      store.skipRoutineFiring({
+        attemptedAt: now.toISOString(),
+        name: "minute-report",
+        nextFireAt: nextRecurringFireAt(schedule, now),
+        projectName: "alpha",
+        reason: "overlap"
+      })
+    ).toBe(true);
+
+    try {
+      const app = createHttpApp({
+        runStore: store,
+        stateRoot,
+        version: "0.1.0"
+      });
+      const apiResponse = await app.request("/api/routines");
+      const apiBody = (await apiResponse.json()) as {
+        routines: Array<Record<string, unknown>>;
+      };
+      expect(apiBody.routines[0]).toMatchObject({
+        lastAttemptedAt: now.toISOString(),
+        lastSkipAt: now.toISOString(),
+        lastSkipReason: "overlap",
+        skipCounts24h: {
+          catch_up_window: 0,
+          concurrency_cap: 0,
+          overlap: 1
+        }
+      });
+
+      const pageResponse = await app.request("/");
+      const page = await pageResponse.text();
+      expect(page).toContain("last_attempted_at");
+      expect(page).toContain("overlap=1");
+
+      const dashboard = renderStatusDashboard({
+        daemon: "running",
+        issueCounts: {
+          candidate: 0,
+          failed: 0,
+          filtered: 0,
+          running: 0,
+          stale: 0
+        },
+        lastPollOutcome: "ok",
+        latestEvents: new Map(),
+        projects: [],
+        reload: "ok",
+        routines: store.listRoutines(),
+        runs: [],
+        stateRoot
+      });
+      expect(dashboard).toContain("overlap=1");
+
+      const output = { stderr: "", stdout: "" };
+      const program = buildCli({
+        openRunStore: () => openRunStore({ stateRoot }),
+        registerSignalHandlers: false
+      });
+      program.configureOutput({
+        writeErr: (message) => {
+          output.stderr += message;
+        },
+        writeOut: (message) => {
+          output.stdout += message;
+        }
+      });
+      program.exitOverride();
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "routines",
+        "--config",
+        path.join(stateRoot, "symphonika.yml")
+      ]);
+      expect(output.stdout).toContain("last_attempted_at");
+      expect(output.stdout).toContain("last_skip_reason");
+      expect(output.stdout).toContain("overlap=1");
+    } finally {
+      store.close();
+    }
+  });
+
   it("GET /api/routines returns routine status rows", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });
@@ -212,10 +316,10 @@ describe("routine operator surfaces", () => {
     ]);
 
     expect(output.stdout).toContain(
-      "project  routine  state  next_fire_at  last_fired_at  pull_requests"
+      "project  routine  state  next_fire_at  last_fired_at  last_attempted_at  last_skip_reason  last_skip_at  skips_24h  pull_requests"
     );
     expect(output.stdout).toContain(
-      "alpha  daily-report  active  2026-05-22T10:00:00.000Z  -  #42"
+      "alpha  daily-report  active  2026-05-22T10:00:00.000Z  -  -  -  -  overlap=0,concurrency_cap=0,catch_up_window=0  #42"
     );
   });
 

--- a/tests/routine-workspace.test.ts
+++ b/tests/routine-workspace.test.ts
@@ -27,6 +27,43 @@ afterEach(async () => {
 });
 
 describe("Routine workspace preparation", () => {
+  it("isolates overlapping git firings by firing id", async () => {
+    const root = await makeTempRoot();
+    const remotePath = await createRemoteRepository(root);
+    const workspaceRoot = path.join(root, "workspaces", "alpha");
+    const project = {
+      name: "alpha",
+      workspace: {
+        git: { base_branch: "main", remote: remotePath },
+        root: workspaceRoot
+      }
+    };
+
+    const first = await prepareRoutineWorkspace({
+      configDir: root,
+      firingId: "01JABCDEFGHJKMNPQRSTVWXYZ12",
+      kind: "git",
+      project,
+      routineName: "dependency-update"
+    });
+    const second = await prepareRoutineWorkspace({
+      configDir: root,
+      firingId: "01KLMNOPQRJKMNPQRSTVWXYZ12",
+      kind: "git",
+      project,
+      routineName: "dependency-update"
+    });
+
+    expect(first.workspacePath).not.toBe(second.workspacePath);
+    expect(first.branchName).not.toBe(second.branchName);
+    await expect(
+      git(["-C", first.workspacePath, "rev-parse", "--abbrev-ref", "HEAD"])
+    ).resolves.toBe(first.branchName);
+    await expect(
+      git(["-C", second.workspacePath, "rev-parse", "--abbrev-ref", "HEAD"])
+    ).resolves.toBe(second.branchName);
+  });
+
   it("creates a deterministic kind: git branch from the project base", async () => {
     const root = await makeTempRoot();
     const remotePath = await createRemoteRepository(root);


### PR DESCRIPTION
## Summary

- add catch-up and overlap front-matter policies with safe omitted defaults
- persist uniform catch-up-window, overlap, and concurrency-cap skip evidence plus exact rolling 24-hour counters
- expose attempt/skip status in the routines API, web and terminal dashboards, and CLI
- document the policy and counter-evidence decision in SPEC, CONTEXT, and ADR 0058

## Verification

- npm run lint
- npm run typecheck
- npm test (69 files, 698 tests)
- npm run build

Closes #192