### PR TITLE
fix(lifecycle): don't treat pre-attempt errors as executed workflow actions

### DIFF
--- a/src/lifecycle/run-controller.ts
+++ b/src/lifecycle/run-controller.ts
@@ -2266,6 +2266,7 @@ export class RunController {
         // classifyFailure outcome without an FSM-driven overlay.
         if (currentState !== undefined && loadedWorkflow !== undefined) {
           workflowOutcome = this.applyWorkflowOutcome({
+            actionExecuted: attemptCreated,
             currentState,
             deferRetryableTransientAdvance,
             issue: input.issue,
@@ -2496,6 +2497,7 @@ export class RunController {
   }
 
   private applyWorkflowOutcome(input: {
+    actionExecuted: boolean;
     currentState: ExpandedWorkflowState;
     deferRetryableTransientAdvance?: boolean;
     issue: IssueSnapshot;
@@ -2506,7 +2508,7 @@ export class RunController {
   }): WorkflowOutcomeResult {
     const signals = signalsFromTerminal(input.terminal);
     const decision = decideNextStep({
-      actionExecuted: true,
+      actionExecuted: input.actionExecuted,
       signals,
       state: input.currentState
     });

--- a/tests/daemon-dispatch.test.ts
+++ b/tests/daemon-dispatch.test.ts
@@ -3168,6 +3168,106 @@ describe("daemon dispatch", () => {
       await daemon.stop();
     }
   });
+
+  // Regression test for #272: a pre-attempt error (e.g. provider.validate()
+  // rejecting before any attempt row is created) must not be routed through
+  // the FSM as if the agent action had executed and legitimately fallen
+  // through to a workflow-declared `terminal: blocked` node. Distinct from
+  // the test above, where the agent genuinely runs and the workflow author's
+  // FSM deliberately routes a successful run to a blocked terminal.
+  it("does not reclassify a pre-attempt error as workflow_terminal_blocked", async () => {
+    const root = await makeTempRoot();
+    await writePreAttemptFallbackBlockedRawFsmProject(root);
+
+    const githubIssuesApi = {
+      addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+      listOpenIssues: vi
+        .fn()
+        .mockResolvedValueOnce([
+          issueFixture({
+            labels: ["agent-ready"],
+            number: 8,
+            title: "Dispatch an end-to-end run through a test provider"
+          })
+        ])
+        .mockResolvedValue([]),
+      removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+    };
+    const codexProvider = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      name: "codex" as const,
+      runAttempt: vi.fn(async function* (): AsyncGenerator<ProviderEvent> {
+        await Promise.resolve();
+        yield {
+          normalized: { exitCode: 0, type: "process_exit" },
+          raw: { code: 0, kind: "exit" }
+        };
+      }),
+      validate: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("simulated pre-attempt contention: max_in_flight reached")
+        )
+    } satisfies AgentProvider;
+    const preparedWorkspace = preparedWorkspaceFixture(root);
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: codexProvider },
+      createRunId: () => "run-pre-attempt-error",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi,
+      lifecyclePolicy: {
+        continuation: { cap: 0, delayMs: 0 },
+        retry: { cap: 0, delaysMs: [], maxBackoffMs: 0 }
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareIssueWorkspace: () => Promise.resolve(preparedWorkspace)
+    });
+
+    try {
+      const status = await waitForRun(daemon.url, "failed");
+      const run = firstRun(status);
+      expect(run).toMatchObject({
+        id: "run-pre-attempt-error",
+        issueNumber: 8,
+        state: "failed"
+      });
+
+      const database = new Database(
+        path.join(root, ".symphonika", "symphonika.db"),
+        { readonly: true }
+      );
+      try {
+        const storedRun = database
+          .prepare(
+            [
+              "select state, terminal_reason, failure_classification",
+              "from runs where id = ?"
+            ].join(" ")
+          )
+          .get("run-pre-attempt-error");
+        expect(storedRun).toMatchObject({
+          state: "failed",
+          terminal_reason:
+            "simulated pre-attempt contention: max_in_flight reached",
+          failure_classification: "transient"
+        });
+
+        const attemptCount = database
+          .prepare("select count(*) as c from attempts where run_id = ?")
+          .get("run-pre-attempt-error") as { c: number };
+        expect(attemptCount.c).toBe(0);
+      } finally {
+        database.close();
+      }
+
+      expect(codexProvider.runAttempt).not.toHaveBeenCalled();
+    } finally {
+      await daemon.stop();
+    }
+  });
 });
 
 function issueFixture(overrides: {
@@ -3400,6 +3500,40 @@ async function writeBlockedTerminalRawFsmProject(root: string): Promise<void> {
       "      complete_when:",
       "        provider_success: true",
       "        branch_ahead_of_base: true",
+      "      transitions:",
+      "        - to: done",
+      "    done:",
+      "      terminal: blocked",
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    path.join(root, "prompt.md"),
+    "Work on #{{issue.number}}: {{issue.title}}.\n"
+  );
+}
+
+// No `complete_when`, so decideNextStep never rejects on an unmet predicate,
+// and an unconditional fallback transition into a `terminal: blocked` node.
+// A run whose agent action never actually executed (a pre-attempt error, e.g.
+// contention or a provider.validate() failure) must not be routed through
+// this transition as if the agent had run and legitimately reached it.
+async function writePreAttemptFallbackBlockedRawFsmProject(
+  root: string
+): Promise<void> {
+  await writeRawFsmProjectConfig(root);
+  await writeFile(
+    path.join(root, "workflow.yml"),
+    [
+      "workflow:",
+      "  name: pre_attempt_fallback_blocked",
+      "  initial: run_agent",
+      "  states:",
+      "    run_agent:",
+      "      action:",
+      "        kind: agent",
+      "        provider: codex",
+      "        prompt: prompt.md",
       "      transitions:",
       "        - to: done",
       "    done:",


### PR DESCRIPTION
## Summary

- `applyWorkflowOutcome` hardcoded `actionExecuted: true` regardless of whether an attempt was ever created, so pre-attempt errors (contention, `provider.validate()` failures, claim races) were routed through `decideNextStep` as if the agent action had run and legitimately fallen through the workflow's transitions.
- When that landed on a `terminal: blocked` node, `fuseWorkflowTerminal` discarded the run's real transient classification and error message and replaced it with an unretryable, undiagnosable `workflow_terminal_blocked` — the exact symptom from the 24 zero-attempt runs described in #272.
- Thread the run controller's existing `attemptCreated` flag through `runAttemptLifecycle` as `actionExecuted`, so only genuine post-attempt outcomes (the agent actually ran) can take the FSM-transition path. Pre-attempt errors now flow through as ordinary `classifyFailure` verdicts with their real message and classification (typically `transient`, restoring retry eligibility).
- Genuine workflow-author-declared `terminal: blocked`/`terminal: failure` nodes reached after the agent actually runs are unaffected — `attemptCreated` is `true` in that case, same as before.

Fixes #272

## Test plan

- [x] `npm test` — all 687 tests passing
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] New regression test (`tests/daemon-dispatch.test.ts`) reproduces the bug against pre-fix code (red: `deterministic` + `workflow_terminal_blocked`, discarding the real error) and passes against the fix (green: original `transient` classification and message preserved, zero attempts recorded)