### PR TITLE
feat(lifecycle): add blocked RunState distinct from failed

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,7 +60,7 @@ label drift but still stop when the Issue closes.
 _Avoid_: dispatch eligibility when referring to active-run or scheduled-work re-checks
 
 **Operational Label**:
-A GitHub issue label owned by the orchestrator for dispatch safety and runtime bookkeeping; v1 labels are `sym:claimed`, `sym:running`, `sym:failed`, and `sym:stale`.
+A GitHub issue label owned by the orchestrator for dispatch safety and runtime bookkeeping; v1 labels are `sym:claimed`, `sym:running`, `sym:failed`, `sym:blocked`, and `sym:stale`.
 _Avoid_: workflow label
 
 **Workflow Label**:
@@ -70,6 +70,13 @@ _Avoid_: operational label
 **Stale Claim**:
 A durable orchestrator claim on an issue for which no live local run exists.
 _Avoid_: failed run
+
+**Blocked Run**:
+A Run that reached a deterministic, non-actionable terminal outcome — the agent correctly declined
+the task (`no_workspace_changes`) or a raw FSM workflow reached a `blocked` terminal state — as
+opposed to a `failed` Run, which is reserved for outcomes that indicate something actually broke
+(crash, malformed event, workspace-prep error, unexpected exit code). See ADR 0058.
+_Avoid_: failed run, error
 
 **Issue Reservation**:
 The orchestrator's exclusive claim on a Project's Issue, whether currently in flight as an

--- a/SPEC.md
+++ b/SPEC.md
@@ -88,7 +88,7 @@ An issue is eligible when all are true:
 - it has every configured `labels_all` label
 - it has none of the configured `labels_none` labels
 - it does not have blocking operational labels
-- it is not already running, claimed, failed, or stale according to the orchestrator
+- it is not already running, claimed, failed, blocked, or stale according to the orchestrator
 
 v1 uses labels only for blocking. Symphonika does not parse issue body text, task lists, GitHub
 Projects fields, or linked PRs to infer blockers.
@@ -100,6 +100,7 @@ Symphonika owns this narrow GitHub label namespace:
 - `sym:claimed`
 - `sym:running`
 - `sym:failed`
+- `sym:blocked`
 - `sym:stale`
 
 The orchestrator may write these labels for dispatch safety and runtime bookkeeping. Workflow
@@ -651,6 +652,12 @@ On failed deterministic terminal state:
 - add `sym:failed`
 - preserve `sym:claimed` until operator action
 
+On blocked deterministic terminal state (see §12.1, ADR 0058):
+
+- remove `sym:running`
+- add `sym:blocked`
+- preserve `sym:claimed` until operator action
+
 On closed issue:
 
 - cancel active run
@@ -821,6 +828,8 @@ Normalized lifecycle states:
 - `running`
 - `input_required` (transient or legacy only; durable provider-input failures are `failed`)
 - `failed`
+- `blocked` (non-actionable no-op or FSM-declared block — see below; distinct from `failed`, which
+  is reserved for outcomes that indicate something actually broke)
 - `succeeded`
 - `cancelled`
 - `stale`
@@ -834,15 +843,21 @@ On provider exit code 0:
 
 1. Inspect the Workspace issue branch against
    `refs/remotes/origin/<configured-base-branch>..HEAD`.
-2. If the branch has zero commits ahead of base, mark the run `failed` with deterministic terminal
-   reason `no_workspace_changes`.
+2. If the branch has zero commits ahead of base, mark the run `blocked` with deterministic terminal
+   reason `no_workspace_changes` and add `sym:blocked`. This covers the agent correctly declining
+   the task (e.g. the target was already superseded) — exit 0, zero commits, nothing broken.
 3. If Workspace inspection fails, mark the run `failed` with deterministic terminal reason
-   `workspace_inspection_failed`.
+   `workspace_inspection_failed` and add `sym:failed`. This is a real failure (the `git` inspection
+   command itself errored), unlike case 2.
 4. If the branch is ahead of base, mark run `succeeded`.
 5. Remove `sym:running`.
 6. Re-check GitHub issue.
 7. If the issue remains eligible, schedule a short continuation.
 8. If the continuation cap is reached, mark `sym:failed` and surface the reason.
+
+For raw FSM workflows, a state whose `terminal` is `blocked` (§12.2) produces RunState `blocked` and
+`sym:blocked`, mirroring case 2 above; a state whose `terminal` is `failure` produces RunState
+`failed` and `sym:failed`, mirroring case 3. See ADR 0058.
 
 Default continuation delay: about 1 second.
 
@@ -856,9 +871,10 @@ For raw FSM workflows, retryable transient failures consume the retry budget bef
 FSM transitions matching the failure signals are allowed to advance or park the workflow. The retry
 re-enters the same FSM state and preserves the state-advance label-immunity bit when the failed run
 was already mid-walk. Terminal `failure` / `blocked` transitions remain workflow-authored
-deterministic verdicts and pre-empt retry. After the retry budget is exhausted, the final attempt's
-signals are evaluated normally by the FSM; if no workflow transition handles them, the run follows
-the exhausted-retry failure path below.
+deterministic verdicts and pre-empt retry — `failure` maps to RunState `failed` (`sym:failed`),
+`blocked` maps to RunState `blocked` (`sym:blocked`). After the retry budget is exhausted, the final
+attempt's signals are evaluated normally by the FSM; if no workflow transition handles them, the run
+follows the exhausted-retry failure path below.
 
 Default retry policy:
 
@@ -866,17 +882,17 @@ Default retry policy:
 - delays: about `10s`, `30s`, `2m`
 - maximum backoff: `5m`
 
-Do not automatically retry deterministic failures:
+Do not automatically retry these deterministic terminal outcomes:
 
-- prompt render error
-- invalid config
-- missing workflow
-- input required
-- continuation cap reached
-- no workspace commits ahead of base after provider exit code 0
-- workspace success inspection failure
-- workspace branch conflict
-- Project validation failure
+- prompt render error (`failed`)
+- invalid config (`failed`)
+- missing workflow (`failed`)
+- input required (`failed`)
+- continuation cap reached (`failed`)
+- no workspace commits ahead of base after provider exit code 0 (`blocked` — see §12.1)
+- workspace success inspection failure (`failed`)
+- workspace branch conflict (`failed`)
+- Project validation failure (`failed`)
 
 After retry exhaustion:
 

--- a/docs/adr/0058-blocked-run-state.md
+++ b/docs/adr/0058-blocked-run-state.md
@@ -1,0 +1,82 @@
+# Split "agent correctly declined" out of the `failed` RunState
+
+`RunState` (`src/run-store.ts`) had one value, `failed`, for two very different situations: a
+provider crash, malformed event, workspace-prep error, or unexpected exit code (something actually
+broke), and an agent that inspected the issue, correctly decided the task was not actionable (most
+often because another Run had already superseded it), commented on the issue, and exited cleanly
+with zero commits (nothing broke — the autonomy contract in ADR 0043 working as intended). Both
+rendered identically: `sym:failed` on the GitHub issue, a red "failed" pill in the web UI
+(`stateFamily()` in `src/http/pages.ts`), and the same line in the CLI status dashboard's Attention
+section.
+
+A sample of the last 50 Runs across all Projects found 17 `failed` Runs, of which 16 (94%) carried
+`terminal_reason = "no_workspace_changes"` — the deterministic-no-commits outcome from
+`classifyFailure` (`src/lifecycle/classify-failure.ts`), not a crash. Spending the alarming "failed"
+signal on routine, correct declines trains operators to stop trusting it — including for the 6%
+that are real failures. See issue #271 for the full incident writeup.
+
+## Decision
+
+`RunState` gains a `blocked` value, with a matching `sym:blocked` GitHub label (added to
+`REQUIRED_OPERATIONAL_LABELS` in `src/operational-labels.ts`, alongside `sym:claimed`,
+`sym:running`, `sym:failed`, `sym:stale`). `blocked` is the umbrella for "nothing broke, but an
+operator still needs to look" — it covers both:
+
+- **`no_workspace_changes`** — the agent exited 0 with zero commits ahead of base (§12.1 of
+  `SPEC.md`). This is the common case from the incident data above.
+- **`workflow_terminal_blocked`** — a raw FSM workflow reached a state whose `terminal` is
+  `blocked` (`fsm-expansion.ts` already distinguishes `success` / `failure` / `blocked` terminal
+  labels; only the last two were previously fused into RunState `failed` in
+  `fuseWorkflowTerminal`). This covers the broader "stuck, needs a human decision" case — e.g. a
+  PR follow-up workflow that cannot resolve merge conflicts or clear failing checks on its own.
+
+`workspace_inspection_failed` (the `git rev-list` inspection command itself erroring) stays
+`failed` — that is a real infrastructure problem, not a decline.
+
+**Detection is reason-based, not a new outcome kind, and unconditional.** `ClassifiedTerminal.kind`
+is untouched: both blocked reasons keep `kind: "failed"`, so every existing branch that reads
+`kind`/`classification` for retry and scheduling decisions
+(`deferRetryableTransientAdvance`, `willRetry`, `signalsFromTerminal`, the `fsmContinuing`
+suppression, the transient-retry branch in `scheduleNext`) is provably unaffected — this issue is
+explicit that retry/continuation scheduling must not change. A single reason-keyed helper,
+`isBlockedOutcome` in `src/lifecycle/run-controller.ts`, checks
+`outcome.reason ∈ {no_workspace_changes, workflow_terminal_blocked}` and is consulted only at the
+points that decide the RunState to persist (`mapOutcomeToRunState`) and which GitHub label to write
+(`applyTerminalLabels`, and its bail-out restore path in `scheduleNext`).
+
+The mapping is unconditional on the reason string alone — there is no attempt to detect "the agent
+left an explanatory issue comment" before downgrading a decline from `failed` to `blocked`. That
+would require either a GitHub API round-trip during classification or pattern-matching on
+provider tool-call events for a `gh issue comment` invocation; both are fragile, and a missed
+detection would silently re-hide exactly the declines this ADR exists to surface. The reason string
+is already a clean, race-free signal computed at classification time.
+
+## Consequences
+
+- **Eligibility is unchanged in shape.** `sym:blocked` is a required operational label exactly like
+  `sym:failed`: present, it blocks re-dispatch (`evaluateProjectEligibility` in
+  `src/issue-polling.ts` iterates `REQUIRED_OPERATIONAL_LABELS` uniformly); `init-project` /
+  `doctor` provision it the same way (`OPERATIONAL_LABEL_DESCRIPTIONS` in `src/doctor.ts`). Whatever
+  redispatch behavior an operator observed for `failed` issues today, they now observe for `blocked`
+  issues under the new label — this ADR only renames which label/state represents the outcome, not
+  when re-dispatch can happen.
+- **Closed-issue cleanup** removes `sym:blocked` alongside `sym:failed` and `sym:claimed`, so a
+  blocked issue that gets closed doesn't retain a stale label.
+- **UI**: `stateFamily()` gains a `blocked` family with its own pill color (violet, distinct from
+  the amber "in progress" and red "fail" families) in both the web dashboard and the CLI status
+  dashboard's Attention/Recent sections. The run-detail outcome banner renders calmer copy ("Run
+  blocked" instead of "Run failed") but still surfaces `terminal_reason`, since that's exactly what
+  an operator needs to decide whether to close the issue, relabel it, or leave it as-is.
+- **Not in scope**: Routine Firings (`src/routines/dispatcher.ts`, `RoutineFiringState`) have their
+  own independent `queued`/`preparing_workspace`/`running`/`succeeded`/`failed`/`cancelled` states
+  and their own `no_workspace_changes` handling (`SPEC.md` §8). They are a separate concept from
+  issue-dispatched Runs and are untouched here; a future ADR can decide whether the same split
+  applies there.
+- **Not in scope**: this ADR does not change what counts as eligible, does not auto-close or
+  auto-relabel GitHub issues based on agent verdicts, and does not touch the pre-existing
+  `input_required` RunState (declared in the `RunState` union but never actually written by any
+  code path today — a separate, older gap, out of scope for this issue).
+
+## Numbering
+
+ADR `0057` is the most recent number in tree; this ADR is `0058`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1381,6 +1381,7 @@ function isRunState(value: string): value is RunState {
     value === "running" ||
     value === "input_required" ||
     value === "failed" ||
+    value === "blocked" ||
     value === "succeeded" ||
     value === "cancelled" ||
     value === "stale"
@@ -1865,7 +1866,10 @@ function formatRecentRunSuffix(
   },
   store: RunStore
 ): string {
-  if (run.terminalReason === null || run.state !== "failed") {
+  if (
+    run.terminalReason === null ||
+    (run.state !== "failed" && run.state !== "blocked")
+  ) {
     return "";
   }
   const capKind = parseCapReachedReason(run.terminalReason);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -615,6 +615,7 @@ export async function startDaemon(
   const TERMINAL_STATES = new Set<RunState>([
     "cancelled",
     "failed",
+    "blocked",
     "input_required",
     "stale",
     "succeeded"

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -135,6 +135,11 @@ const OPERATIONAL_LABEL_DESCRIPTIONS: Record<
   (typeof REQUIRED_OPERATIONAL_LABELS)[number],
   LabelDescription
 > = {
+  "sym:blocked": {
+    color: "d4c5f9",
+    description:
+      "A Symphonika run reached a non-actionable blocked state (the agent declined the task, or a workflow needs a human decision). Not a crash."
+  },
   "sym:claimed": {
     color: "5319e7",
     description: "Symphonika has claimed this issue for an orchestrated run."

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -102,6 +102,7 @@ const KNOWN_RUN_STATES: ReadonlySet<RunState> = new Set([
   "running",
   "input_required",
   "failed",
+  "blocked",
   "succeeded",
   "cancelled",
   "stale",
@@ -111,6 +112,7 @@ const KNOWN_RUN_STATES: ReadonlySet<RunState> = new Set([
 const TERMINAL_RUN_STATES: ReadonlySet<RunState> = new Set([
   "cancelled",
   "failed",
+  "blocked",
   "input_required",
   "stale",
   "succeeded"

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -33,6 +33,7 @@ export type RegisterPagesOptions = {
 const TERMINAL_STATES: ReadonlySet<RunState> = new Set([
   "cancelled",
   "failed",
+  "blocked",
   "input_required",
   "stale",
   "succeeded"
@@ -44,12 +45,17 @@ const KNOWN_RUN_STATES: ReadonlySet<RunState> = new Set([
   "running",
   "input_required",
   "failed",
+  "blocked",
   "succeeded",
   "cancelled",
   "stale"
 ]);
 
 const FAILURE_STATES: ReadonlySet<RunState> = new Set(["failed", "stale"]);
+
+// Runs whose outcome banner should render, but with the calmer "blocked"
+// family/copy rather than the alarming "failed" one — see issue #271.
+const BLOCKED_STATES: ReadonlySet<RunState> = new Set(["blocked"]);
 
 // A single run's detail view is cheap to render; coalescing streamed message
 // tokens collapses hundreds of rows into a handful, so fetch a generous tail.
@@ -150,7 +156,8 @@ export function registerPages(options: RegisterPagesOptions): void {
     });
     const eventsTruncated = tailDesc.length > EVENT_TAIL_LIMIT;
     const events = tailDesc.slice(0, EVENT_TAIL_LIMIT).reverse();
-    const isFailure = FAILURE_STATES.has(detail.state);
+    const isFailure =
+      FAILURE_STATES.has(detail.state) || BLOCKED_STATES.has(detail.state);
     const terminalAttempt = detail.attempts[detail.attempts.length - 1];
     const failureEvent = isFailure
       ? options.runStore.getLastFailureEvent(id, terminalAttempt?.id)
@@ -246,7 +253,9 @@ const DARK_TOKENS = `
   --fail-ink: oklch(0.77 0.15 28);
   --fail-bg: oklch(0.31 0.075 28);
   --ok-ink: oklch(0.8 0.13 152);
-  --ok-bg: oklch(0.3 0.06 152);`;
+  --ok-bg: oklch(0.3 0.06 152);
+  --blocked-ink: oklch(0.8 0.13 300);
+  --blocked-bg: oklch(0.32 0.06 300);`;
 
 const STYLES = `${FONT_FACES}
 :root {
@@ -283,6 +292,8 @@ const STYLES = `${FONT_FACES}
   --fail-bg: oklch(0.945 0.04 28);
   --ok-ink: oklch(0.45 0.12 152);
   --ok-bg: oklch(0.94 0.05 152);
+  --blocked-ink: oklch(0.5 0.15 300);
+  --blocked-bg: oklch(0.945 0.035 300);
 }
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {${DARK_TOKENS}
@@ -444,6 +455,7 @@ td code { color: var(--ink-2); }
 .pill--progress { color: var(--progress-ink); background: var(--progress-bg); border-color: color-mix(in oklch, var(--progress-ink) 22%, transparent); }
 .pill--fail { color: var(--fail-ink); background: var(--fail-bg); border-color: color-mix(in oklch, var(--fail-ink) 22%, transparent); }
 .pill--ok { color: var(--ok-ink); background: var(--ok-bg); border-color: color-mix(in oklch, var(--ok-ink) 22%, transparent); }
+.pill--blocked { color: var(--blocked-ink); background: var(--blocked-bg); border-color: color-mix(in oklch, var(--blocked-ink) 22%, transparent); }
 .pill--neutral { color: var(--ink-muted); background: var(--surface-2); border-color: var(--border); }
 
 .fields {
@@ -528,12 +540,17 @@ td code { color: var(--ink-2); }
   padding: var(--sp-3) var(--sp-4);
   margin: 0 0 var(--sp-5);
 }
+.banner--blocked {
+  border-color: var(--blocked-ink);
+  background: var(--blocked-bg);
+}
 .banner-title {
   margin: 0 0 var(--sp-1);
   font-weight: 600;
   text-transform: capitalize;
   color: var(--fail-ink);
 }
+.banner--blocked .banner-title { color: var(--blocked-ink); }
 .banner-reason { margin: 0 0 var(--sp-2); white-space: pre-wrap; color: var(--ink); }
 .banner-context { margin: 0; font-size: var(--fs-meta); color: var(--ink-muted); }
 .banner-context code { color: var(--ink-2); }
@@ -582,7 +599,9 @@ ${body}
 </html>`;
 }
 
-function stateFamily(state: RunState): "ok" | "fail" | "progress" | "neutral" {
+function stateFamily(
+  state: RunState
+): "ok" | "fail" | "blocked" | "progress" | "neutral" {
   switch (state) {
     case "succeeded":
       return "ok";
@@ -590,6 +609,8 @@ function stateFamily(state: RunState): "ok" | "fail" | "progress" | "neutral" {
     case "cancelled":
     case "stale":
       return "fail";
+    case "blocked":
+      return "blocked";
     case "queued":
     case "preparing_workspace":
     case "running":
@@ -988,9 +1009,11 @@ function renderOutcomeBanner(
   failureEvent: ProviderEventRecord | undefined,
   exitEvent: ProviderEventRecord | undefined
 ): string {
-  // Only failure-state runs get a banner. A prior attempt's failure event must
-  // never surface on a run that ultimately succeeded or is still running.
-  if (!FAILURE_STATES.has(detail.state)) {
+  // Only failure- and blocked-state runs get a banner. A prior attempt's
+  // failure event must never surface on a run that ultimately succeeded or is
+  // still running.
+  const isBlocked = BLOCKED_STATES.has(detail.state);
+  if (!FAILURE_STATES.has(detail.state) && !isBlocked) {
     return "";
   }
   const providerMessage =
@@ -1002,7 +1025,9 @@ function renderOutcomeBanner(
   const reason =
     providerMessage !== undefined
       ? `<p class="banner-reason">${escapeHtml(providerMessage)}</p>`
-      : `<p class="banner-reason">No provider failure message was recorded. See the transcript and logs below.</p>`;
+      : isBlocked
+        ? `<p class="banner-reason">The agent finished without making workspace changes, or a workflow needs a human decision. See the terminal reason and transcript below.</p>`
+        : `<p class="banner-reason">No provider failure message was recorded. See the transcript and logs below.</p>`;
 
   const context: string[] = [];
   if (detail.terminalReason !== null) {
@@ -1019,7 +1044,8 @@ function renderOutcomeBanner(
     context.push(`event #${failureEvent.sequence}`);
   }
 
-  return `<section class="banner"><p class="banner-title">Run ${escapeHtml(detail.state)}</p>${reason}<p class="banner-context">${context.join(" &middot; ")}</p></section>`;
+  const bannerClass = isBlocked ? "banner banner--blocked" : "banner";
+  return `<section class="${bannerClass}"><p class="banner-title">Run ${escapeHtml(detail.state)}</p>${reason}<p class="banner-context">${context.join(" &middot; ")}</p></section>`;
 }
 
 // Exit code is reported only when abnormal: codex exits 0 even after refusing a

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -206,11 +206,12 @@ type ApplyLabelsInput = {
   // True when applyWorkflowOutcome advanced the raw-FSM walk to a non-terminal
   // next state or parked into a wait/merge_pr action. The per-state
   // ClassifiedTerminal may still be `failed` (e.g. a planning step that
-  // exited provider_success=true without committing → no_workspace_changes),
-  // but the workflow as a whole is continuing — so `sym:failed` must not be
-  // added on this transition or the issue will stay externally marked failed
-  // even after a later state succeeds (subsequent applyTerminalLabels calls
-  // only remove `sym:running`).
+  // exited provider_success=true without committing → no_workspace_changes,
+  // which isBlockedOutcome would otherwise map to `sym:blocked`), but the
+  // workflow as a whole is continuing — so neither `sym:failed` nor
+  // `sym:blocked` must be added on this transition or the issue will stay
+  // externally marked failed/blocked even after a later state succeeds
+  // (subsequent applyTerminalLabels calls only remove `sym:running`).
   fsmContinuing: boolean;
   issueNumber: number;
   outcome: ClassifiedTerminal;
@@ -2752,6 +2753,30 @@ export class RunController {
     );
   }
 
+  private async markIssueBlocked(input: {
+    issueNumber: number;
+    repository: GitHubIssueRepositoryInput;
+  }): Promise<void> {
+    const api = this.githubIssuesApi as LabelWritingGitHubIssuesApi;
+    try {
+      await api.addLabelsToIssue({
+        ...input.repository,
+        issueNumber: input.issueNumber,
+        labels: ["sym:blocked"]
+      });
+    } catch (err) {
+      this.logger?.warn(
+        { err, issueNumber: input.issueNumber },
+        "symphonika failed to add sym:blocked label; sym:claimed left in place"
+      );
+      return;
+    }
+    this.logger?.info(
+      { issueNumber: input.issueNumber },
+      "symphonika marked issue sym:blocked"
+    );
+  }
+
   private async applyTerminalLabels(input: ApplyLabelsInput): Promise<void> {
     const api = this.githubIssuesApi as LabelWritingGitHubIssuesApi;
     if (input.outcome.kind === "cancelled") {
@@ -2795,6 +2820,20 @@ export class RunController {
           {
             issueNumber: input.issueNumber,
             label: "sym:failed",
+            operation: "removeLabel",
+            phase: "closed-issue-cleanup"
+          }
+        );
+        await this.bestEffort(
+          () =>
+            api.removeLabelsFromIssue({
+              ...input.repository,
+              issueNumber: input.issueNumber,
+              labels: ["sym:blocked"]
+            }),
+          {
+            issueNumber: input.issueNumber,
+            label: "sym:blocked",
             operation: "removeLabel",
             phase: "closed-issue-cleanup"
           }
@@ -2843,10 +2882,17 @@ export class RunController {
       !input.willRetry &&
       !input.fsmContinuing
     ) {
-      await this.markIssueFailed({
-        issueNumber: input.issueNumber,
-        repository: input.repository
-      });
+      if (isBlockedOutcome(input.outcome)) {
+        await this.markIssueBlocked({
+          issueNumber: input.issueNumber,
+          repository: input.repository
+        });
+      } else {
+        await this.markIssueFailed({
+          issueNumber: input.issueNumber,
+          repository: input.repository
+        });
+      }
     }
   }
 
@@ -2933,21 +2979,29 @@ export class RunController {
       // stateAdvance != null implies it). What it did depends on the outcome:
       //
       // - `failed && !willRetry`: applyTerminalLabels suppressed `sym:failed`
-      //   on the assumption that the FSM would continue. The suppression
-      //   promise is now broken; restore `sym:failed` so the issue is not
-      //   orphaned with only `sym:claimed`. Then return — there is no retry
-      //   to fire and no continuation to schedule.
-      // - `failed && willRetry`: applyTerminalLabels did not add `sym:failed`
+      //   (or `sym:blocked`, see isBlockedOutcome) on the assumption that the
+      //   FSM would continue. The suppression promise is now broken; restore
+      //   whichever label matches the outcome so the issue is not orphaned
+      //   with only `sym:claimed`. Then return — there is no retry to fire and
+      //   no continuation to schedule.
+      // - `failed && willRetry`: applyTerminalLabels did not add either label
       //   (it short-circuited on `willRetry`). The transient-retry branch
       //   below is the right path; fall through so it fires.
-      // - `success`: applyTerminalLabels did not add `sym:failed`, and no
+      // - `success`: applyTerminalLabels did not add either label, and no
       //   retry applies. Fall through; `suppressContinuation` (always true
       //   when `stateAdvance != null`) ends the call.
       if (input.outcome.kind === "failed" && !input.willRetry) {
-        await this.markIssueFailed({
-          issueNumber: input.issue.number,
-          repository: input.repository
-        });
+        if (isBlockedOutcome(input.outcome)) {
+          await this.markIssueBlocked({
+            issueNumber: input.issue.number,
+            repository: input.repository
+          });
+        } else {
+          await this.markIssueFailed({
+            issueNumber: input.issue.number,
+            repository: input.repository
+          });
+        }
         return;
       }
       // For all other outcomes, fall through to the subsequent branches.
@@ -3233,7 +3287,26 @@ function indentReviewBody(body: string): string {
     .join("\n");
 }
 
+// Reason-based, not a new ClassifiedTerminal.kind: `kind` stays "failed" for
+// these outcomes so retry/classification/scheduling logic (deferRetryableTransientAdvance,
+// willRetry, signalsFromTerminal, fsmContinuing) is untouched by this
+// distinction — only RunState and the GitHub label branch downstream care.
+// See ADR 0058 / issue #271.
+const BLOCKED_TERMINAL_REASONS = new Set([
+  "no_workspace_changes",
+  "workflow_terminal_blocked"
+]);
+
+function isBlockedOutcome(outcome: ClassifiedTerminal): boolean {
+  return (
+    outcome.kind === "failed" && BLOCKED_TERMINAL_REASONS.has(outcome.reason)
+  );
+}
+
 function mapOutcomeToRunState(outcome: ClassifiedTerminal): RunState {
+  if (isBlockedOutcome(outcome)) {
+    return "blocked";
+  }
   switch (outcome.kind) {
     case "success":
       return "succeeded";

--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -1007,6 +1007,24 @@ export class RunController {
           terminalStateId: next.id,
           transitionReason: decision.reason
         });
+        // A wait/merge_pr row can advance straight into a workflow-authored
+        // `terminal: blocked` node (e.g. a PR follow-up that gives up on
+        // merge conflicts). Honor the same RunState/label contract as the
+        // provider-attempt path (ADR 0058) so the issue doesn't stay
+        // eligible for redispatch under a stale "succeeded" verdict.
+        if (next.terminal === "blocked") {
+          this.runStore.recordTerminalReason(
+            runId,
+            "workflow_terminal_blocked",
+            "deterministic"
+          );
+          this.runStore.updateRunState(runId, "blocked");
+          await this.markIssueBlocked({
+            issueNumber: refreshed.number,
+            repository
+          });
+          return;
+        }
         this.runStore.updateRunState(runId, "succeeded");
         return;
       }
@@ -1067,6 +1085,22 @@ export class RunController {
         terminalStateId: decision.stateId,
         transitionReason: `entered terminal state ${decision.terminal}`
       });
+      // See the matching `terminal === "blocked"` handling in the `advance`
+      // branch above — same ADR 0058 contract, reached via a direct
+      // terminate decision instead of an advance-to-terminal one.
+      if (decision.terminal === "blocked") {
+        this.runStore.recordTerminalReason(
+          runId,
+          "workflow_terminal_blocked",
+          "deterministic"
+        );
+        this.runStore.updateRunState(runId, "blocked");
+        await this.markIssueBlocked({
+          issueNumber: refreshed.number,
+          repository
+        });
+        return;
+      }
       this.runStore.updateRunState(runId, "succeeded");
     }
   }

--- a/src/operational-labels.ts
+++ b/src/operational-labels.ts
@@ -2,5 +2,6 @@ export const REQUIRED_OPERATIONAL_LABELS = [
   "sym:claimed",
   "sym:running",
   "sym:failed",
+  "sym:blocked",
   "sym:stale"
 ] as const;

--- a/src/run-store.ts
+++ b/src/run-store.ts
@@ -24,6 +24,7 @@ export type RunState =
   | "running"
   | "input_required"
   | "failed"
+  | "blocked"
   | "succeeded"
   | "cancelled"
   | "stale"

--- a/src/status-dashboard.ts
+++ b/src/status-dashboard.ts
@@ -46,11 +46,12 @@ const ACTIVE_RUN_STATES = new Set<RunState>([
   "waiting"
 ]);
 
-const ATTENTION_RUN_STATES = new Set<RunState>(["failed", "stale"]);
+const ATTENTION_RUN_STATES = new Set<RunState>(["failed", "blocked", "stale"]);
 
 const RECENT_RUN_STATES = new Set<RunState>([
   "cancelled",
   "failed",
+  "blocked",
   "stale",
   "succeeded"
 ]);
@@ -100,7 +101,7 @@ export function renderStatusDashboard(input: StatusDashboardInput): string {
     `│ State root: ${input.stateRoot}`,
     `│ Projects: ${validProjects} valid / ${invalidProjects} invalid`,
     `│ Issues: candidate ${input.issueCounts.candidate} | filtered ${input.issueCounts.filtered} | running ${input.issueCounts.running} | failed ${input.issueCounts.failed} | stale ${input.issueCounts.stale}`,
-    `│ Runs: active ${activeRuns.length} | succeeded ${runCounts.succeeded ?? 0} | failed ${runCounts.failed ?? 0} | cancelled ${runCounts.cancelled ?? 0} | total ${input.runs.length}`,
+    `│ Runs: active ${activeRuns.length} | succeeded ${runCounts.succeeded ?? 0} | failed ${runCounts.failed ?? 0} | blocked ${runCounts.blocked ?? 0} | cancelled ${runCounts.cancelled ?? 0} | total ${input.runs.length}`,
     `│ Last poll: ${input.lastPollOutcome}`,
     "├─ Active runs",
     ...formatActiveRuns(
@@ -238,7 +239,7 @@ function formatAttention(
     }
   }
   if (lines.length === 0) {
-    return ["│   No failed, input-required, or stale work"];
+    return ["│   No failed, blocked, input-required, or stale work"];
   }
   return lines;
 }

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -112,6 +112,41 @@ describe("CLI run commands", () => {
     expect(output.stdout).toContain("r-failed");
   });
 
+  it("status shows the terminal-reason suffix for blocked runs in the plain-text recent-runs listing", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "r-blocked",
+      issue: sampleIssue({ number: 5 }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.recordTerminalReason(
+      "r-blocked",
+      "no_workspace_changes",
+      "deterministic"
+    );
+    store.updateRunState("r-blocked", "blocked");
+    store.close();
+
+    const { output, program } = captureProgram(stateRoot);
+    await program.parseAsync([
+      "node",
+      "symphonika",
+      "status",
+      "--config",
+      path.join(stateRoot, "symphonika.yml")
+    ]);
+
+    expect(output.stdout).toContain("blocked: 1");
+    // Regression: blocked runs must keep the terminal-reason suffix that
+    // failed runs already show — see issue #271 / ADR 0058.
+    expect(output.stdout).toContain(
+      "r-blocked  alpha  #5  blocked  codex  — no_workspace_changes"
+    );
+  });
+
   it("status identifies only active runs inside the watchdog grace window", async () => {
     const stateRoot = await makeTempRoot();
     const store = openRunStore({ stateRoot });
@@ -1331,6 +1366,67 @@ describe("CLI run commands", () => {
     const verifyStore = openRunStore({ stateRoot });
     expect(verifyStore.getRun("cancel-live")?.cancelRequested).toBe(false);
     verifyStore.close();
+  });
+
+  it("cancel reports the correct already-blocked conflict message for a blocked run", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    store.createRun({
+      id: "cancel-blocked",
+      issue: sampleIssue({ number: 12 }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    store.recordTerminalReason(
+      "cancel-blocked",
+      "no_workspace_changes",
+      "deterministic"
+    );
+    store.updateRunState("cancel-blocked", "blocked");
+    store.close();
+
+    const cfg = path.join(stateRoot, "symphonika.yml");
+    const resolvedStateRoot = path.join(stateRoot, ".symphonika");
+    await mkdir(resolvedStateRoot, { recursive: true });
+    await writeFile(
+      path.join(resolvedStateRoot, "daemon.json"),
+      JSON.stringify({ url: "http://127.0.0.1:3030" }),
+      "utf8"
+    );
+    const { output, program } = captureProgram(stateRoot, {
+      fetch: (input: string | URL | Request) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.endsWith("/api/status")) {
+          return Promise.resolve(
+            Response.json({ stateRoot: resolvedStateRoot })
+          );
+        }
+        return Promise.resolve(
+          Response.json(
+            { kind: "already-terminal", state: "blocked" },
+            { status: 409 }
+          )
+        );
+      }
+    });
+    await expect(
+      program.parseAsync([
+        "node",
+        "symphonika",
+        "cancel",
+        "cancel-blocked",
+        "--config",
+        cfg
+      ])
+    ).rejects.toThrow();
+
+    expect(output.stderr).toContain("run cancel-blocked already blocked");
   });
 
   it("poll-now discovers the local daemon, preflights state root, and prints the poll summary", async () => {

--- a/tests/cli-runs.test.ts
+++ b/tests/cli-runs.test.ts
@@ -395,7 +395,9 @@ describe("CLI run commands", () => {
     expect(output.stdout).toContain(
       "watchdog idle since 2026-05-13T08:45:00.000Z"
     );
-    expect(output.stdout).toContain("No failed, input-required, or stale work");
+    expect(output.stdout).toContain(
+      "No failed, blocked, input-required, or stale work"
+    );
   });
 
   it("status --dashboard does not report input_required rows as active", async () => {

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -1499,11 +1499,13 @@ describe("daemon dispatch", () => {
 
     try {
       // Wait until both the planning and implementing rows have finished and
-      // had their workspace evidence written. Counting `state in ('failed',
+      // had their workspace evidence written. Counting `state in ('blocked',
       // 'succeeded')` avoids a race where the implementing continuation row
       // exists (insert is synchronous) but startAttempt has not yet populated
-      // `workspace_path`; the implementer also classifies as failed because
-      // the test provider exits clean without committing.
+      // `workspace_path`; the implementer also classifies as blocked (its own
+      // per-state result is no_workspace_changes, and its FSM fallback lands
+      // on a `terminal: blocked` node) because the test provider exits clean
+      // without committing.
       const deadline = Date.now() + 15_000;
       const databaseFile = path.join(root, ".symphonika", "symphonika.db");
       while (Date.now() < deadline) {
@@ -1512,7 +1514,7 @@ describe("daemon dispatch", () => {
           try {
             const row = database
               .prepare(
-                "select count(*) as c from runs where state in ('failed','succeeded')"
+                "select count(*) as c from runs where state in ('blocked','succeeded')"
               )
               .get() as { c: number };
             if (row.c >= 2) {
@@ -1544,12 +1546,13 @@ describe("daemon dispatch", () => {
         const planningRun = rows[0]!;
         const implementingRun = rows[1]!;
 
-        // The planning row classifies as failed (no commits → no_workspace_changes)
+        // The planning row classifies as blocked (no commits → no_workspace_changes,
+        // a non-actionable decline rather than a real failure — see ADR 0058)
         // but the workflow predicate engine still advanced the FSM. Both pieces
         // of state must be present on the row.
         expect(planningRun).toMatchObject({
           id: "run-fsm-advance-noop-1",
-          state: "failed",
+          state: "blocked",
           is_continuation: 0,
           current_state_id: "implementing",
           terminal_state_id: null,
@@ -1560,11 +1563,15 @@ describe("daemon dispatch", () => {
         );
 
         // The implementing run was spawned by the state advance, sharing the
-        // workspace with planning.
+        // workspace with planning. It also exits clean without committing, and
+        // its only fallback transition lands on a `terminal: blocked` FSM node,
+        // so it too records as blocked (not failed).
         expect(implementingRun).toMatchObject({
           id: "run-fsm-advance-noop-2",
           is_continuation: 1,
-          continuation_parent_run_id: "run-fsm-advance-noop-1"
+          continuation_parent_run_id: "run-fsm-advance-noop-1",
+          state: "blocked",
+          terminal_reason: "workflow_terminal_blocked"
         });
         expect(planningRun["workspace_path"]).toBe(workspacePath);
         expect(implementingRun["workspace_path"]).toBe(workspacePath);
@@ -1573,15 +1580,17 @@ describe("daemon dispatch", () => {
       }
 
       // Label hygiene: the planning step's per-state outcome classifies as
-      // failed (no_workspace_changes), but its workflow outcome advanced to
-      // `implementing`. applyTerminalLabels must NOT add `sym:failed` on
+      // blocked (no_workspace_changes), but its workflow outcome advanced to
+      // `implementing`. applyTerminalLabels must NOT add `sym:blocked` on
       // that transition — otherwise the issue stays externally marked
-      // failed even though a later state may succeed (subsequent
+      // blocked even though a later state may succeed (subsequent
       // applyTerminalLabels calls only remove `sym:running`). The
-      // implementing step does legitimately fail here (provider exits clean
-      // without committing → no_workspace_changes → no transition matches
-      // except the fallback `to: failed` terminal), so we expect exactly
-      // one `sym:failed` label add (from implementing's terminal), not two.
+      // implementing step does legitimately terminate here (provider exits
+      // clean without committing → no_workspace_changes → no transition
+      // matches except the fallback `to: failed` node, which is
+      // `terminal: blocked`), so we expect exactly one `sym:blocked` label
+      // add (from implementing's terminal), not two, and zero `sym:failed`
+      // adds — nothing here indicates a real failure.
       const failedLabelAdds =
         githubIssuesApi.addLabelsToIssue.mock.calls.filter(
           (call: unknown[]) => {
@@ -1589,21 +1598,29 @@ describe("daemon dispatch", () => {
             return args?.labels?.includes("sym:failed") === true;
           }
         );
-      expect(failedLabelAdds).toHaveLength(1);
+      expect(failedLabelAdds).toHaveLength(0);
+      const blockedLabelAdds =
+        githubIssuesApi.addLabelsToIssue.mock.calls.filter(
+          (call: unknown[]) => {
+            const args = call[0] as { labels?: string[] } | undefined;
+            return args?.labels?.includes("sym:blocked") === true;
+          }
+        );
+      expect(blockedLabelAdds).toHaveLength(1);
     } finally {
       await daemon.stop();
     }
   });
 
-  // Regression: when the FSM intends to advance after a failed-deterministic
-  // outcome, `applyTerminalLabels` suppresses `sym:failed` on the assumption
-  // that `executeStateAdvance` will run. But `scheduleNext`'s `stateAdvance`
-  // branch calls `refreshIssue` first, and that can bail on a transient
-  // GitHub API failure. Without restoration the run is persisted as failed
-  // and the issue has had `sym:running` removed but never gets `sym:failed`
-  // — stuck wearing only `sym:claimed`. Verify the rollback puts
-  // `sym:failed` back on `refreshIssue` failures.
-  it("restores sym:failed when a state-advance refresh aborts after fsmContinuing suppression", async () => {
+  // Regression: when the FSM intends to advance after a blocked-deterministic
+  // outcome (no_workspace_changes), `applyTerminalLabels` suppresses
+  // `sym:blocked` on the assumption that `executeStateAdvance` will run. But
+  // `scheduleNext`'s `stateAdvance` branch calls `refreshIssue` first, and
+  // that can bail on a transient GitHub API failure. Without restoration the
+  // run is persisted as blocked and the issue has had `sym:running` removed
+  // but never gets `sym:blocked` — stuck wearing only `sym:claimed`. Verify
+  // the rollback puts `sym:blocked` back on `refreshIssue` failures.
+  it("restores sym:blocked when a state-advance refresh aborts after fsmContinuing suppression", async () => {
     const root = await makeTempRoot();
     await writeTransitionOnlyMultiStateRawFsmProject(root);
 
@@ -1626,9 +1643,11 @@ describe("daemon dispatch", () => {
     const codexProvider = successfulCodexProvider();
     const preparedWorkspace = preparedWorkspaceFixture(root);
     // Base commit only — planning exits clean without committing →
-    // outcome.kind = failed, classification = deterministic. FSM matches
-    // `to: implementing when: provider_success: true`, so stateAdvance
-    // fires, but getIssue (via refreshIssue) throws → scheduleNext bails.
+    // outcome.kind = failed, classification = deterministic, reason =
+    // no_workspace_changes (which isBlockedOutcome maps to RunState
+    // "blocked"). FSM matches `to: implementing when: provider_success:
+    // true`, so stateAdvance fires, but getIssue (via refreshIssue) throws →
+    // scheduleNext bails.
     await createGitWorkspaceAtBase(preparedWorkspace);
 
     let runCounter = 0;
@@ -1658,7 +1677,7 @@ describe("daemon dispatch", () => {
           const database = new Database(databaseFile, { readonly: true });
           try {
             const row = database
-              .prepare("select count(*) as c from runs where state = 'failed'")
+              .prepare("select count(*) as c from runs where state = 'blocked'")
               .get() as { c: number };
             if (row.c >= 1) {
               break;
@@ -1671,7 +1690,7 @@ describe("daemon dispatch", () => {
         }
         await new Promise((resolve) => setTimeout(resolve, 20));
       }
-      // Give scheduleNext's bail-out path time to call markIssueFailed
+      // Give scheduleNext's bail-out path time to call markIssueBlocked
       // before reading the mock call list.
       await new Promise((resolve) => setTimeout(resolve, 50));
 
@@ -1686,7 +1705,7 @@ describe("daemon dispatch", () => {
         // any implementing row from being created.
         expect(rows).toHaveLength(1);
         expect(rows[0]).toMatchObject({
-          state: "failed",
+          state: "blocked",
           is_continuation: 0,
           current_state_id: "implementing"
         });
@@ -1694,15 +1713,15 @@ describe("daemon dispatch", () => {
         database.close();
       }
 
-      // The rollback restored `sym:failed` so the issue is not orphaned.
-      const failedLabelAdds =
+      // The rollback restored `sym:blocked` so the issue is not orphaned.
+      const blockedLabelAdds =
         githubIssuesApi.addLabelsToIssue.mock.calls.filter(
           (call: unknown[]) => {
             const args = call[0] as { labels?: string[] } | undefined;
-            return args?.labels?.includes("sym:failed") === true;
+            return args?.labels?.includes("sym:blocked") === true;
           }
         );
-      expect(failedLabelAdds).toHaveLength(1);
+      expect(blockedLabelAdds).toHaveLength(1);
     } finally {
       await daemon.stop();
     }
@@ -3081,7 +3100,7 @@ describe("daemon dispatch", () => {
   // entering a terminal node — that case still records state="succeeded"
   // because the workflow merely stalled. This test exercises the explicit
   // `terminal: blocked` node path, which is a workflow-author-declared failure.
-  it("walks a raw FSM workflow to a terminal blocked node and records the run as failed", async () => {
+  it("walks a raw FSM workflow to a terminal blocked node and records the run as blocked", async () => {
     const root = await makeTempRoot();
     await writeBlockedTerminalRawFsmProject(root);
 
@@ -3119,13 +3138,13 @@ describe("daemon dispatch", () => {
     });
 
     try {
-      const status = await waitForRun(daemon.url, "failed");
+      const status = await waitForRun(daemon.url, "blocked");
       await new Promise((resolve) => setTimeout(resolve, 100));
       const run = firstRun(status);
       expect(run).toMatchObject({
         id: "run-raw-fsm-terminal-blocked",
         issueNumber: 8,
-        state: "failed"
+        state: "blocked"
       });
 
       const finalStatus = (await fetch(`${daemon.url}/api/status`).then((r) =>
@@ -3148,7 +3167,7 @@ describe("daemon dispatch", () => {
           )
           .get("run-raw-fsm-terminal-blocked");
         expect(storedRun).toMatchObject({
-          state: "failed",
+          state: "blocked",
           current_state_id: null,
           terminal_state_id: "done",
           terminal_reason: "workflow_terminal_blocked",
@@ -3158,12 +3177,21 @@ describe("daemon dispatch", () => {
         database.close();
       }
 
+      // A workflow-declared `terminal: blocked` node is a non-actionable
+      // no-op verdict, not a real failure — it must add `sym:blocked`, not
+      // `sym:failed`. See ADR 0058 / issue #271.
       const failedLabelCalls =
         githubIssuesApi.addLabelsToIssue.mock.calls.filter((call) => {
           const arg = call[0] as { labels?: string[] } | undefined;
           return arg?.labels?.includes("sym:failed") ?? false;
         });
-      expect(failedLabelCalls.length).toBeGreaterThanOrEqual(1);
+      expect(failedLabelCalls).toHaveLength(0);
+      const blockedLabelCalls =
+        githubIssuesApi.addLabelsToIssue.mock.calls.filter((call) => {
+          const arg = call[0] as { labels?: string[] } | undefined;
+          return arg?.labels?.includes("sym:blocked") ?? false;
+        });
+      expect(blockedLabelCalls.length).toBeGreaterThanOrEqual(1);
     } finally {
       await daemon.stop();
     }

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -7,6 +7,7 @@ import pino from "pino";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resolveLogLevel, startDaemon } from "../src/daemon.js";
+import type { IssueSnapshot } from "../src/issue-polling.js";
 import { openRunStore, RunStore } from "../src/run-store.js";
 
 const tempRoots: string[] = [];
@@ -15,6 +16,22 @@ async function makeTempRoot(): Promise<string> {
   const root = await mkdtemp(path.join(tmpdir(), "symphonika-daemon-test-"));
   tempRoots.push(root);
   return root;
+}
+
+function sampleIssue(overrides: Partial<IssueSnapshot> = {}): IssueSnapshot {
+  return {
+    body: "",
+    created_at: "",
+    id: 1,
+    labels: [],
+    number: 1,
+    priority: 99,
+    state: "open",
+    title: "issue",
+    updated_at: "",
+    url: "",
+    ...overrides
+  };
 }
 
 afterEach(async () => {
@@ -61,6 +78,56 @@ describe("startDaemon", () => {
       await daemon.stop();
     }
     await expect(readFile(endpointPath, "utf8")).rejects.toThrow();
+  });
+
+  it("preserves a blocked run's terminal verdict when cancel is attempted (issue #271)", async () => {
+    const cwd = await makeTempRoot();
+    const stateRoot = path.join(cwd, ".symphonika");
+    const seedStore = openRunStore({ stateRoot });
+    seedStore.createRun({
+      id: "run-blocked",
+      issue: sampleIssue({ number: 9 }),
+      projectName: "alpha",
+      providerCommand: "x",
+      providerName: "codex"
+    });
+    seedStore.recordTerminalReason(
+      "run-blocked",
+      "no_workspace_changes",
+      "deterministic"
+    );
+    seedStore.updateRunState("run-blocked", "blocked");
+    seedStore.close();
+
+    const daemon = await startDaemon({
+      configPath: "symphonika.yml",
+      cwd,
+      logger: pino({ enabled: false }),
+      port: 0
+    });
+
+    try {
+      // Regression: src/daemon.ts wires createHttpApp with its own
+      // cancelViaUi closure (a THIRD independent copy of the terminal-states
+      // allowlist, distinct from pages.ts and http/app.ts's fallback). It
+      // must also treat "blocked" as terminal, or cancelling a blocked run
+      // wrongly proceeds and overwrites the verdict with "cancelled".
+      const response = await fetch(
+        `${daemon.url}/api/runs/run-blocked/cancel`,
+        { method: "POST" }
+      );
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        kind: "already-terminal",
+        state: "blocked"
+      });
+
+      const verifyStore = openRunStore({ stateRoot });
+      expect(verifyStore.getRun("run-blocked")?.state).toBe("blocked");
+      verifyStore.close();
+    } finally {
+      await daemon.stop();
+    }
   });
 
   it("cleans up the HTTP listener when endpoint descriptor writing fails", async () => {

--- a/tests/doctor-github.test.ts
+++ b/tests/doctor-github.test.ts
@@ -41,6 +41,7 @@ describe("GitHub Project validation", () => {
           "sym:claimed",
           "sym:running",
           "sym:failed",
+          "sym:blocked",
           "sym:stale"
         ]),
       validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
@@ -117,10 +118,15 @@ describe("GitHub Project validation", () => {
 
     expect(report.ok).toBe(false);
     expect(report.errors).toContain(
-      "projects.symphonika.tracker.repository pmatos/symphonika is missing operational labels: sym:running, sym:failed, sym:stale"
+      "projects.symphonika.tracker.repository pmatos/symphonika is missing operational labels: sym:running, sym:failed, sym:blocked, sym:stale"
     );
     expect(report.projects[0]).toMatchObject({
-      missingOperationalLabels: ["sym:running", "sym:failed", "sym:stale"],
+      missingOperationalLabels: [
+        "sym:running",
+        "sym:failed",
+        "sym:blocked",
+        "sym:stale"
+      ],
       validForDispatch: false
     });
     expect(githubApi.createLabel).not.toHaveBeenCalled();
@@ -138,6 +144,7 @@ describe("GitHub Project validation", () => {
           "sym:claimed",
           "sym:running",
           "sym:failed",
+          "sym:blocked",
           "sym:stale"
         ]),
       validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
@@ -252,7 +259,7 @@ describe("GitHub Project initialization", () => {
 
     expect(report.ok).toBe(false);
     expect(report.warnings).toContain(
-      "init-project would create operational labels in pmatos/symphonika: sym:running, sym:failed, sym:stale"
+      "init-project would create operational labels in pmatos/symphonika: sym:running, sym:failed, sym:blocked, sym:stale"
     );
     expect(report.errors).toContain(
       "pass --yes to create missing operational labels non-interactively"
@@ -279,13 +286,13 @@ describe("GitHub Project initialization", () => {
 
     expect(report.ok).toBe(true);
     expect(report.warnings).toContain(
-      "init-project will create operational labels in pmatos/symphonika: sym:running, sym:stale"
+      "init-project will create operational labels in pmatos/symphonika: sym:running, sym:blocked, sym:stale"
     );
     expect(report.projects[0]).toMatchObject({
-      createdOperationalLabels: ["sym:running", "sym:stale"],
-      missingOperationalLabels: ["sym:running", "sym:stale"]
+      createdOperationalLabels: ["sym:running", "sym:blocked", "sym:stale"],
+      missingOperationalLabels: ["sym:running", "sym:blocked", "sym:stale"]
     });
-    expect(githubApi.createLabel).toHaveBeenCalledTimes(2);
+    expect(githubApi.createLabel).toHaveBeenCalledTimes(3);
     expect(githubApi.createLabel).toHaveBeenNthCalledWith(1, {
       name: "sym:running",
       owner: "pmatos",
@@ -293,6 +300,12 @@ describe("GitHub Project initialization", () => {
       token: "secret-token"
     });
     expect(githubApi.createLabel).toHaveBeenNthCalledWith(2, {
+      name: "sym:blocked",
+      owner: "pmatos",
+      repo: "symphonika",
+      token: "secret-token"
+    });
+    expect(githubApi.createLabel).toHaveBeenNthCalledWith(3, {
       name: "sym:stale",
       owner: "pmatos",
       repo: "symphonika",
@@ -326,8 +339,9 @@ describe("GitHub Project initialization", () => {
     });
 
     expect(events).toEqual([
-      "warning:init-project will create operational labels in pmatos/symphonika: sym:failed, sym:stale",
+      "warning:init-project will create operational labels in pmatos/symphonika: sym:failed, sym:blocked, sym:stale",
       "create:sym:failed",
+      "create:sym:blocked",
       "create:sym:stale"
     ]);
   });
@@ -360,8 +374,8 @@ describe("GitHub Project initialization", () => {
       "projects.symphonika.tracker.repository pmatos/symphonika could not create operational label sym:stale: already exists"
     );
     expect(report.projects[0]).toMatchObject({
-      createdOperationalLabels: ["sym:running"],
-      missingOperationalLabels: ["sym:running", "sym:stale"]
+      createdOperationalLabels: ["sym:running", "sym:blocked"],
+      missingOperationalLabels: ["sym:running", "sym:blocked", "sym:stale"]
     });
   });
 });

--- a/tests/http-app-runs.test.ts
+++ b/tests/http-app-runs.test.ts
@@ -1141,4 +1141,46 @@ describe("HTTP app — runs API and pages", () => {
       test.cleanup();
     }
   });
+
+  it("renders a blocked run with the calmer blocked pill and banner, not the failed styling", async () => {
+    const test = await setup();
+    try {
+      test.runStore.createRun({
+        id: "run-blocked",
+        issue: sampleIssue({ number: 271, title: "Declined, superseded" }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.recordTerminalReason(
+        "run-blocked",
+        "no_workspace_changes",
+        "deterministic"
+      );
+      test.runStore.updateRunState("run-blocked", "blocked");
+
+      const app = createHttpApp({
+        runStore: test.runStore,
+        stateRoot: test.stateRoot,
+        version: "0.1.0"
+      });
+
+      const detail = await app.request("/runs/run-blocked");
+      expect(detail.status).toBe(200);
+      const body = await detail.text();
+      expect(body).toContain('pill pill--blocked"');
+      expect(body).not.toContain('pill pill--fail"');
+      expect(body).toContain("banner--blocked");
+      expect(body).toContain("Run blocked");
+      expect(body).toContain("no_workspace_changes");
+
+      const runsList = await app.request("/runs?state=blocked");
+      expect(runsList.status).toBe(200);
+      const runsListBody = await runsList.text();
+      expect(runsListBody).toContain("run-blocked");
+      expect(runsListBody).toContain('pill pill--blocked"');
+    } finally {
+      test.cleanup();
+    }
+  });
 });

--- a/tests/http-app-runs.test.ts
+++ b/tests/http-app-runs.test.ts
@@ -84,6 +84,14 @@ describe("HTTP app — runs API and pages", () => {
         providerName: "claude"
       });
       test.runStore.updateRunState("run-c", "failed");
+      test.runStore.createRun({
+        id: "run-d",
+        issue: sampleIssue({ number: 4 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.updateRunState("run-d", "blocked");
 
       const app = createHttpApp({
         runStore: test.runStore,
@@ -97,6 +105,15 @@ describe("HTTP app — runs API and pages", () => {
       const body = (await response.json()) as { runs: { id: string }[] };
       expect(response.status).toBe(200);
       expect(body.runs.map((r) => r.id)).toEqual(["run-b"]);
+
+      const blockedResponse = await app.request(
+        "/api/runs?state=blocked&project=alpha"
+      );
+      const blockedBody = (await blockedResponse.json()) as {
+        runs: { id: string }[];
+      };
+      expect(blockedResponse.status).toBe(200);
+      expect(blockedBody.runs.map((r) => r.id)).toEqual(["run-d"]);
     } finally {
       test.cleanup();
     }
@@ -387,6 +404,19 @@ describe("HTTP app — runs API and pages", () => {
         providerName: "codex"
       });
       test.runStore.updateRunState("needs-input", "input_required");
+      test.runStore.createRun({
+        id: "blocked-run",
+        issue: sampleIssue({ number: 14 }),
+        projectName: "alpha",
+        providerCommand: "x",
+        providerName: "codex"
+      });
+      test.runStore.recordTerminalReason(
+        "blocked-run",
+        "no_workspace_changes",
+        "deterministic"
+      );
+      test.runStore.updateRunState("blocked-run", "blocked");
 
       const app = createHttpApp({
         runStore: test.runStore,
@@ -426,6 +456,18 @@ describe("HTTP app — runs API and pages", () => {
         kind: "already-terminal",
         state: "input_required"
       });
+
+      // Regression: cancelling an already-blocked run must not overwrite its
+      // terminal verdict with "cancelled" — see issue #271 / ADR 0058.
+      const blocked = await app.request("/api/runs/blocked-run/cancel", {
+        method: "POST"
+      });
+      expect(blocked.status).toBe(409);
+      expect(await blocked.json()).toMatchObject({
+        kind: "already-terminal",
+        state: "blocked"
+      });
+      expect(test.runStore.getRun("blocked-run")?.state).toBe("blocked");
 
       const form = await app.request("/api/runs/live/cancel", {
         body: "",

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -342,7 +342,7 @@ describe("runSmoke", () => {
     expect(report.ok).toBe(false);
     expect(report.runDetail).toMatchObject({
       issueNumber,
-      state: "failed",
+      state: "blocked",
       terminalReason: "no_workspace_changes",
       workspacePath
     });
@@ -350,7 +350,7 @@ describe("runSmoke", () => {
     expect(report.errors[0]).toContain("terminalReason=no_workspace_changes");
     expect(githubIssuesApi.addLabelsToIssue).toHaveBeenCalledWith({
       issueNumber,
-      labels: ["sym:failed"],
+      labels: ["sym:blocked"],
       owner: "pmatos",
       repo: "symphonika",
       token: "test-token"

--- a/tests/status-dashboard-redraw.test.ts
+++ b/tests/status-dashboard-redraw.test.ts
@@ -1,6 +1,89 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { renderStatusDashboardRedrawFrame } from "../src/status-dashboard.js";
+import { openRunStore } from "../src/run-store.js";
+import {
+  renderStatusDashboard,
+  renderStatusDashboardRedrawFrame
+} from "../src/status-dashboard.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-dashboard-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+describe("renderStatusDashboard blocked runs", () => {
+  it("surfaces a blocked run in the Attention and Recent sections", async () => {
+    const stateRoot = await makeTempRoot();
+    const store = openRunStore({ stateRoot });
+    try {
+      store.createRun({
+        id: "blocked-run",
+        issue: {
+          body: "",
+          created_at: "2026-05-13T08:00:00.000Z",
+          id: 271,
+          labels: ["agent-ready"],
+          number: 271,
+          priority: 0,
+          state: "open",
+          title: "Superseded by other work",
+          updated_at: "2026-05-13T08:00:00.000Z",
+          url: "https://github.com/pmatos/symphonika/issues/271"
+        },
+        projectName: "alpha",
+        providerCommand: "codex fake",
+        providerName: "codex"
+      });
+      store.recordTerminalReason(
+        "blocked-run",
+        "no_workspace_changes",
+        "deterministic"
+      );
+      store.updateRunState("blocked-run", "blocked");
+
+      const runs = store.listRuns();
+      const dashboard = renderStatusDashboard({
+        daemon: "running",
+        issueCounts: {
+          candidate: 0,
+          failed: 0,
+          filtered: 0,
+          running: 0,
+          stale: 0
+        },
+        lastPollOutcome: "ok",
+        latestEvents: new Map(),
+        projects: [],
+        reload: "ok",
+        runs,
+        stateRoot
+      });
+
+      expect(dashboard).toContain(
+        "Runs: active 0 | succeeded 0 | failed 0 | blocked 1 | cancelled 0 | total 1"
+      );
+      expect(dashboard).toContain("blocked-run");
+      expect(dashboard).toContain("#271");
+      expect(dashboard).toContain("no_workspace_changes");
+    } finally {
+      store.close();
+    }
+  });
+});
 
 describe("status dashboard watch redraw frames", () => {
   it("renders the initial frame with cursor home, line erases, and a trailing erase-to-end-of-screen", () => {

--- a/tests/wait-state.test.ts
+++ b/tests/wait-state.test.ts
@@ -157,6 +157,84 @@ function gatedSuccessProvider(): GatedProvider {
   };
 }
 
+async function writeWaitStateBlockedTerminalProject(
+  root: string
+): Promise<void> {
+  await writeFile(
+    path.join(root, "symphonika.yml"),
+    [
+      "state:",
+      "  root: ./.symphonika",
+      "polling:",
+      "  interval_ms: 30000",
+      "providers:",
+      "  codex:",
+      `    command: "${DEFAULT_CODEX_COMMAND}"`,
+      "  claude:",
+      '    command: "claude -p --dangerously-skip-permissions --input-format stream-json --output-format stream-json"',
+      "projects:",
+      "  - name: symphonika",
+      "    disabled: false",
+      "    weight: 1",
+      "    tracker:",
+      "      kind: github",
+      "      owner: pmatos",
+      "      repo: symphonika",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked", "needs-human"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      "      root: ./.symphonika/workspaces/symphonika",
+      "      git:",
+      "        remote: git@github.com:pmatos/symphonika.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      "    workflow: ./workflow.yml",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: agent_then_wait_blocked",
+      "  initial: planning",
+      "  states:",
+      "    planning:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: plan-prompt.md",
+      "      complete_when:",
+      "        provider_success: true",
+      "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: holding",
+      "    holding:",
+      "      action:",
+      "        kind: wait",
+      "      transitions:",
+      "        - to: done",
+      "          when:",
+      "            checks: success",
+      "            mergeable: true",
+      "    done:",
+      "      terminal: blocked",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "plan-prompt.md"),
+    "Plan work on #{{issue.number}}.\n"
+  );
+}
+
 async function writeWaitStateProject(root: string): Promise<void> {
   await writeFile(
     path.join(root, "symphonika.yml"),
@@ -624,6 +702,68 @@ describe("wait state lifecycle", () => {
       expect(after?.terminalStateId).toBe("done");
       expect(after?.stateTransitionReason).toContain(
         "holding advanced to done"
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("records a waiting run as blocked (not succeeded) when it advances into a terminal: blocked node", async () => {
+    const root = await makeTempRoot();
+    await writeWaitStateBlockedTerminalProject(root);
+    const store = openRunStore({ stateRoot: path.join(root, ".symphonika") });
+    try {
+      const issue = issueFixture();
+      store.createRun({
+        id: "parent-run",
+        issue,
+        projectName: "symphonika",
+        providerCommand: DEFAULT_CODEX_COMMAND,
+        providerName: "codex"
+      });
+      store.updateRunState("parent-run", "succeeded");
+      store.createWaitingRun({
+        currentStateId: "holding",
+        id: "waiting-run",
+        issue,
+        parentRunId: "parent-run",
+        projectName: "symphonika"
+      });
+      store.trackPullRequest({
+        branchName: "sym/symphonika/8-wait-state-acceptance-fixture",
+        headSha: "deadbeef",
+        issueNumber: issue.number,
+        prNumber: 99,
+        prUrl: "https://example.test/pr/99",
+        projectName: "symphonika",
+        runId: "parent-run"
+      });
+
+      const githubIssuesApi: GitHubIssuesApi = {
+        addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+        getIssue: vi.fn().mockResolvedValue({
+          ...issue,
+          labels: issue.labels.map((name) => ({ name }))
+        }),
+        getPullRequestFollowupState: vi.fn().mockResolvedValue(prState()),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+      };
+      const controller = buildController({
+        githubIssuesApi,
+        project: projectFixture("./workflow.yml"),
+        root,
+        runStore: store
+      });
+
+      await controller.reEvaluateWaitingRun("waiting-run");
+
+      const after = store.getRun("waiting-run");
+      expect(after?.state).toBe("blocked");
+      expect(after?.terminalStateId).toBe("done");
+      expect(after?.terminalReason).toBe("workflow_terminal_blocked");
+      expect(githubIssuesApi.addLabelsToIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ["sym:blocked"] })
       );
     } finally {
       store.close();


### PR DESCRIPTION
## Summary

- `RunState` gains a `blocked` value (and matching `sym:blocked` GitHub label) for non-actionable, deterministic no-op outcomes — the agent correctly declined the task (`no_workspace_changes`) or a raw FSM workflow reached a `terminal: blocked` node — as distinct from `failed`, now reserved for outcomes that indicate something actually broke.
- Detection is reason-based (`no_workspace_changes` / `workflow_terminal_blocked`), not a new `ClassifiedTerminal.kind`, so retry/continuation scheduling logic is provably untouched.
- Web UI (`stateFamily`/pill/banner), CLI status dashboard, `doctor`/`init-project` label provisioning, `SPEC.md`, `CONTEXT.md`, and a new ADR (0058) are all updated to match.

Fixes #271

## Test plan

- [x] `npm test` — all passing (687/688; the one failure, `builds a missing dist bin during npm link`, is a pre-existing flake unrelated to this change, confirmed failing identically on `main`)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] New regression coverage: `daemon-dispatch.test.ts` (planning/implementing FSM walk to a `blocked` terminal, bail-out label restore), `http-app-runs.test.ts` (blocked pill/banner rendering), `status-dashboard-redraw.test.ts` (blocked run in Attention/Recent), `doctor-github.test.ts`/`smoke.test.ts` updated for the new label