### PR TITLE
feat: split global and project initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ cd symphonika
 npm ci
 ```
 
+After linking or otherwise installing the CLI, initialize Symphonika once, then register each
+repository from inside its checkout:
+
+```sh
+npm link
+symphonika init
+cd /path/to/project
+symphonika init-project
+symphonika doctor
+```
+
+Both initialization commands show their defaults interactively. Use `--yes` for unattended setup;
+use `init --force` only to replace the global config, and `init-project --force` only to replace a
+Project with the same name. Export the GitHub credential referenced by the generated Project before
+running `init-project` or `doctor`.
+
 Run the local quality gate:
 
 ```sh

--- a/SPEC.md
+++ b/SPEC.md
@@ -222,11 +222,20 @@ dispatch, retry, continuation, provider-command selection, and PR follow-up poli
 reload is surfaced in structured logs and operator status while the daemon keeps using the last
 known good effective snapshot.
 
-`symphonika init` is the default first-run path for a project checkout. It runs from inside a
-GitHub-backed repository, derives the Project from `origin`, writes the user service config, chooses
-`$XDG_STATE_HOME/symphonika` (or `~/.local/state/symphonika`) as the state root, and creates a
-starter repository-owned `WORKFLOW.md` only when one does not already exist. It does not create
-GitHub operational labels; `init-project --yes` remains the explicit label-creation step.
+`symphonika init` initializes Symphonika's user Service Config independently of any repository. It
+prompts for service-level state, polling, pull-request merge policy, and Codex/Claude commands,
+writes `$XDG_CONFIG_HOME/symphonika/symphonika.yml` (or the home-directory fallback), and starts
+with `projects: []`. `--yes` accepts every displayed default without prompting, and `--force` is
+required to replace an existing user config.
+
+`symphonika init-project` runs inside a GitHub-backed repository and requires an existing selected
+Service Config. It derives repository defaults from `origin`, prompts for the Project name, Agent
+Provider, base branch, issue-label filters, priority-label mapping, and Workflow Contract path, and
+appends the Project without discarding unrelated Projects or hand-authored config. A duplicate
+Project name is refused unless `--force`, which replaces only that sequence entry. The command
+creates a starter Workflow Contract only when the selected path is absent, then creates missing
+Operational Labels in the newly registered repository. `--yes` accepts Project defaults and
+performs label setup without prompting.
 
 Example:
 
@@ -291,7 +300,9 @@ projects:
       - ./daily-report.md
 ```
 
-The bootstrap slice must use this final multi-project shape even with one configured Project.
+The bootstrap slice must use this final multi-project shape even with one configured Project. The
+intermediate global config written before the first `init-project` invocation intentionally has an
+empty `projects` sequence and is not daemon-ready until a Project is registered.
 
 A Project may override only `watchdog.grace_minutes` with a positive integer. It inherits
 `watchdog.enabled`, `watchdog.sample_interval_seconds`, and `watchdog.mtime_ignore` from daemon
@@ -427,9 +438,9 @@ state:
   root: ~/.local/state/symphonika
 ```
 
-Project repositories do not need a deploy-local state directory when using `symphonika init`; state
-and workspaces live under the user state root. Repositories that carry their own project-local
-`symphonika.yml` should gitignore `.symphonika/`.
+Project repositories do not need a deploy-local state directory when using the initialized user
+config; state and workspaces live under the user state root. Repositories that carry their own
+project-local `symphonika.yml` should gitignore `.symphonika/`.
 
 ### 7.2 Run Store
 
@@ -1082,9 +1093,9 @@ states (§12.6).
 
 Bootstrap CLI commands:
 
-- `symphonika init [--provider codex|claude] [--force]`
+- `symphonika init [--yes] [--force]`
 - `symphonika doctor [--config <path>]`
-- `symphonika init-project [--config <path>] --yes`
+- `symphonika init-project [--config <path>] [--yes] [--force]`
 - `symphonika daemon [--config <path>] [--port <port>]`
 - `symphonika service install [--config <path>] [--force] [--print] [--no-reload]`
 - `symphonika status [--config <path>] [--dashboard] [--watch] [--interval-ms <ms>] [--doctor-ttl-ms <ms>]`
@@ -1110,8 +1121,9 @@ config path and points the operator to `symphonika init`.
 - database path
 - workspace root
 
-`init` writes local files only and never mutates GitHub. `init-project` creates missing operational
-labels only after explicit confirmation.
+`init` writes only the user Service Config and never inspects or mutates a repository or GitHub.
+`init-project` registers the current repository, creates a missing starter Workflow Contract, and
+creates missing Operational Labels after the interactive review or explicit `--yes` selection.
 
 `service install --config <path>` resolves the selected Service Config to an absolute path and
 bakes it into the generated unit as `daemon --config <absolute-path>`. Omitting `--config` keeps the
@@ -1198,10 +1210,12 @@ The bootstrap slice is accepted when:
 
 - tests pass
 - lint passes
-- `init` can create a user service config and starter workflow from a GitHub-backed project checkout
+- `init` can create an empty user Service Config with interactive service-level settings
+- `init-project` can append a Project without losing existing config and create its starter
+  Workflow Contract
 - `doctor` validates service config, GitHub auth, operational labels, Codex and Claude provider
   commands, workflow file, database path, and workspace root
-- `init-project` can create missing operational labels after confirmation
+- `init-project` can create missing operational labels after interactive review or `--yes`
 - `daemon` can claim one `agent-ready` issue in this repository
 - daemon prepares the deterministic issue worktree and branch
 - daemon runs the configured provider through either Codex JSON-RPC or Claude stream-json

--- a/docs/adr/0059-split-global-and-project-initialization.md
+++ b/docs/adr/0059-split-global-and-project-initialization.md
@@ -1,0 +1,14 @@
+# Split global and Project initialization
+
+Status: Accepted
+
+Symphonika separates initialization along its configuration ownership boundary. `init` creates only
+the user Service Config and service-level defaults, with an empty Project sequence.
+`init-project` registers the current GitHub repository in an existing Service Config, creates a
+starter Workflow Contract when needed, and provisions that repository's missing Operational Labels.
+Both commands are interactive by default and accept `--yes` for unattended default selection.
+
+Project registration edits the YAML document so unrelated Projects, keys, and comments survive.
+Duplicate Project names fail by default; `--force` replaces only the matching sequence entry. This
+supersedes ADR 0026's original bootstrap command split, where `init` derived one Project and
+`init-project` only provisioned labels.

--- a/docs/smoke.md
+++ b/docs/smoke.md
@@ -44,9 +44,10 @@ Exit codes:
 2. **GitHub credentials**: export `GITHUB_TOKEN` (or the variable referenced
    by `tracker.token` in your config) with write access to issues for the
    target repository.
-3. **Operational labels created**: the four `sym:*` labels must already exist
-   on the target repository. Smoke never creates labels itself. Run
-   `symphonika init-project --yes` once as an operator to create them.
+3. **Operational labels created**: the `sym:*` labels must already exist on the target repository.
+   Smoke never creates labels itself. For a new setup, `symphonika init-project` provisions them
+   while registering the repository. For this hand-authored example config, verify the labels in
+   the repository settings rather than force-replacing the checked-in Project entry.
 4. **Provider binary on `PATH`**: install the binary that matches
    `agent.provider`. Codex provides `codex`; Claude provides `claude`.
 5. **At least one issue labeled `agent-ready`** that does not also carry any
@@ -57,7 +58,6 @@ Exit codes:
 ```sh
 export GITHUB_TOKEN=<your-personal-token>
 npx symphonika doctor --config symphonika.example.yml
-npx symphonika init-project --config symphonika.example.yml --yes   # one-time, creates sym:* labels
 npm run smoke -- --config symphonika.example.yml                    # equivalent to: symphonika smoke --config …
 ```
 

--- a/docs/specs/2026-07-21-interactive-initialization-design.md
+++ b/docs/specs/2026-07-21-interactive-initialization-design.md
@@ -1,0 +1,40 @@
+# Interactive global and Project initialization
+
+Issue #181 splits first-run setup along the existing domain boundary between the global Service
+Config and repository-specific Projects.
+
+## Command responsibilities
+
+`symphonika init` creates the user Service Config with service-level settings and an empty
+`projects` sequence. It can run outside a Git repository. Interactive mode prompts for the state
+root, polling interval, pull-request merge policy, and both provider commands. `--yes` accepts the
+displayed defaults, and `--force` remains the only way to replace an existing user config. The
+command never mutates GitHub or a repository.
+
+`symphonika init-project` requires an existing selected Service Config and runs inside a GitHub
+repository with an `origin` remote. It prompts for the Project name, Agent Provider, base branch,
+required and excluded issue labels, priority label mapping, and Workflow Contract path. It adds the
+Project to the existing YAML document, creates a starter `WORKFLOW.md` only when the selected path
+does not exist, and then creates any missing Operational Labels in that Project's repository.
+`--yes` accepts defaults and is the explicit confirmation for label creation.
+
+## YAML preservation and duplicate names
+
+Project registration edits the parsed YAML document rather than constructing a fresh Service
+Config, preserving unrelated top-level keys, Projects, and comments. A duplicate Project name is an
+error by default. With `--force`, only the matching Project sequence entry is replaced in place;
+unrelated Projects remain untouched. Emitting a second entry with the same name was rejected
+because runtime Project lookup assumes names identify one Project.
+
+## Interaction and validation
+
+Prompts show defaults and accept a blank answer as the default. Label lists use comma-separated
+values. Priority mappings use comma-separated `label=non-negative-integer` pairs. Invalid numeric,
+boolean, provider, merge-method, or priority answers fail without writing either config or
+workflow files. Git and GitHub failures are returned through the existing report/error CLI surface.
+
+## Test seams
+
+Behavior is tested through `runInit`, `runInitProject`, and the Commander CLI. Tests inject prompt
+answers and a fake GitHub API, while using real temporary files and Git repositories. This keeps
+filesystem/YAML behavior real and mocks only the GitHub system boundary.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -7,7 +7,7 @@ claims an `agent-ready` issue from a GitHub repository you own, runs a coding ag
 - a built `symphonika` CLI on your `PATH`
 - a user-level `symphonika.yml` service config pointed at one of your repositories
 - a repository-owned `WORKFLOW.md` workflow contract that the agent will execute
-- the four `sym:*` operational labels created on the target repository
+- the `sym:*` Operational Labels created on the target repository
 - one completed run (via `smoke`) with logs you can inspect
 - a long-running `daemon` you can stop and start at will
 
@@ -83,22 +83,28 @@ The rest of this tutorial uses `symphonika <subcommand>` for brevity.
 
 ---
 
-## 3. Initialize Symphonika from your project
+## 3. Initialize Symphonika, then register your Project
 
-Go to the repository you want Symphonika to manage and run `init` there. You do
-not need a separate deployment directory.
+Create the user Service Config first, then go to the repository you want Symphonika to manage and
+register it:
 
 ```sh
+symphonika init
 cd ~/dev/s11
-symphonika init --provider codex     # or: --provider claude
+symphonika init-project
 ```
 
-`init` reads the GitHub `origin` remote, creates the user service config at
+`init` creates the user service config at
 `$XDG_CONFIG_HOME/symphonika/symphonika.yml` (usually
 `~/.config/symphonika/symphonika.yml`), stores local runtime state under
-`$XDG_STATE_HOME/symphonika` (usually `~/.local/state/symphonika`), and creates
-`WORKFLOW.md` in the project only if that file is absent. It does not touch
-GitHub; label creation still happens later via `init-project --yes`.
+`$XDG_STATE_HOME/symphonika` (usually `~/.local/state/symphonika`), and starts with
+`projects: []`. It prompts for service-level settings and never inspects a repository or touches
+GitHub.
+
+`init-project` reads the current repository's GitHub `origin`, prompts for the Project-specific
+settings, appends the Project, creates `WORKFLOW.md` only if the selected path is absent, and creates
+missing `sym:*` Operational Labels. Pass `--yes` to either command to accept every displayed
+default without prompting. Run `init-project` again from another checkout to add another Project.
 
 If you already have a user config, `init` refuses to overwrite it unless you pass
 `--force`. For hand-authored setups, every command still accepts `--config
@@ -221,7 +227,7 @@ If you are running Claude, skip this section.
 
 ## 6. Review your `WORKFLOW.md`
 
-`symphonika init` creates a starter `WORKFLOW.md` if your project does not
+`symphonika init-project` creates a starter `WORKFLOW.md` if your project does not
 already have one. The workflow contract is the prompt the agent receives, with
 placeholders that Symphonika fills in at dispatch time. Available placeholders
 are listed in [SPEC.md §5.3](../SPEC.md#53-templating); the most useful are
@@ -306,26 +312,15 @@ database path, workspace root. It dispatches no work.
 symphonika doctor
 ```
 
-The first time you run this against a fresh repository, `doctor` will exit
-non-zero and report the four `sym:*` operational labels as missing — for
-example:
-
-```
-doctor failed:
-- projects.my-app.tracker.repository your-handle/your-repo is missing operational labels: sym:claimed, sym:running, sym:failed, sym:stale
-```
-
-That specific error is expected and is exactly what step 8 (`init-project --yes`)
-resolves; re-run `doctor` after step 8 and it should print `doctor ok`. Any
-*other* error — a bad token, an unreadable workflow file, a missing provider
-binary — is a real problem and must be fixed before continuing, because smoke
-and daemon refuse to start when `doctor` is unhappy.
+Because `init-project` already provisions the Operational Labels, `doctor` should print `doctor ok`.
+Any error — a bad token, an unreadable workflow file, a missing provider binary, or deleted labels —
+must be fixed before continuing, because smoke and daemon refuse to start when `doctor` is unhappy.
 
 Common first-run errors and what they mean:
 
 - *"GitHub auth failed"* — `GITHUB_TOKEN` is unset, expired, or lacks scopes.
 - *"workflow file not found"* — check the `workflow:` path in the user service
-  config. `init` writes an absolute path; hand-authored relative paths resolve
+  config. `init-project` writes an absolute path; hand-authored relative paths resolve
   from the directory containing `symphonika.yml`.
 - *"provider command not on PATH"* — the `codex` or `claude` binary cannot be
   resolved. Check `which codex` / `which claude`.
@@ -333,19 +328,18 @@ Common first-run errors and what they mean:
 
 ---
 
-## 8. Create the operational labels
+## 8. Add another Project
 
-Symphonika owns four GitHub labels (`sym:claimed`, `sym:running`, `sym:failed`,
-`sym:stale`) and refuses to create them silently. Run `init-project` once per
-target repository:
+To manage another repository with the same daemon, run `init-project` from that checkout. It appends
+the new Project and provisions its Operational Labels without replacing existing Projects:
 
 ```sh
-symphonika init-project --yes
+cd ~/dev/another-project
+symphonika init-project
 ```
 
-The `--yes` flag is the explicit confirmation. Without it the command runs in
-preview mode and prints what *would* be created without touching GitHub. After
-this completes, `doctor` should report a clean bill of health.
+If a Project with the chosen name already exists, the command refuses to continue. `--force`
+replaces only that matching entry; it does not overwrite the rest of the Service Config.
 
 ---
 
@@ -543,8 +537,8 @@ from whichever provider started the attempt.
 ## Appendix A: Troubleshooting
 
 **`doctor` says no initialized user service config exists.** Run
-`symphonika init` from the GitHub repository you want Symphonika to manage, then
-run `symphonika doctor` again.
+`symphonika init`, then run `symphonika init-project` from the GitHub repository you want
+Symphonika to manage before running `symphonika doctor` again.
 
 **`doctor` complains about a `sym:stale` label on an issue.** A previous attempt
 left durable claim labels but no live local run. Run

--- a/knip.json
+++ b/knip.json
@@ -6,6 +6,5 @@
     "src/lifecycle/eligibility-interface.ts",
     "src/lifecycle/run-lifecycle-interface.ts"
   ],
-  "project": ["src/**/*.ts", "fuzz/**/*.mjs"],
-  "ignoreBinaries": ["scripts/smoke.sh"]
+  "project": ["src/**/*.ts", "fuzz/**/*.mjs"]
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ import type {
   InitProjectReport
 } from "./doctor.js";
 import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
-import type { InitOptions, InitProvider, InitReport } from "./init.js";
+import type { InitOptions, InitReport } from "./init.js";
 import { runInit } from "./init.js";
 import type { ProjectIssuePollReport } from "./issue-polling.js";
 import type { RoutineStatus } from "./routines/types.js";
@@ -176,20 +176,13 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
 
   program
     .command("init")
-    .description(
-      "create a user service config for the current GitHub repository"
-    )
-    .option(
-      "--provider <name>",
-      "agent provider for the project",
-      parseProvider,
-      "codex"
-    )
+    .description("create the user service config")
+    .option("--yes", "use defaults without interactive prompts")
     .option("--force", "overwrite an existing user service config")
-    .action(async (options: { force?: boolean; provider: InitProvider }) => {
+    .action(async (options: { force?: boolean; yes?: boolean }) => {
       const report = await init({
         force: options.force === true,
-        provider: options.provider
+        yes: options.yes === true
       });
 
       if (!report.ok) {
@@ -204,77 +197,65 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
       writeOut(program, "init ok\n");
       writeOut(program, `config:    ${report.configPath}\n`);
       writeOut(program, `state:     ${report.stateRoot}\n`);
-      if (report.repository !== null) {
-        writeOut(program, `repo:      ${report.repository}\n`);
-      }
-      if (report.projectName !== null) {
-        writeOut(program, `project:   ${report.projectName}\n`);
-      }
-      if (report.workflowPath !== null) {
-        const workflowLabel = report.createdWorkflow
-          ? "workflow:"
-          : "workflow:  existing";
-        writeOut(program, `${workflowLabel} ${report.workflowPath}\n`);
-      }
-      writeOut(
-        program,
-        "next:      export GITHUB_TOKEN=... && symphonika doctor\n"
-      );
-      writeOut(program, "then:      symphonika init-project --yes\n");
+      writeOut(program, "next:      export GITHUB_TOKEN=...\n");
+      writeOut(program, "then:      cd <project> && symphonika init-project\n");
+      writeOut(program, "after:     symphonika doctor\n");
     });
 
   program
     .command("init-project")
-    .description(
-      "create missing GitHub operational labels after explicit confirmation"
-    )
+    .description("register the current GitHub repository as a Project")
     .option("--config <path>", "service config path")
+    .option("--force", "replace a Project with the same name")
     .option(
       "--yes",
-      "create missing operational labels without an interactive prompt"
+      "use defaults and create missing labels without interactive prompts"
     )
-    .action(async (options: { config?: string; yes?: boolean }) => {
-      const emittedWarnings = new Set<string>();
-      const report = await initProject({
-        ...withConfigPath(options.config),
-        onWarning: (warning) => {
-          emittedWarnings.add(warning);
+    .action(
+      async (options: { config?: string; force?: boolean; yes?: boolean }) => {
+        const emittedWarnings = new Set<string>();
+        const report = await initProject({
+          ...withConfigPath(options.config),
+          force: options.force === true,
+          onWarning: (warning) => {
+            emittedWarnings.add(warning);
+            writeErr(program, `warning: ${warning}\n`);
+          },
+          yes: options.yes === true
+        });
+
+        for (const warning of report.warnings) {
+          if (emittedWarnings.has(warning)) {
+            continue;
+          }
           writeErr(program, `warning: ${warning}\n`);
-        },
-        yes: options.yes === true
-      });
-
-      for (const warning of report.warnings) {
-        if (emittedWarnings.has(warning)) {
-          continue;
         }
-        writeErr(program, `warning: ${warning}\n`);
-      }
 
-      if (!report.ok) {
-        writeErr(program, "init-project failed:\n");
-        for (const error of report.errors) {
-          writeErr(program, `- ${error}\n`);
+        if (!report.ok) {
+          writeErr(program, "init-project failed:\n");
+          for (const error of report.errors) {
+            writeErr(program, `- ${error}\n`);
+          }
+          process.exitCode = 1;
+          return;
         }
-        process.exitCode = 1;
-        return;
-      }
 
-      const createdLabels = report.projects.flatMap((project) =>
-        project.createdOperationalLabels.map((label) => ({
-          label,
-          repository: project.repository
-        }))
-      );
+        const createdLabels = report.projects.flatMap((project) =>
+          project.createdOperationalLabels.map((label) => ({
+            label,
+            repository: project.repository
+          }))
+        );
 
-      writeOut(
-        program,
-        `init-project ok: created ${createdLabels.length} ${pluralize("label", createdLabels.length)}\n`
-      );
-      for (const created of createdLabels) {
-        writeOut(program, `- ${created.label} in ${created.repository}\n`);
+        writeOut(
+          program,
+          `init-project ok: registered ${report.projects.length} ${pluralize("Project", report.projects.length)} and created ${createdLabels.length} ${pluralize("label", createdLabels.length)}\n`
+        );
+        for (const created of createdLabels) {
+          writeOut(program, `- ${created.label} in ${created.repository}\n`);
+        }
       }
-    });
+    );
 
   program
     .command("clear-stale")
@@ -1909,13 +1890,6 @@ function parseIssueNumber(value: string): number {
   }
 
   return issue;
-}
-
-function parseProvider(value: string): InitProvider {
-  if (value === "codex" || value === "claude") {
-    return value;
-  }
-  throw new InvalidArgumentError("provider must be one of codex, claude");
 }
 
 function pluralize(word: string, count: number): string {

--- a/src/config-paths.ts
+++ b/src/config-paths.ts
@@ -63,7 +63,7 @@ export function isDefaultUserConfigPath(
 }
 
 export function missingUserConfigHint(configPath: string): string {
-  return `no initialized user service config found at ${configPath}; run \`symphonika init\` from the GitHub project you want Symphonika to manage`;
+  return `no initialized Service Config found at ${configPath}; run \`symphonika init\` first`;
 }
 
 function resolution(

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,5 +1,5 @@
 import { constants } from "node:fs";
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { stdin, stdout } from "node:process";
 import { createInterface } from "node:readline/promises";
@@ -480,11 +480,13 @@ export async function runInitProject(
   const rawProjects = projectsNode.toJSON();
   const matchingIndexes = rawProjects.reduce<number[]>(
     (indexes, entry, index) => {
+      const rawName =
+        typeof entry === "object" && entry !== null && "name" in entry
+          ? (entry as { name?: unknown }).name
+          : undefined;
       if (
-        typeof entry === "object" &&
-        entry !== null &&
-        "name" in entry &&
-        (entry as { name?: unknown }).name === settings.projectName
+        typeof rawName === "string" &&
+        rawName.trim() === settings.projectName
       ) {
         indexes.push(index);
       }
@@ -535,6 +537,20 @@ export async function runInitProject(
     return initProjectReport(configPath, errors, warnings, projects);
   }
 
+  let createdWorkflow = false;
+  if (!(await fileExists(settings.workflowPath))) {
+    try {
+      await mkdir(path.dirname(settings.workflowPath), { recursive: true });
+      await writeFile(settings.workflowPath, defaultWorkflowContract(), "utf8");
+      createdWorkflow = true;
+    } catch (error) {
+      errors.push(
+        `starter Workflow Contract could not be created at ${settings.workflowPath}: ${errorMessage(error)}`
+      );
+      return initProjectReport(configPath, errors, warnings, projects);
+    }
+  }
+
   projects.push(
     await createOperationalLabels({
       errors,
@@ -550,19 +566,8 @@ export async function runInitProject(
     })
   );
   if (errors.length > 0) {
+    await removeCreatedWorkflow(settings.workflowPath, createdWorkflow, errors);
     return initProjectReport(configPath, errors, warnings, projects);
-  }
-
-  if (!(await fileExists(settings.workflowPath))) {
-    try {
-      await mkdir(path.dirname(settings.workflowPath), { recursive: true });
-      await writeFile(settings.workflowPath, defaultWorkflowContract(), "utf8");
-    } catch (error) {
-      errors.push(
-        `starter Workflow Contract could not be created at ${settings.workflowPath}: ${errorMessage(error)}`
-      );
-      return initProjectReport(configPath, errors, warnings, projects);
-    }
   }
 
   try {
@@ -571,6 +576,7 @@ export async function runInitProject(
     errors.push(
       `service config could not be written at ${configPath}: ${errorMessage(error)}`
     );
+    await removeCreatedWorkflow(settings.workflowPath, createdWorkflow, errors);
   }
 
   return initProjectReport(configPath, errors, warnings, projects);
@@ -914,6 +920,23 @@ async function confirmOperationalLabelCreation(input: {
     throw new Error("operational label confirmation must be yes or no");
   } finally {
     promptController.close();
+  }
+}
+
+async function removeCreatedWorkflow(
+  workflowPath: string,
+  createdWorkflow: boolean,
+  errors: string[]
+): Promise<void> {
+  if (!createdWorkflow) {
+    return;
+  }
+  try {
+    await rm(workflowPath);
+  } catch (error) {
+    errors.push(
+      `starter Workflow Contract could not be removed after failed initialization at ${workflowPath}: ${errorMessage(error)}`
+    );
   }
 }
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -82,6 +82,7 @@ type InitProjectPromptInput = {
     | "priorityLabels"
     | "projectName"
     | "provider"
+    | "confirmOperationalLabels"
     | "requiredLabels"
     | "workflowPath";
   message: string;
@@ -541,6 +542,7 @@ export async function runInitProject(
       ...(options.onWarning === undefined
         ? {}
         : { onWarning: options.onWarning }),
+      ...(options.prompt === undefined ? {} : { prompt: options.prompt }),
       project: registeredProject,
       validation: accessValidation,
       warnings,
@@ -822,6 +824,7 @@ async function createOperationalLabels(input: {
   errors: string[];
   githubApi: GitHubApi;
   onWarning?: (warning: string) => void;
+  prompt?: InitProjectPrompt;
   project: ProjectConfig;
   validation: ProjectGitHubAccessValidation;
   warnings: string[];
@@ -834,11 +837,22 @@ async function createOperationalLabels(input: {
     const warning = `init-project ${input.yes ? "will" : "would"} create operational labels in ${repositoryName}: ${missingOperationalLabels.join(", ")}`;
     input.warnings.push(warning);
     input.onWarning?.(warning);
-    if (input.yes !== true) {
-      input.errors.push(
-        "pass --yes to create missing operational labels non-interactively"
-      );
-    } else {
+    let confirmed = input.yes;
+    if (!confirmed) {
+      try {
+        confirmed = await confirmOperationalLabelCreation({
+          missingOperationalLabels,
+          ...(input.prompt === undefined ? {} : { prompt: input.prompt }),
+          repositoryName
+        });
+        if (!confirmed) {
+          input.errors.push("operational label creation was declined");
+        }
+      } catch (error) {
+        input.errors.push(errorMessage(error));
+      }
+    }
+    if (confirmed) {
       for (const label of missingOperationalLabels) {
         try {
           await input.githubApi.createLabel({ ...repository, name: label });
@@ -858,6 +872,35 @@ async function createOperationalLabels(input: {
     name: input.project.name,
     repository: repositoryName
   };
+}
+
+async function confirmOperationalLabelCreation(input: {
+  missingOperationalLabels: string[];
+  prompt?: InitProjectPrompt;
+  repositoryName: string;
+}): Promise<boolean> {
+  const promptController = createInitProjectPromptController(
+    input.prompt,
+    false
+  );
+  try {
+    const answer = (
+      await promptController.ask({
+        defaultValue: "yes",
+        key: "confirmOperationalLabels",
+        message: `Create missing operational labels in ${input.repositoryName}: ${input.missingOperationalLabels.join(", ")}? (yes/no)`
+      })
+    ).toLowerCase();
+    if (answer === "yes" || answer === "y") {
+      return true;
+    }
+    if (answer === "no" || answer === "n") {
+      return false;
+    }
+    throw new Error("operational label confirmation must be yes or no");
+  } finally {
+    promptController.close();
+  }
 }
 
 async function fileExists(filePath: string): Promise<boolean> {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -515,12 +515,6 @@ export async function runInitProject(
     return initProjectReport(configPath, errors, warnings, projects);
   }
 
-  await writeFile(configPath, document.toString(), "utf8");
-  if (!(await fileExists(settings.workflowPath))) {
-    await mkdir(path.dirname(settings.workflowPath), { recursive: true });
-    await writeFile(settings.workflowPath, defaultWorkflowContract(), "utf8");
-  }
-
   const registeredProject = parsedConfig.projects.find(
     (entry) => entry.name === settings.projectName
   );
@@ -528,19 +522,37 @@ export async function runInitProject(
     errors.push(`registered Project ${settings.projectName} could not be read`);
     return initProjectReport(configPath, errors, warnings, projects);
   }
-  const projectReport = await initializeOperationalLabels({
+
+  const githubApi = options.githubApi ?? DEFAULT_GITHUB_API;
+  const accessValidation = await validateProjectGitHubAccess({
     env,
     errors,
-    githubApi: options.githubApi ?? DEFAULT_GITHUB_API,
-    ...(options.onWarning === undefined
-      ? {}
-      : { onWarning: options.onWarning }),
-    project: registeredProject,
-    warnings
+    githubApi,
+    project: registeredProject
   });
-  if (projectReport !== undefined) {
-    projects.push(projectReport);
+  if (accessValidation === undefined) {
+    return initProjectReport(configPath, errors, warnings, projects);
   }
+
+  await writeFile(configPath, document.toString(), "utf8");
+  if (!(await fileExists(settings.workflowPath))) {
+    await mkdir(path.dirname(settings.workflowPath), { recursive: true });
+    await writeFile(settings.workflowPath, defaultWorkflowContract(), "utf8");
+  }
+
+  projects.push(
+    await createOperationalLabels({
+      errors,
+      githubApi,
+      ...(options.onWarning === undefined
+        ? {}
+        : { onWarning: options.onWarning }),
+      project: registeredProject,
+      validation: accessValidation,
+      warnings,
+      yes: options.yes === true
+    })
+  );
 
   return initProjectReport(configPath, errors, warnings, projects);
 }
@@ -749,14 +761,18 @@ function buildProjectConfig(input: {
   };
 }
 
-async function initializeOperationalLabels(input: {
+type ProjectGitHubAccessValidation = {
+  missingOperationalLabels: string[];
+  repository: { owner: string; repo: string; token: string };
+  repositoryName: string;
+};
+
+async function validateProjectGitHubAccess(input: {
   env: NodeJS.ProcessEnv;
   errors: string[];
   githubApi: GitHubApi;
-  onWarning?: (warning: string) => void;
   project: ProjectConfig;
-  warnings: string[];
-}): Promise<InitProjectProjectReport | undefined> {
+}): Promise<ProjectGitHubAccessValidation | undefined> {
   const token = resolveEnvBackedValue(input.project.tracker.token, input.env);
   if (token === undefined) {
     const variableName = envReferenceName(input.project.tracker.token);
@@ -796,19 +812,39 @@ async function initializeOperationalLabels(input: {
   const missingOperationalLabels = REQUIRED_OPERATIONAL_LABELS.filter(
     (label) => !labels.has(label)
   );
+  return { missingOperationalLabels, repository, repositoryName };
+}
+
+async function createOperationalLabels(input: {
+  errors: string[];
+  githubApi: GitHubApi;
+  onWarning?: (warning: string) => void;
+  project: ProjectConfig;
+  validation: ProjectGitHubAccessValidation;
+  warnings: string[];
+  yes: boolean;
+}): Promise<InitProjectProjectReport> {
+  const { missingOperationalLabels, repository, repositoryName } =
+    input.validation;
   const createdOperationalLabels: string[] = [];
   if (missingOperationalLabels.length > 0) {
-    const warning = `init-project will create operational labels in ${repositoryName}: ${missingOperationalLabels.join(", ")}`;
+    const warning = `init-project ${input.yes ? "will" : "would"} create operational labels in ${repositoryName}: ${missingOperationalLabels.join(", ")}`;
     input.warnings.push(warning);
     input.onWarning?.(warning);
-    for (const label of missingOperationalLabels) {
-      try {
-        await input.githubApi.createLabel({ ...repository, name: label });
-        createdOperationalLabels.push(label);
-      } catch (error) {
-        input.errors.push(
-          `projects.${input.project.name}.tracker.repository ${repositoryName} could not create operational label ${label}: ${errorMessage(error)}`
-        );
+    if (input.yes !== true) {
+      input.errors.push(
+        "pass --yes to create missing operational labels non-interactively"
+      );
+    } else {
+      for (const label of missingOperationalLabels) {
+        try {
+          await input.githubApi.createLabel({ ...repository, name: label });
+          createdOperationalLabels.push(label);
+        } catch (error) {
+          input.errors.push(
+            `projects.${input.project.name}.tracker.repository ${repositoryName} could not create operational label ${label}: ${errorMessage(error)}`
+          );
+        }
       }
     }
   }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,7 +1,10 @@
-import { readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
 import { Octokit } from "@octokit/rest";
-import { parse } from "yaml";
+import { isSeq, parse, parseDocument } from "yaml";
 import { z } from "zod";
 
 import type { WorkflowFormat } from "./config-schemas.js";
@@ -15,12 +18,18 @@ import {
   resolveServiceConfigPath
 } from "./config-paths.js";
 import {
+  defaultWorkflowContract,
+  inspectCurrentGitHubProject,
+  type InitProvider
+} from "./init.js";
+import {
   DEFAULT_GITHUB_ISSUES_API,
   type GitHubIssuesApi
 } from "./issue-polling.js";
 import { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
+import { resolveStateRoot } from "./state.js";
 import {
   loadExpandedWorkflow,
   validateExpandedWorkflowReferences
@@ -59,9 +68,28 @@ export type DoctorReport = {
 };
 
 export type InitProjectOptions = DoctorOptions & {
+  force?: boolean;
   onWarning?: (warning: string) => void;
+  prompt?: InitProjectPrompt;
   yes?: boolean;
 };
+
+export type InitProjectPromptInput = {
+  defaultValue: string;
+  key:
+    | "baseBranch"
+    | "excludedLabels"
+    | "priorityLabels"
+    | "projectName"
+    | "provider"
+    | "requiredLabels"
+    | "workflowPath";
+  message: string;
+};
+
+export type InitProjectPrompt = (
+  input: InitProjectPromptInput
+) => Promise<string>;
 
 type InitProjectProjectReport = {
   createdOperationalLabels: string[];
@@ -385,98 +413,405 @@ export async function runInitProject(
   const errors: string[] = [];
   const warnings: string[] = [];
   const projects: InitProjectProjectReport[] = [];
-  const rawConfig = await readConfig(configPath, errors);
-
-  if (rawConfig === undefined) {
-    if (resolvedConfig.source === "user" && !resolvedConfig.configExists) {
-      errors.push(missingUserConfigHint(configPath));
-    }
+  if (!resolvedConfig.configExists) {
+    errors.push(missingUserConfigHint(configPath));
     return initProjectReport(configPath, errors, warnings, projects);
   }
 
-  const parsedConfig = parseServiceConfig(rawConfig, errors);
+  let configContents: string;
+  try {
+    configContents = await readFile(configPath, "utf8");
+  } catch (error) {
+    errors.push(
+      `service config could not be read at ${configPath}: ${errorMessage(error)}`
+    );
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+
+  const document = parseDocument(configContents);
+  if (document.errors.length > 0) {
+    errors.push(
+      ...document.errors.map(
+        (error) => `service config could not be parsed: ${error.message}`
+      )
+    );
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+  const projectsNode = document.get("projects", true);
+  if (!isSeq(projectsNode)) {
+    errors.push(
+      "service config must contain a projects sequence; run `symphonika init --force` to recreate the global config"
+    );
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+
+  let metadata: Awaited<ReturnType<typeof inspectCurrentGitHubProject>>;
+  try {
+    metadata = await inspectCurrentGitHubProject(cwd);
+  } catch (error) {
+    errors.push(errorMessage(error));
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+
+  let settings: ProjectInitSettings;
+  try {
+    settings = await collectProjectSettings({
+      metadata,
+      ...(options.prompt === undefined ? {} : { prompt: options.prompt }),
+      yes: options.yes === true
+    });
+  } catch (error) {
+    errors.push(errorMessage(error));
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+
+  let stateRoot: string;
+  try {
+    stateRoot = resolveStateRoot({ configPath, cwd, env }).stateRoot;
+  } catch (error) {
+    errors.push(errorMessage(error));
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+
+  const project = buildProjectConfig({ metadata, settings, stateRoot });
+  const rawProjects = projectsNode.toJSON();
+  const existingIndex = rawProjects.findIndex(
+    (entry) =>
+      typeof entry === "object" &&
+      entry !== null &&
+      "name" in entry &&
+      (entry as { name?: unknown }).name === settings.projectName
+  );
+  if (existingIndex >= 0 && options.force !== true) {
+    errors.push(
+      `project ${settings.projectName} already exists in ${configPath}; pass --force to replace that Project`
+    );
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+  if (existingIndex >= 0) {
+    document.setIn(["projects", existingIndex], project);
+  } else {
+    projectsNode.add(project);
+  }
+
+  const parsedConfig = parseServiceConfig(document.toJS(), errors);
   if (parsedConfig === undefined) {
     return initProjectReport(configPath, errors, warnings, projects);
   }
 
-  const githubApi = options.githubApi ?? DEFAULT_GITHUB_API;
+  await writeFile(configPath, document.toString(), "utf8");
+  if (!(await fileExists(settings.workflowPath))) {
+    await mkdir(path.dirname(settings.workflowPath), { recursive: true });
+    await writeFile(settings.workflowPath, defaultWorkflowContract(), "utf8");
+  }
 
-  for (const project of parsedConfig.projects) {
-    const token = resolveEnvBackedValue(project.tracker.token, env);
-    if (token === undefined) {
-      const variableName = envReferenceName(project.tracker.token);
-      errors.push(
-        variableName === undefined
-          ? `projects.${project.name}.tracker.token must reference an environment variable like $GITHUB_TOKEN`
-          : `projects.${project.name}.tracker.token references unset environment variable $${variableName}`
-      );
-      continue;
-    }
-
-    const repository = {
-      owner: project.tracker.owner,
-      repo: project.tracker.repo,
-      token
-    };
-    const repositoryName = `${project.tracker.owner}/${project.tracker.repo}`;
-    const access = await githubApi.validateRepositoryAccess(repository);
-    if (!access.ok) {
-      errors.push(
-        `projects.${project.name}.tracker.repository ${repositoryName} is not accessible: ${access.message ?? "unknown GitHub error"}`
-      );
-      continue;
-    }
-
-    let labels: Set<string>;
-    try {
-      labels = new Set(await githubApi.listLabels(repository));
-    } catch (error) {
-      errors.push(
-        `projects.${project.name}.tracker.repository ${repositoryName} labels could not be listed: ${errorMessage(error)}`
-      );
-      continue;
-    }
-
-    const missingOperationalLabels = REQUIRED_OPERATIONAL_LABELS.filter(
-      (label) => !labels.has(label)
-    );
-    const createdOperationalLabels: string[] = [];
-
-    if (missingOperationalLabels.length > 0) {
-      const warning = `init-project ${options.yes === true ? "will" : "would"} create operational labels in ${repositoryName}: ${missingOperationalLabels.join(", ")}`;
-      warnings.push(warning);
-      options.onWarning?.(warning);
-
-      if (options.yes !== true) {
-        errors.push(
-          "pass --yes to create missing operational labels non-interactively"
-        );
-      } else {
-        for (const label of missingOperationalLabels) {
-          try {
-            await githubApi.createLabel({
-              ...repository,
-              name: label
-            });
-            createdOperationalLabels.push(label);
-          } catch (error) {
-            errors.push(
-              `projects.${project.name}.tracker.repository ${repositoryName} could not create operational label ${label}: ${errorMessage(error)}`
-            );
-          }
-        }
-      }
-    }
-
-    projects.push({
-      createdOperationalLabels,
-      missingOperationalLabels,
-      name: project.name,
-      repository: repositoryName
-    });
+  const registeredProject = parsedConfig.projects.find(
+    (entry) => entry.name === settings.projectName
+  );
+  if (registeredProject === undefined) {
+    errors.push(`registered Project ${settings.projectName} could not be read`);
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+  const projectReport = await initializeOperationalLabels({
+    env,
+    errors,
+    githubApi: options.githubApi ?? DEFAULT_GITHUB_API,
+    ...(options.onWarning === undefined
+      ? {}
+      : { onWarning: options.onWarning }),
+    project: registeredProject,
+    warnings
+  });
+  if (projectReport !== undefined) {
+    projects.push(projectReport);
   }
 
   return initProjectReport(configPath, errors, warnings, projects);
+}
+
+type ProjectInitSettings = {
+  baseBranch: string;
+  excludedLabels: string[];
+  priorityLabels: Record<string, number>;
+  projectName: string;
+  provider: InitProvider;
+  requiredLabels: string[];
+  workflowPath: string;
+};
+
+async function collectProjectSettings(input: {
+  metadata: Awaited<ReturnType<typeof inspectCurrentGitHubProject>>;
+  prompt?: InitProjectPrompt;
+  yes: boolean;
+}): Promise<ProjectInitSettings> {
+  const defaultWorkflowPath = path.join(
+    input.metadata.projectRoot,
+    "WORKFLOW.md"
+  );
+  const promptController = createInitProjectPromptController(
+    input.prompt,
+    input.yes
+  );
+
+  try {
+    const projectName = await promptController.ask({
+      defaultValue: input.metadata.projectName,
+      key: "projectName",
+      message: "Project name"
+    });
+    const provider = parseInitProvider(
+      await promptController.ask({
+        defaultValue: "codex",
+        key: "provider",
+        message: "Agent Provider (codex or claude)"
+      })
+    );
+    const baseBranch = await promptController.ask({
+      defaultValue: input.metadata.baseBranch,
+      key: "baseBranch",
+      message: "Base branch"
+    });
+    const requiredLabels = parseLabelList(
+      await promptController.ask({
+        defaultValue: "agent-ready",
+        key: "requiredLabels",
+        message: "Required issue labels (comma-separated)"
+      }),
+      "required issue labels"
+    );
+    const excludedLabels = parseLabelList(
+      await promptController.ask({
+        defaultValue: "blocked, needs-human, sym:stale",
+        key: "excludedLabels",
+        message: "Excluded issue labels (comma-separated)"
+      }),
+      "excluded issue labels"
+    );
+    const priorityLabels = parsePriorityLabels(
+      await promptController.ask({
+        defaultValue:
+          "priority:critical=0, priority:high=1, priority:medium=2, priority:low=3",
+        key: "priorityLabels",
+        message: "Priority labels (comma-separated label=number pairs)"
+      })
+    );
+    const workflowAnswer = await promptController.ask({
+      defaultValue: defaultWorkflowPath,
+      key: "workflowPath",
+      message: "Workflow Contract path"
+    });
+
+    if (projectName.trim().length === 0) {
+      throw new Error("Project name must not be empty");
+    }
+    if (baseBranch.trim().length === 0) {
+      throw new Error("base branch must not be empty");
+    }
+    if (workflowAnswer.trim().length === 0) {
+      throw new Error("Workflow Contract path must not be empty");
+    }
+
+    return {
+      baseBranch,
+      excludedLabels,
+      priorityLabels,
+      projectName,
+      provider,
+      requiredLabels,
+      workflowPath: path.isAbsolute(workflowAnswer)
+        ? path.normalize(workflowAnswer)
+        : path.resolve(input.metadata.projectRoot, workflowAnswer)
+    };
+  } finally {
+    promptController.close();
+  }
+}
+
+function createInitProjectPromptController(
+  injectedPrompt: InitProjectPrompt | undefined,
+  yes: boolean
+): { ask: InitProjectPrompt; close: () => void } {
+  if (yes) {
+    return {
+      ask: (input) => Promise.resolve(input.defaultValue),
+      close: () => undefined
+    };
+  }
+  if (injectedPrompt !== undefined) {
+    return {
+      ask: async (input) => {
+        const answer = await injectedPrompt(input);
+        return answer.trim().length === 0 ? input.defaultValue : answer.trim();
+      },
+      close: () => undefined
+    };
+  }
+
+  const readline = createInterface({ input: stdin, output: stdout });
+  return {
+    ask: async (input) => {
+      const answer = await readline.question(
+        `${input.message} [${input.defaultValue}]: `
+      );
+      return answer.trim().length === 0 ? input.defaultValue : answer.trim();
+    },
+    close: () => readline.close()
+  };
+}
+
+function parseInitProvider(value: string): InitProvider {
+  if (value === "codex" || value === "claude") {
+    return value;
+  }
+  throw new Error("Agent Provider must be one of codex, claude");
+}
+
+function parseLabelList(value: string, label: string): string[] {
+  const labels = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  if (labels.length === 0) {
+    throw new Error(`${label} must contain at least one label`);
+  }
+  return labels;
+}
+
+function parsePriorityLabels(value: string): Record<string, number> {
+  const priorities: Record<string, number> = {};
+  for (const entry of value.split(",")) {
+    const match = /^(.+)=([0-9]+)$/.exec(entry.trim());
+    if (match === null || match[1] === undefined || match[2] === undefined) {
+      throw new Error(
+        "priority labels must use comma-separated label=non-negative-integer pairs"
+      );
+    }
+    priorities[match[1].trim()] = Number(match[2]);
+  }
+  return priorities;
+}
+
+function buildProjectConfig(input: {
+  metadata: Awaited<ReturnType<typeof inspectCurrentGitHubProject>>;
+  settings: ProjectInitSettings;
+  stateRoot: string;
+}): unknown {
+  return {
+    name: input.settings.projectName,
+    disabled: false,
+    weight: 1,
+    tracker: {
+      kind: "github",
+      owner: input.metadata.owner,
+      repo: input.metadata.repo,
+      token: "$GITHUB_TOKEN"
+    },
+    issue_filters: {
+      states: ["open"],
+      labels_all: input.settings.requiredLabels,
+      labels_none: input.settings.excludedLabels
+    },
+    priority: {
+      labels: input.settings.priorityLabels,
+      default: 99
+    },
+    workspace: {
+      root: path.join(
+        input.stateRoot,
+        "workspaces",
+        input.settings.projectName
+      ),
+      git: {
+        remote: input.metadata.remote,
+        base_branch: input.settings.baseBranch
+      }
+    },
+    agent: {
+      provider: input.settings.provider
+    },
+    workflow: input.settings.workflowPath
+  };
+}
+
+async function initializeOperationalLabels(input: {
+  env: NodeJS.ProcessEnv;
+  errors: string[];
+  githubApi: GitHubApi;
+  onWarning?: (warning: string) => void;
+  project: ProjectConfig;
+  warnings: string[];
+}): Promise<InitProjectProjectReport | undefined> {
+  const token = resolveEnvBackedValue(input.project.tracker.token, input.env);
+  if (token === undefined) {
+    const variableName = envReferenceName(input.project.tracker.token);
+    input.errors.push(
+      variableName === undefined
+        ? `projects.${input.project.name}.tracker.token must reference an environment variable like $GITHUB_TOKEN`
+        : `projects.${input.project.name}.tracker.token references unset environment variable $${variableName}`
+    );
+    return undefined;
+  }
+
+  const repository = {
+    owner: input.project.tracker.owner,
+    repo: input.project.tracker.repo,
+    token
+  };
+  const repositoryName = `${repository.owner}/${repository.repo}`;
+  const repositoryAccess =
+    await input.githubApi.validateRepositoryAccess(repository);
+  if (!repositoryAccess.ok) {
+    input.errors.push(
+      `projects.${input.project.name}.tracker.repository ${repositoryName} is not accessible: ${repositoryAccess.message ?? "unknown GitHub error"}`
+    );
+    return undefined;
+  }
+
+  let labels: Set<string>;
+  try {
+    labels = new Set(await input.githubApi.listLabels(repository));
+  } catch (error) {
+    input.errors.push(
+      `projects.${input.project.name}.tracker.repository ${repositoryName} labels could not be listed: ${errorMessage(error)}`
+    );
+    return undefined;
+  }
+
+  const missingOperationalLabels = REQUIRED_OPERATIONAL_LABELS.filter(
+    (label) => !labels.has(label)
+  );
+  const createdOperationalLabels: string[] = [];
+  if (missingOperationalLabels.length > 0) {
+    const warning = `init-project will create operational labels in ${repositoryName}: ${missingOperationalLabels.join(", ")}`;
+    input.warnings.push(warning);
+    input.onWarning?.(warning);
+    for (const label of missingOperationalLabels) {
+      try {
+        await input.githubApi.createLabel({ ...repository, name: label });
+        createdOperationalLabels.push(label);
+      } catch (error) {
+        input.errors.push(
+          `projects.${input.project.name}.tracker.repository ${repositoryName} could not create operational label ${label}: ${errorMessage(error)}`
+        );
+      }
+    }
+  }
+
+  return {
+    createdOperationalLabels,
+    missingOperationalLabels,
+    name: input.project.name,
+    repository: repositoryName
+  };
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 const STALE_CLEAR_LABELS = ["sym:stale", "sym:claimed", "sym:running"] as const;

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -477,13 +477,27 @@ export async function runInitProject(
 
   const project = buildProjectConfig({ metadata, settings, stateRoot });
   const rawProjects = projectsNode.toJSON();
-  const existingIndex = rawProjects.findIndex(
-    (entry) =>
-      typeof entry === "object" &&
-      entry !== null &&
-      "name" in entry &&
-      (entry as { name?: unknown }).name === settings.projectName
+  const matchingIndexes = rawProjects.reduce<number[]>(
+    (indexes, entry, index) => {
+      if (
+        typeof entry === "object" &&
+        entry !== null &&
+        "name" in entry &&
+        (entry as { name?: unknown }).name === settings.projectName
+      ) {
+        indexes.push(index);
+      }
+      return indexes;
+    },
+    []
   );
+  if (matchingIndexes.length > 1) {
+    errors.push(
+      `project ${settings.projectName} appears ${matchingIndexes.length} times in ${configPath}; remove the duplicate Projects before running init-project`
+    );
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+  const existingIndex = matchingIndexes[0] ?? -1;
   if (existingIndex >= 0 && options.force !== true) {
     errors.push(
       `project ${settings.projectName} already exists in ${configPath}; pass --force to replace that Project`

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -534,12 +534,6 @@ export async function runInitProject(
     return initProjectReport(configPath, errors, warnings, projects);
   }
 
-  await writeFile(configPath, document.toString(), "utf8");
-  if (!(await fileExists(settings.workflowPath))) {
-    await mkdir(path.dirname(settings.workflowPath), { recursive: true });
-    await writeFile(settings.workflowPath, defaultWorkflowContract(), "utf8");
-  }
-
   projects.push(
     await createOperationalLabels({
       errors,
@@ -553,6 +547,15 @@ export async function runInitProject(
       yes: options.yes === true
     })
   );
+  if (errors.length > 0) {
+    return initProjectReport(configPath, errors, warnings, projects);
+  }
+
+  await writeFile(configPath, document.toString(), "utf8");
+  if (!(await fileExists(settings.workflowPath))) {
+    await mkdir(path.dirname(settings.workflowPath), { recursive: true });
+    await writeFile(settings.workflowPath, defaultWorkflowContract(), "utf8");
+  }
 
   return initProjectReport(configPath, errors, warnings, projects);
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -74,7 +74,7 @@ export type InitProjectOptions = DoctorOptions & {
   yes?: boolean;
 };
 
-export type InitProjectPromptInput = {
+type InitProjectPromptInput = {
   defaultValue: string;
   key:
     | "baseBranch"
@@ -87,9 +87,7 @@ export type InitProjectPromptInput = {
   message: string;
 };
 
-export type InitProjectPrompt = (
-  input: InitProjectPromptInput
-) => Promise<string>;
+type InitProjectPrompt = (input: InitProjectPromptInput) => Promise<string>;
 
 type InitProjectProjectReport = {
   createdOperationalLabels: string[];

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -553,10 +553,24 @@ export async function runInitProject(
     return initProjectReport(configPath, errors, warnings, projects);
   }
 
-  await writeFile(configPath, document.toString(), "utf8");
   if (!(await fileExists(settings.workflowPath))) {
-    await mkdir(path.dirname(settings.workflowPath), { recursive: true });
-    await writeFile(settings.workflowPath, defaultWorkflowContract(), "utf8");
+    try {
+      await mkdir(path.dirname(settings.workflowPath), { recursive: true });
+      await writeFile(settings.workflowPath, defaultWorkflowContract(), "utf8");
+    } catch (error) {
+      errors.push(
+        `starter Workflow Contract could not be created at ${settings.workflowPath}: ${errorMessage(error)}`
+      );
+      return initProjectReport(configPath, errors, warnings, projects);
+    }
+  }
+
+  try {
+    await writeFile(configPath, document.toString(), "utf8");
+  } catch (error) {
+    errors.push(
+      `service config could not be written at ${configPath}: ${errorMessage(error)}`
+    );
   }
 
   return initProjectReport(configPath, errors, warnings, projects);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -412,7 +412,11 @@ export async function runInitProject(
   const warnings: string[] = [];
   const projects: InitProjectProjectReport[] = [];
   if (!resolvedConfig.configExists) {
-    errors.push(missingUserConfigHint(configPath));
+    errors.push(
+      resolvedConfig.source === "user"
+        ? missingUserConfigHint(configPath)
+        : `service config not found at ${configPath}`
+    );
     return initProjectReport(configPath, errors, warnings, projects);
   }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -11,7 +11,7 @@ import { defaultUserConfigPath, defaultUserStateRoot } from "./config-paths.js";
 
 export type InitProvider = "codex" | "claude";
 
-export type InitPromptInput = {
+type InitPromptInput = {
   defaultValue: string;
   key:
     | "claudeCommand"
@@ -25,7 +25,7 @@ export type InitPromptInput = {
   message: string;
 };
 
-export type InitPrompt = (input: InitPromptInput) => Promise<string>;
+type InitPrompt = (input: InitPromptInput) => Promise<string>;
 
 export type InitOptions = {
   env?: NodeJS.ProcessEnv;

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,6 +2,8 @@ import { execFile as execFileCallback } from "node:child_process";
 import { constants } from "node:fs";
 import { access, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
 import { promisify } from "node:util";
 import { stringify } from "yaml";
 
@@ -9,29 +11,48 @@ import { defaultUserConfigPath, defaultUserStateRoot } from "./config-paths.js";
 
 export type InitProvider = "codex" | "claude";
 
+export type InitPromptInput = {
+  defaultValue: string;
+  key:
+    | "claudeCommand"
+    | "codexCommand"
+    | "mergeEnabled"
+    | "mergeMethod"
+    | "pollingIntervalMs"
+    | "requireReviewDecision"
+    | "requireStatusSuccess"
+    | "stateRoot";
+  message: string;
+};
+
+export type InitPrompt = (input: InitPromptInput) => Promise<string>;
+
 export type InitOptions = {
-  cwd?: string;
   env?: NodeJS.ProcessEnv;
   force?: boolean;
   homeDir?: string;
-  provider?: InitProvider;
+  prompt?: InitPrompt;
+  yes?: boolean;
 };
 
 export type InitReport = {
   configPath: string;
   createdConfig: boolean;
-  createdWorkflow: boolean;
   errors: string[];
   ok: boolean;
-  projectName: string | null;
-  repository: string | null;
   stateRoot: string;
-  workflowPath: string | null;
 };
 
 type GitHubRemote = {
   owner: string;
   repo: string;
+};
+
+export type GitHubProjectMetadata = GitHubRemote & {
+  baseBranch: string;
+  projectName: string;
+  projectRoot: string;
+  remote: string;
 };
 
 const execFile = promisify(execFileCallback);
@@ -41,34 +62,35 @@ const DEFAULT_CODEX_COMMAND =
 const DEFAULT_CLAUDE_COMMAND =
   "claude -p --dangerously-skip-permissions --verbose --input-format stream-json --output-format stream-json";
 
+type GlobalInitSettings = {
+  claudeCommand: string;
+  codexCommand: string;
+  mergeEnabled: boolean;
+  mergeMethod: "merge" | "rebase" | "squash";
+  pollingIntervalMs: number;
+  requireReviewDecision: boolean;
+  requireStatusSuccess: boolean;
+  stateRoot: string;
+};
+
 export async function runInit(options: InitOptions = {}): Promise<InitReport> {
-  const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
-  const provider = options.provider ?? "codex";
   const userPathOptions = {
     ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
     env
   };
   const configPath = defaultUserConfigPath(userPathOptions);
-  const stateRoot = defaultUserStateRoot(userPathOptions);
+  const defaultStateRoot = defaultUserStateRoot(userPathOptions);
+  let stateRoot = defaultStateRoot;
   const errors: string[] = [];
   const baseReport = (overrides: Partial<InitReport> = {}): InitReport => ({
     configPath,
     createdConfig: false,
-    createdWorkflow: false,
     errors,
     ok: false,
-    projectName: null,
-    repository: null,
     stateRoot,
-    workflowPath: null,
     ...overrides
   });
-
-  if (provider !== "codex" && provider !== "claude") {
-    errors.push("provider must be one of codex, claude");
-    return baseReport();
-  }
 
   if (options.force !== true && (await fileExists(configPath))) {
     errors.push(
@@ -77,80 +99,36 @@ export async function runInit(options: InitOptions = {}): Promise<InitReport> {
     return baseReport();
   }
 
-  let projectRoot: string;
-  let remoteUrl: string;
-  let baseBranch: string;
+  let settings: GlobalInitSettings;
   try {
-    projectRoot = await gitOutput(["rev-parse", "--show-toplevel"], cwd);
-    remoteUrl = await gitOutput(["remote", "get-url", "origin"], projectRoot);
-    baseBranch = await detectBaseBranch(projectRoot);
+    settings = await collectGlobalSettings({
+      defaultStateRoot,
+      ...(options.prompt === undefined ? {} : { prompt: options.prompt }),
+      yes: options.yes === true
+    });
   } catch (error) {
-    errors.push(
-      `symphonika init must run inside a Git repository with an origin remote: ${errorMessage(error)}`
-    );
+    errors.push(errorMessage(error));
     return baseReport();
   }
-
-  const parsedRemote = parseGitHubRemote(remoteUrl);
-  if (parsedRemote === null) {
-    errors.push(
-      `origin remote must point at github.com for automatic init; found ${remoteUrl}`
-    );
-    return baseReport();
-  }
-
-  const projectName = sanitizeProjectName(parsedRemote.repo);
-  const workflowPath = path.join(projectRoot, "WORKFLOW.md");
-  const config = buildServiceConfig({
-    baseBranch,
-    projectName,
-    provider,
-    remote: remoteUrl,
-    stateRoot,
-    workflowPath,
-    ...parsedRemote
-  });
+  stateRoot = settings.stateRoot;
+  const config = buildServiceConfig(settings);
 
   await mkdir(path.dirname(configPath), { recursive: true });
   await writeFile(configPath, stringify(config), "utf8");
 
-  let createdWorkflow = false;
-  if (!(await fileExists(workflowPath))) {
-    await writeFile(workflowPath, defaultWorkflowContract(), "utf8");
-    createdWorkflow = true;
-  }
-
   return baseReport({
     createdConfig: true,
-    createdWorkflow,
-    ok: true,
-    projectName,
-    repository: `${parsedRemote.owner}/${parsedRemote.repo}`,
-    workflowPath
+    ok: true
   });
 }
 
-function buildServiceConfig(input: {
-  baseBranch: string;
-  owner: string;
-  projectName: string;
-  provider: InitProvider;
-  remote: string;
-  repo: string;
-  stateRoot: string;
-  workflowPath: string;
-}): unknown {
+function buildServiceConfig(settings: GlobalInitSettings): unknown {
   return {
     state: {
-      root: input.stateRoot
+      root: settings.stateRoot
     },
     polling: {
-      interval_ms: 30000
-    },
-    watchdog: {
-      enabled: true,
-      grace_minutes: 30,
-      sample_interval_seconds: 60
+      interval_ms: settings.pollingIntervalMs
     },
     pull_requests: {
       enabled: true,
@@ -158,59 +136,179 @@ function buildServiceConfig(input: {
         max_dispatches_per_pr: 3
       },
       merge: {
-        enabled: false,
-        method: "squash",
-        require_review_decision: false,
-        require_status_success: true
+        enabled: settings.mergeEnabled,
+        method: settings.mergeMethod,
+        require_review_decision: settings.requireReviewDecision,
+        require_status_success: settings.requireStatusSuccess
       }
     },
     providers: {
       codex: {
-        command: DEFAULT_CODEX_COMMAND
+        command: settings.codexCommand
       },
       claude: {
-        command: DEFAULT_CLAUDE_COMMAND
+        command: settings.claudeCommand
       }
     },
-    projects: [
-      {
-        name: input.projectName,
-        disabled: false,
-        weight: 1,
-        tracker: {
-          kind: "github",
-          owner: input.owner,
-          repo: input.repo,
-          token: "$GITHUB_TOKEN"
-        },
-        issue_filters: {
-          states: ["open"],
-          labels_all: ["agent-ready"],
-          labels_none: ["blocked", "needs-human", "sym:stale"]
-        },
-        priority: {
-          labels: {
-            "priority:critical": 0,
-            "priority:high": 1,
-            "priority:medium": 2,
-            "priority:low": 3
-          },
-          default: 99
-        },
-        workspace: {
-          root: path.join(input.stateRoot, "workspaces", input.projectName),
-          git: {
-            remote: input.remote,
-            base_branch: input.baseBranch
-          }
-        },
-        agent: {
-          provider: input.provider
-        },
-        workflow: input.workflowPath
-      }
-    ]
+    projects: []
   };
+}
+
+async function collectGlobalSettings(input: {
+  defaultStateRoot: string;
+  prompt?: InitPrompt;
+  yes: boolean;
+}): Promise<GlobalInitSettings> {
+  const defaults = {
+    claudeCommand: DEFAULT_CLAUDE_COMMAND,
+    codexCommand: DEFAULT_CODEX_COMMAND,
+    mergeEnabled: "no",
+    mergeMethod: "squash",
+    pollingIntervalMs: "30000",
+    requireReviewDecision: "no",
+    requireStatusSuccess: "yes",
+    stateRoot: input.defaultStateRoot
+  } as const;
+  const promptController = createPromptController(input.prompt, input.yes);
+
+  try {
+    const stateRoot = await promptController.ask({
+      defaultValue: defaults.stateRoot,
+      key: "stateRoot",
+      message: "State root"
+    });
+    const pollingIntervalMs = positiveInteger(
+      await promptController.ask({
+        defaultValue: defaults.pollingIntervalMs,
+        key: "pollingIntervalMs",
+        message: "Polling interval (ms)"
+      }),
+      "polling interval"
+    );
+    const mergeEnabled = parseBooleanAnswer(
+      await promptController.ask({
+        defaultValue: defaults.mergeEnabled,
+        key: "mergeEnabled",
+        message: "Enable automatic pull-request merging"
+      }),
+      "automatic pull-request merging"
+    );
+    const mergeMethod = parseMergeMethod(
+      await promptController.ask({
+        defaultValue: defaults.mergeMethod,
+        key: "mergeMethod",
+        message: "Pull-request merge method (squash, merge, or rebase)"
+      })
+    );
+    const requireStatusSuccess = parseBooleanAnswer(
+      await promptController.ask({
+        defaultValue: defaults.requireStatusSuccess,
+        key: "requireStatusSuccess",
+        message: "Require successful status checks before merge"
+      }),
+      "status-check requirement"
+    );
+    const requireReviewDecision = parseBooleanAnswer(
+      await promptController.ask({
+        defaultValue: defaults.requireReviewDecision,
+        key: "requireReviewDecision",
+        message: "Require an approving review before merge"
+      }),
+      "review requirement"
+    );
+    const codexCommand = await promptController.ask({
+      defaultValue: defaults.codexCommand,
+      key: "codexCommand",
+      message: "Codex command"
+    });
+    const claudeCommand = await promptController.ask({
+      defaultValue: defaults.claudeCommand,
+      key: "claudeCommand",
+      message: "Claude command"
+    });
+
+    for (const [label, value] of [
+      ["state root", stateRoot],
+      ["Codex command", codexCommand],
+      ["Claude command", claudeCommand]
+    ] as const) {
+      if (value.trim().length === 0) {
+        throw new Error(`${label} must not be empty`);
+      }
+    }
+
+    return {
+      claudeCommand,
+      codexCommand,
+      mergeEnabled,
+      mergeMethod,
+      pollingIntervalMs,
+      requireReviewDecision,
+      requireStatusSuccess,
+      stateRoot
+    };
+  } finally {
+    promptController.close();
+  }
+}
+
+function createPromptController(
+  injectedPrompt: InitPrompt | undefined,
+  yes: boolean
+): { ask: InitPrompt; close: () => void } {
+  if (yes) {
+    return {
+      ask: (input) => Promise.resolve(input.defaultValue),
+      close: () => undefined
+    };
+  }
+
+  if (injectedPrompt !== undefined) {
+    return {
+      ask: async (input) => {
+        const answer = await injectedPrompt(input);
+        return answer.trim().length === 0 ? input.defaultValue : answer.trim();
+      },
+      close: () => undefined
+    };
+  }
+
+  const readline = createInterface({ input: stdin, output: stdout });
+  return {
+    ask: async (input) => {
+      const answer = await readline.question(
+        `${input.message} [${input.defaultValue}]: `
+      );
+      return answer.trim().length === 0 ? input.defaultValue : answer.trim();
+    },
+    close: () => readline.close()
+  };
+}
+
+function positiveInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseBooleanAnswer(value: string, label: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  if (["y", "yes", "true"].includes(normalized)) {
+    return true;
+  }
+  if (["n", "no", "false"].includes(normalized)) {
+    return false;
+  }
+  throw new Error(`${label} must be yes or no`);
+}
+
+function parseMergeMethod(value: string): GlobalInitSettings["mergeMethod"] {
+  if (value === "squash" || value === "merge" || value === "rebase") {
+    return value;
+  }
+  throw new Error("merge method must be one of squash, merge, rebase");
 }
 
 async function detectBaseBranch(projectRoot: string): Promise<string> {
@@ -243,6 +341,39 @@ async function detectBaseBranch(projectRoot: string): Promise<string> {
   }
 
   return "main";
+}
+
+export async function inspectCurrentGitHubProject(
+  cwd: string
+): Promise<GitHubProjectMetadata> {
+  let projectRoot: string;
+  let remote: string;
+  let baseBranch: string;
+  try {
+    projectRoot = await gitOutput(["rev-parse", "--show-toplevel"], cwd);
+    remote = await gitOutput(["remote", "get-url", "origin"], projectRoot);
+    baseBranch = await detectBaseBranch(projectRoot);
+  } catch (error) {
+    throw new Error(
+      `symphonika init-project must run inside a Git repository with an origin remote: ${errorMessage(error)}`,
+      { cause: error }
+    );
+  }
+
+  const parsedRemote = parseGitHubRemote(remote);
+  if (parsedRemote === null) {
+    throw new Error(
+      `origin remote must point at github.com for automatic Project initialization; found ${remote}`
+    );
+  }
+
+  return {
+    ...parsedRemote,
+    baseBranch,
+    projectName: sanitizeProjectName(parsedRemote.repo),
+    projectRoot,
+    remote
+  };
 }
 
 async function gitOutput(args: string[], cwd: string): Promise<string> {
@@ -302,7 +433,7 @@ function sanitizeProjectName(repo: string): string {
   return sanitized.replace(/^-+|-+$/g, "") || "project";
 }
 
-function defaultWorkflowContract(): string {
+export function defaultWorkflowContract(): string {
   return [
     "# Implementing issue #{{issue.number}}: {{issue.title}}",
     "",

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -546,26 +546,16 @@ describe("CLI", () => {
     }
   });
 
-  it("init creates a user service config for the current GitHub project", async () => {
+  it("init --yes creates a global service config without requiring a Git repository", async () => {
     const previousExitCode = process.exitCode;
     const previousCwd = process.cwd();
     const previousConfigHome = process.env.XDG_CONFIG_HOME;
     const previousStateHome = process.env.XDG_STATE_HOME;
     process.exitCode = 0;
     const root = await makeTempRoot();
-    const projectRoot = path.join(root, "s11");
     const configHome = path.join(root, "config");
     const stateHome = path.join(root, "state");
-    await mkdir(projectRoot, { recursive: true });
-    await execFile("git", ["init", "--initial-branch", "main"], {
-      cwd: projectRoot
-    });
-    await execFile(
-      "git",
-      ["remote", "add", "origin", "https://github.com/pmatos/s11.git"],
-      { cwd: projectRoot }
-    );
-    process.chdir(projectRoot);
+    process.chdir(root);
     process.env.XDG_CONFIG_HOME = configHome;
     process.env.XDG_STATE_HOME = stateHome;
     const output = { stderr: "", stdout: "" };
@@ -581,25 +571,19 @@ describe("CLI", () => {
     });
     const configPath = path.join(configHome, "symphonika", "symphonika.yml");
     const stateRoot = path.join(stateHome, "symphonika");
-    const workflowPath = path.join(projectRoot, "WORKFLOW.md");
 
     try {
-      await program.parseAsync(["node", "symphonika", "init"]);
+      await program.parseAsync(["node", "symphonika", "init", "--yes"]);
 
       const config = await readFile(configPath, "utf8");
-      const workflow = await readFile(workflowPath, "utf8");
       expect(config).toContain(`root: ${stateRoot}`);
-      expect(config).toContain("owner: pmatos");
-      expect(config).toContain("repo: s11");
-      expect(config).toContain("remote: https://github.com/pmatos/s11.git");
-      expect(config).toContain(
-        `root: ${path.join(stateRoot, "workspaces", "s11")}`
-      );
-      expect(config).toContain(`workflow: ${workflowPath}`);
-      expect(workflow).toContain("# Implementing issue #{{issue.number}}");
+      expect(config).toContain("interval_ms: 30000");
+      expect(config).toContain("projects: []");
+      expect(config).not.toContain("tracker:");
+      expect(config).not.toContain("watchdog:");
       expect(output.stdout).toContain("init ok");
       expect(output.stdout).toContain(configPath);
-      expect(output.stdout).toContain("symphonika doctor");
+      expect(output.stdout).toContain("symphonika init-project");
       expect(output.stderr).toBe("");
       expect(process.exitCode).not.toBe(1);
     } finally {
@@ -650,12 +634,14 @@ describe("CLI", () => {
       "init-project",
       "--config",
       "custom.yml",
+      "--force",
       "--yes"
     ]);
 
     expect(initializations).toHaveLength(1);
     expect(initializations[0]).toMatchObject({
       configPath: "custom.yml",
+      force: true,
       yes: true
     });
     expect(output.stderr).toContain("will create operational labels");

--- a/tests/doctor-github.test.ts
+++ b/tests/doctor-github.test.ts
@@ -1,6 +1,8 @@
+import { execFile as execFileCallback } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -13,6 +15,7 @@ import type { GitHubIssuesApi } from "../src/issue-polling.js";
 import type { AgentProviderRegistry } from "../src/provider.js";
 
 const tempRoots: string[] = [];
+const execFile = promisify(execFileCallback);
 
 async function makeTempRoot(): Promise<string> {
   const root = await mkdtemp(path.join(tmpdir(), "symphonika-github-test-"));
@@ -241,7 +244,7 @@ function fakeAgentProviders(): AgentProviderRegistry {
 }
 
 describe("GitHub Project initialization", () => {
-  it("warns about the target repository and labels without mutating unless confirmed", async () => {
+  it("refuses to replace an existing Project name unless forced", async () => {
     const root = await makeTempRoot();
     await writeValidProject(root);
     const githubApi: GitHubApi = {
@@ -254,16 +257,15 @@ describe("GitHub Project initialization", () => {
       configPath: "symphonika.yml",
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
-      githubApi
+      githubApi,
+      yes: true
     });
 
     expect(report.ok).toBe(false);
-    expect(report.warnings).toContain(
-      "init-project would create operational labels in pmatos/symphonika: sym:running, sym:failed, sym:blocked, sym:stale"
+    expect(report.errors[0]).toMatch(
+      /project symphonika already exists.*pass --force/i
     );
-    expect(report.errors).toContain(
-      "pass --yes to create missing operational labels non-interactively"
-    );
+    expect(githubApi.validateRepositoryAccess).not.toHaveBeenCalled();
     expect(githubApi.createLabel).not.toHaveBeenCalled();
   });
 
@@ -280,6 +282,7 @@ describe("GitHub Project initialization", () => {
       configPath: "symphonika.yml",
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
+      force: true,
       githubApi,
       yes: true
     });
@@ -331,6 +334,7 @@ describe("GitHub Project initialization", () => {
       configPath: "symphonika.yml",
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
+      force: true,
       githubApi,
       onWarning: (warning) => {
         events.push(`warning:${warning}`);
@@ -365,6 +369,7 @@ describe("GitHub Project initialization", () => {
       configPath: "symphonika.yml",
       cwd: root,
       env: { GITHUB_TOKEN: "secret-token" },
+      force: true,
       githubApi,
       yes: true
     });
@@ -555,6 +560,12 @@ describe("runClearStale", () => {
 
 async function writeValidProject(root: string): Promise<void> {
   await mkdir(root, { recursive: true });
+  await execFile("git", ["init", "--initial-branch", "main"], { cwd: root });
+  await execFile(
+    "git",
+    ["remote", "add", "origin", "https://github.com/pmatos/symphonika.git"],
+    { cwd: root }
+  );
   await writeFile(
     path.join(root, "symphonika.yml"),
     [

--- a/tests/init-project.test.ts
+++ b/tests/init-project.test.ts
@@ -281,6 +281,93 @@ describe("Project initialization", () => {
     ]);
     expect(githubApi.validateRepositoryAccess).not.toHaveBeenCalled();
   });
+
+  it("does not persist the new Project when the repository is not accessible", async () => {
+    const root = await makeTempRoot();
+    const repositoryRoot = path.join(root, "new-project");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await createGitHubRepository(
+      repositoryRoot,
+      "https://github.com/acme/new-project.git"
+    );
+    await writeExistingConfig(configPath, root);
+    const originalContents = await readFile(configPath, "utf8");
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      validateRepositoryAccess: vi
+        .fn()
+        .mockResolvedValue({ message: "not a collaborator", ok: false })
+    };
+
+    const report = await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      yes: true
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual([
+      "projects.new-project.tracker.repository acme/new-project is not accessible: not a collaborator"
+    ]);
+    expect(githubApi.listLabels).not.toHaveBeenCalled();
+    expect(githubApi.createLabel).not.toHaveBeenCalled();
+    await expect(readFile(configPath, "utf8")).resolves.toBe(originalContents);
+    await expect(
+      readFile(path.join(repositoryRoot, "WORKFLOW.md"), "utf8")
+    ).rejects.toThrow();
+  });
+
+  it("registers the Project but requires --yes before creating missing operational labels", async () => {
+    const root = await makeTempRoot();
+    const repositoryRoot = path.join(root, "new-project");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await createGitHubRepository(
+      repositoryRoot,
+      "https://github.com/acme/new-project.git"
+    );
+    await writeExistingConfig(configPath, root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue([]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      prompt: (input) =>
+        Promise.resolve(input.key === "provider" ? "codex" : "")
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual([
+      "pass --yes to create missing operational labels non-interactively"
+    ]);
+    expect(report.warnings).toEqual([
+      expect.stringContaining(
+        "init-project would create operational labels in acme/new-project"
+      )
+    ]);
+    expect(report.projects).toEqual([
+      expect.objectContaining({
+        createdOperationalLabels: [],
+        name: "new-project"
+      })
+    ]);
+    expect(githubApi.createLabel).not.toHaveBeenCalled();
+    const config = parse(await readFile(configPath, "utf8")) as {
+      projects: Array<{ name: string }>;
+    };
+    expect(config.projects.map((project) => project.name)).toEqual([
+      "existing",
+      "new-project"
+    ]);
+  });
 });
 
 async function makeTempRoot(): Promise<string> {

--- a/tests/init-project.test.ts
+++ b/tests/init-project.test.ts
@@ -70,7 +70,9 @@ describe("Project initialization", () => {
     });
 
     expect(report.ok).toBe(false);
-    expect(report.errors).toEqual([`service config not found at ${configPath}`]);
+    expect(report.errors).toEqual([
+      `service config not found at ${configPath}`
+    ]);
     expect(githubApi.validateRepositoryAccess).not.toHaveBeenCalled();
   });
 

--- a/tests/init-project.test.ts
+++ b/tests/init-project.test.ts
@@ -25,7 +25,35 @@ afterEach(async () => {
 });
 
 describe("Project initialization", () => {
-  it("points to global initialization when the Service Config is missing", async () => {
+  it("points to global initialization when the default user Service Config is missing", async () => {
+    const root = await makeTempRoot();
+    const configHome = path.join(root, "config-home");
+    const expectedConfigPath = path.join(
+      configHome,
+      "symphonika",
+      "symphonika.yml"
+    );
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      validateRepositoryAccess: vi.fn()
+    };
+
+    const report = await runInitProject({
+      cwd: root,
+      env: { XDG_CONFIG_HOME: configHome },
+      githubApi,
+      yes: true
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual([
+      `no initialized Service Config found at ${expectedConfigPath}; run \`symphonika init\` first`
+    ]);
+    expect(githubApi.validateRepositoryAccess).not.toHaveBeenCalled();
+  });
+
+  it("reports a plain missing-config error for a nonexistent explicit --config path", async () => {
     const root = await makeTempRoot();
     const configPath = path.join(root, "missing", "symphonika.yml");
     const githubApi: GitHubApi = {
@@ -42,9 +70,7 @@ describe("Project initialization", () => {
     });
 
     expect(report.ok).toBe(false);
-    expect(report.errors).toEqual([
-      `no initialized Service Config found at ${configPath}; run \`symphonika init\` first`
-    ]);
+    expect(report.errors).toEqual([`service config not found at ${configPath}`]);
     expect(githubApi.validateRepositoryAccess).not.toHaveBeenCalled();
   });
 

--- a/tests/init-project.test.ts
+++ b/tests/init-project.test.ts
@@ -1,0 +1,301 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
+
+import {
+  REQUIRED_OPERATIONAL_LABELS,
+  runInitProject,
+  type GitHubApi
+} from "../src/doctor.js";
+
+const execFile = promisify(execFileCallback);
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("Project initialization", () => {
+  it("points to global initialization when the Service Config is missing", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "missing", "symphonika.yml");
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn(),
+      validateRepositoryAccess: vi.fn()
+    };
+
+    const report = await runInitProject({
+      configPath,
+      cwd: root,
+      githubApi,
+      yes: true
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual([
+      `no initialized Service Config found at ${configPath}; run \`symphonika init\` first`
+    ]);
+    expect(githubApi.validateRepositoryAccess).not.toHaveBeenCalled();
+  });
+
+  it("appends the current repository while preserving existing config and creates its workflow", async () => {
+    const root = await makeTempRoot();
+    const repositoryRoot = path.join(root, "new-project");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await createGitHubRepository(
+      repositoryRoot,
+      "https://github.com/acme/new-project.git"
+    );
+    await writeExistingConfig(configPath, root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue([...REQUIRED_OPERATIONAL_LABELS]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      yes: true
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.projects).toEqual([
+      expect.objectContaining({
+        name: "new-project",
+        repository: "acme/new-project"
+      })
+    ]);
+    const contents = await readFile(configPath, "utf8");
+    const config = parse(contents) as {
+      projects: Array<{
+        name: string;
+        tracker: { owner: string; repo: string };
+        workflow: string;
+      }>;
+    };
+    expect(contents).toContain("# Keep this operator note");
+    expect(config.projects.map((project) => project.name)).toEqual([
+      "existing",
+      "new-project"
+    ]);
+    expect(config.projects[1]).toMatchObject({
+      tracker: { owner: "acme", repo: "new-project" },
+      workflow: path.join(repositoryRoot, "WORKFLOW.md")
+    });
+    await expect(
+      readFile(path.join(repositoryRoot, "WORKFLOW.md"), "utf8")
+    ).resolves.toContain("# Implementing issue #{{issue.number}}");
+    expect(githubApi.validateRepositoryAccess).toHaveBeenCalledOnce();
+    expect(githubApi.validateRepositoryAccess).toHaveBeenCalledWith({
+      owner: "acme",
+      repo: "new-project",
+      token: "secret-token"
+    });
+  });
+
+  it("uses interactive answers for repository-specific settings", async () => {
+    const root = await makeTempRoot();
+    const repositoryRoot = path.join(root, "source-repository");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await createGitHubRepository(
+      repositoryRoot,
+      "git@github.com:acme/source-repository.git"
+    );
+    await writeEmptyConfig(configPath, root);
+    const answers: Record<string, string> = {
+      baseBranch: "develop",
+      excludedLabels: "paused, sym:stale",
+      priorityLabels: "urgent=0, normal=5",
+      projectName: "custom-project",
+      provider: "claude",
+      requiredLabels: "ready, backend",
+      workflowPath: "automation/WORKFLOW.md"
+    };
+    const prompted: string[] = [];
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue([...REQUIRED_OPERATIONAL_LABELS]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      prompt: (input) => {
+        prompted.push(input.key);
+        return Promise.resolve(answers[input.key] ?? "");
+      }
+    });
+
+    expect(report.ok).toBe(true);
+    const config = parse(await readFile(configPath, "utf8")) as {
+      projects: Array<Record<string, unknown>>;
+    };
+    expect(config.projects).toHaveLength(1);
+    expect(config.projects[0]).toMatchObject({
+      agent: { provider: "claude" },
+      issue_filters: {
+        labels_all: ["ready", "backend"],
+        labels_none: ["paused", "sym:stale"],
+        states: ["open"]
+      },
+      name: "custom-project",
+      priority: {
+        default: 99,
+        labels: { normal: 5, urgent: 0 }
+      },
+      workflow: path.join(repositoryRoot, "automation", "WORKFLOW.md"),
+      workspace: { git: { base_branch: "develop" } }
+    });
+    expect(prompted).toEqual([
+      "projectName",
+      "provider",
+      "baseBranch",
+      "requiredLabels",
+      "excludedLabels",
+      "priorityLabels",
+      "workflowPath"
+    ]);
+  });
+
+  it("force replaces only the matching Project instead of adding a duplicate", async () => {
+    const root = await makeTempRoot();
+    const repositoryRoot = path.join(root, "new-project");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await createGitHubRepository(
+      repositoryRoot,
+      "https://github.com/acme/new-project.git"
+    );
+    await writeExistingConfig(configPath, root);
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue([...REQUIRED_OPERATIONAL_LABELS]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      yes: true
+    });
+    const report = await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      force: true,
+      githubApi,
+      prompt: (input) =>
+        Promise.resolve(input.key === "provider" ? "claude" : "")
+    });
+
+    expect(report.ok).toBe(true);
+    const config = parse(await readFile(configPath, "utf8")) as {
+      projects: Array<{ agent: { provider: string }; name: string }>;
+    };
+    expect(config.projects.map((project) => project.name)).toEqual([
+      "existing",
+      "new-project"
+    ]);
+    expect(config.projects[1]?.agent.provider).toBe("claude");
+  });
+});
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(
+    path.join(tmpdir(), "symphonika-init-project-test-")
+  );
+  tempRoots.push(root);
+  return root;
+}
+
+async function createGitHubRepository(
+  root: string,
+  remote: string
+): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await execFile("git", ["init", "--initial-branch", "main"], { cwd: root });
+  await execFile("git", ["remote", "add", "origin", remote], { cwd: root });
+}
+
+async function writeExistingConfig(
+  configPath: string,
+  root: string
+): Promise<void> {
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(
+    configPath,
+    [
+      "# Keep this operator note",
+      "state:",
+      `  root: ${path.join(root, "state")}`,
+      "providers:",
+      "  codex:",
+      "    command: codex app-server",
+      "  claude:",
+      "    command: claude --stream",
+      "projects:",
+      "  - name: existing",
+      "    tracker:",
+      "      kind: github",
+      "      owner: acme",
+      "      repo: existing",
+      '      token: "$GITHUB_TOKEN"',
+      "    issue_filters:",
+      '      states: ["open"]',
+      '      labels_all: ["agent-ready"]',
+      '      labels_none: ["blocked"]',
+      "    priority:",
+      "      labels: {}",
+      "      default: 99",
+      "    workspace:",
+      `      root: ${path.join(root, "state", "workspaces", "existing")}`,
+      "      git:",
+      "        remote: https://github.com/acme/existing.git",
+      "        base_branch: main",
+      "    agent:",
+      "      provider: codex",
+      `    workflow: ${path.join(root, "existing", "WORKFLOW.md")}`,
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+}
+
+async function writeEmptyConfig(
+  configPath: string,
+  root: string
+): Promise<void> {
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(
+    configPath,
+    [
+      "state:",
+      `  root: ${path.join(root, "state")}`,
+      "providers:",
+      "  codex:",
+      "    command: codex app-server",
+      "  claude:",
+      "    command: claude --stream",
+      "projects: []",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+}

--- a/tests/init-project.test.ts
+++ b/tests/init-project.test.ts
@@ -470,6 +470,47 @@ describe("Project initialization", () => {
       readFile(path.join(repositoryRoot, "WORKFLOW.md"), "utf8")
     ).rejects.toThrow();
   });
+
+  it("does not persist the new Project when its starter workflow cannot be created", async () => {
+    const root = await makeTempRoot();
+    const repositoryRoot = path.join(root, "new-project");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await createGitHubRepository(
+      repositoryRoot,
+      "https://github.com/acme/new-project.git"
+    );
+    await writeExistingConfig(configPath, root);
+    const originalContents = await readFile(configPath, "utf8");
+    const workflowParent = path.join(repositoryRoot, "workflow-parent");
+    const workflowPath = path.join(workflowParent, "WORKFLOW.md");
+    await writeFile(workflowParent, "not a directory", "utf8");
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue([...REQUIRED_OPERATIONAL_LABELS]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      prompt: (input) =>
+        Promise.resolve(input.key === "workflowPath" ? workflowPath : "")
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual([
+      expect.stringContaining(
+        `starter Workflow Contract could not be created at ${workflowPath}:`
+      )
+    ]);
+    expect(githubApi.createLabel).not.toHaveBeenCalled();
+    await expect(readFile(configPath, "utf8")).resolves.toBe(originalContents);
+    await expect(readFile(workflowParent, "utf8")).resolves.toBe(
+      "not a directory"
+    );
+  });
 });
 
 async function makeTempRoot(): Promise<string> {

--- a/tests/init-project.test.ts
+++ b/tests/init-project.test.ts
@@ -244,7 +244,7 @@ describe("Project initialization", () => {
     expect(config.projects[1]?.agent.provider).toBe("claude");
   });
 
-  it("refuses to force-replace when the config already has duplicate Project names", async () => {
+  it("refuses to force-replace normalized duplicate Project names", async () => {
     const root = await makeTempRoot();
     const repositoryRoot = path.join(root, "dup-project");
     const configPath = path.join(root, "config", "symphonika.yml");
@@ -277,7 +277,7 @@ describe("Project initialization", () => {
     };
     expect(config.projects.map((project) => project.name)).toEqual([
       "dup-project",
-      "dup-project"
+      "dup-project "
     ]);
     expect(githubApi.validateRepositoryAccess).not.toHaveBeenCalled();
   });
@@ -486,7 +486,7 @@ describe("Project initialization", () => {
     await writeFile(workflowParent, "not a directory", "utf8");
     const githubApi: GitHubApi = {
       createLabel: vi.fn(),
-      listLabels: vi.fn().mockResolvedValue([...REQUIRED_OPERATIONAL_LABELS]),
+      listLabels: vi.fn().mockResolvedValue([]),
       validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
     };
 
@@ -601,8 +601,8 @@ async function writeDuplicateProjectConfig(
   root: string,
   name: string
 ): Promise<void> {
-  const project = (repo: string): string[] => [
-    `  - name: ${name}`,
+  const project = (repo: string, projectName: string): string[] => [
+    `  - name: ${JSON.stringify(projectName)}`,
     "    tracker:",
     "      kind: github",
     "      owner: acme",
@@ -637,8 +637,8 @@ async function writeDuplicateProjectConfig(
       "  claude:",
       "    command: claude --stream",
       "projects:",
-      ...project("first-copy"),
-      ...project("second-copy"),
+      ...project("first-copy", name),
+      ...project("second-copy", `${name} `),
       ""
     ].join("\n"),
     "utf8"

--- a/tests/init-project.test.ts
+++ b/tests/init-project.test.ts
@@ -241,6 +241,44 @@ describe("Project initialization", () => {
     ]);
     expect(config.projects[1]?.agent.provider).toBe("claude");
   });
+
+  it("refuses to force-replace when the config already has duplicate Project names", async () => {
+    const root = await makeTempRoot();
+    const repositoryRoot = path.join(root, "dup-project");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await createGitHubRepository(
+      repositoryRoot,
+      "https://github.com/acme/dup-project.git"
+    );
+    await writeDuplicateProjectConfig(configPath, root, "dup-project");
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue([...REQUIRED_OPERATIONAL_LABELS]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      force: true,
+      githubApi,
+      yes: true
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual([
+      `project dup-project appears 2 times in ${configPath}; remove the duplicate Projects before running init-project`
+    ]);
+    const config = parse(await readFile(configPath, "utf8")) as {
+      projects: Array<{ name: string }>;
+    };
+    expect(config.projects.map((project) => project.name)).toEqual([
+      "dup-project",
+      "dup-project"
+    ]);
+    expect(githubApi.validateRepositoryAccess).not.toHaveBeenCalled();
+  });
 });
 
 async function makeTempRoot(): Promise<string> {
@@ -320,6 +358,55 @@ async function writeEmptyConfig(
       "  claude:",
       "    command: claude --stream",
       "projects: []",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+}
+
+async function writeDuplicateProjectConfig(
+  configPath: string,
+  root: string,
+  name: string
+): Promise<void> {
+  const project = (repo: string): string[] => [
+    `  - name: ${name}`,
+    "    tracker:",
+    "      kind: github",
+    "      owner: acme",
+    `      repo: ${repo}`,
+    '      token: "$GITHUB_TOKEN"',
+    "    issue_filters:",
+    '      states: ["open"]',
+    '      labels_all: ["agent-ready"]',
+    '      labels_none: ["blocked"]',
+    "    priority:",
+    "      labels: {}",
+    "      default: 99",
+    "    workspace:",
+    `      root: ${path.join(root, "state", "workspaces", repo)}`,
+    "      git:",
+    `        remote: https://github.com/acme/${repo}.git`,
+    "        base_branch: main",
+    "    agent:",
+    "      provider: codex",
+    `    workflow: ${path.join(root, repo, "WORKFLOW.md")}`
+  ];
+
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(
+    configPath,
+    [
+      "state:",
+      `  root: ${path.join(root, "state")}`,
+      "providers:",
+      "  codex:",
+      "    command: codex app-server",
+      "  claude:",
+      "    command: claude --stream",
+      "projects:",
+      ...project("first-copy"),
+      ...project("second-copy"),
       ""
     ].join("\n"),
     "utf8"

--- a/tests/init-project.test.ts
+++ b/tests/init-project.test.ts
@@ -320,7 +320,7 @@ describe("Project initialization", () => {
     ).rejects.toThrow();
   });
 
-  it("registers the Project but requires --yes before creating missing operational labels", async () => {
+  it("does not register the Project without --yes when operational labels are missing", async () => {
     const root = await makeTempRoot();
     const repositoryRoot = path.join(root, "new-project");
     const configPath = path.join(root, "config", "symphonika.yml");
@@ -329,6 +329,7 @@ describe("Project initialization", () => {
       "https://github.com/acme/new-project.git"
     );
     await writeExistingConfig(configPath, root);
+    const originalContents = await readFile(configPath, "utf8");
     const githubApi: GitHubApi = {
       createLabel: vi.fn(),
       listLabels: vi.fn().mockResolvedValue([]),
@@ -360,13 +361,57 @@ describe("Project initialization", () => {
       })
     ]);
     expect(githubApi.createLabel).not.toHaveBeenCalled();
-    const config = parse(await readFile(configPath, "utf8")) as {
-      projects: Array<{ name: string }>;
+    await expect(readFile(configPath, "utf8")).resolves.toBe(originalContents);
+    await expect(
+      readFile(path.join(repositoryRoot, "WORKFLOW.md"), "utf8")
+    ).rejects.toThrow();
+  });
+
+  it("does not persist the new Project when operational label creation fails", async () => {
+    const root = await makeTempRoot();
+    const repositoryRoot = path.join(root, "new-project");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await createGitHubRepository(
+      repositoryRoot,
+      "https://github.com/acme/new-project.git"
+    );
+    await writeExistingConfig(configPath, root);
+    const originalContents = await readFile(configPath, "utf8");
+    const missingLabel = REQUIRED_OPERATIONAL_LABELS[0];
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn().mockRejectedValue(new Error("permission denied")),
+      listLabels: vi
+        .fn()
+        .mockResolvedValue(
+          REQUIRED_OPERATIONAL_LABELS.filter((label) => label !== missingLabel)
+        ),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
     };
-    expect(config.projects.map((project) => project.name)).toEqual([
-      "existing",
-      "new-project"
+
+    const report = await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      yes: true
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual([
+      `projects.new-project.tracker.repository acme/new-project could not create operational label ${missingLabel}: permission denied`
     ]);
+    expect(report.projects).toEqual([
+      expect.objectContaining({
+        createdOperationalLabels: [],
+        missingOperationalLabels: [missingLabel],
+        name: "new-project"
+      })
+    ]);
+    expect(githubApi.createLabel).toHaveBeenCalledOnce();
+    await expect(readFile(configPath, "utf8")).resolves.toBe(originalContents);
+    await expect(
+      readFile(path.join(repositoryRoot, "WORKFLOW.md"), "utf8")
+    ).rejects.toThrow();
   });
 });
 

--- a/tests/init-project.test.ts
+++ b/tests/init-project.test.ts
@@ -320,7 +320,66 @@ describe("Project initialization", () => {
     ).rejects.toThrow();
   });
 
-  it("does not register the Project without --yes when operational labels are missing", async () => {
+  it("creates missing operational labels after interactive confirmation", async () => {
+    const root = await makeTempRoot();
+    const repositoryRoot = path.join(root, "new-project");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await createGitHubRepository(
+      repositoryRoot,
+      "https://github.com/acme/new-project.git"
+    );
+    await writeExistingConfig(configPath, root);
+    const prompted: string[] = [];
+    const githubApi: GitHubApi = {
+      createLabel: vi.fn(),
+      listLabels: vi.fn().mockResolvedValue([]),
+      validateRepositoryAccess: vi.fn().mockResolvedValue({ ok: true })
+    };
+
+    const report = await runInitProject({
+      configPath,
+      cwd: repositoryRoot,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubApi,
+      prompt: (input) => {
+        prompted.push(input.key);
+        return Promise.resolve("");
+      }
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.projects).toEqual([
+      expect.objectContaining({
+        createdOperationalLabels: [...REQUIRED_OPERATIONAL_LABELS],
+        name: "new-project"
+      })
+    ]);
+    expect(prompted).toEqual([
+      "projectName",
+      "provider",
+      "baseBranch",
+      "requiredLabels",
+      "excludedLabels",
+      "priorityLabels",
+      "workflowPath",
+      "confirmOperationalLabels"
+    ]);
+    expect(githubApi.createLabel).toHaveBeenCalledTimes(
+      REQUIRED_OPERATIONAL_LABELS.length
+    );
+    const config = parse(await readFile(configPath, "utf8")) as {
+      projects: Array<{ name: string }>;
+    };
+    expect(config.projects.map((project) => project.name)).toEqual([
+      "existing",
+      "new-project"
+    ]);
+    await expect(
+      readFile(path.join(repositoryRoot, "WORKFLOW.md"), "utf8")
+    ).resolves.toContain("# Implementing issue #{{issue.number}}");
+  });
+
+  it("does not register the Project when interactive label creation is declined", async () => {
     const root = await makeTempRoot();
     const repositoryRoot = path.join(root, "new-project");
     const configPath = path.join(root, "config", "symphonika.yml");
@@ -342,13 +401,11 @@ describe("Project initialization", () => {
       env: { GITHUB_TOKEN: "secret-token" },
       githubApi,
       prompt: (input) =>
-        Promise.resolve(input.key === "provider" ? "codex" : "")
+        Promise.resolve(input.key === "confirmOperationalLabels" ? "no" : "")
     });
 
     expect(report.ok).toBe(false);
-    expect(report.errors).toEqual([
-      "pass --yes to create missing operational labels non-interactively"
-    ]);
+    expect(report.errors).toEqual(["operational label creation was declined"]);
     expect(report.warnings).toEqual([
       expect.stringContaining(
         "init-project would create operational labels in acme/new-project"

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+import { runInit } from "../src/init.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("global initialization", () => {
+  it("uses interactive answers for cross-project settings", async () => {
+    const root = await makeTempRoot();
+    const configHome = path.join(root, "config");
+    const answers: Record<string, string> = {
+      claudeCommand: "custom-claude --stream",
+      codexCommand: "custom-codex app-server",
+      mergeEnabled: "yes",
+      mergeMethod: "rebase",
+      pollingIntervalMs: "45000",
+      requireReviewDecision: "yes",
+      requireStatusSuccess: "no",
+      stateRoot: path.join(root, "custom-state")
+    };
+    const prompted: string[] = [];
+
+    const report = await runInit({
+      env: { XDG_CONFIG_HOME: configHome },
+      homeDir: root,
+      prompt: (input) => {
+        prompted.push(input.key);
+        return Promise.resolve(answers[input.key] ?? "");
+      }
+    });
+
+    expect(report.ok).toBe(true);
+    const config = parse(await readFile(report.configPath, "utf8")) as {
+      polling: { interval_ms: number };
+      projects: unknown[];
+      providers: Record<string, { command: string }>;
+      pull_requests: {
+        merge: {
+          enabled: boolean;
+          method: string;
+          require_review_decision: boolean;
+          require_status_success: boolean;
+        };
+      };
+      state: { root: string };
+    };
+    expect(config).toMatchObject({
+      polling: { interval_ms: 45000 },
+      projects: [],
+      providers: {
+        claude: { command: "custom-claude --stream" },
+        codex: { command: "custom-codex app-server" }
+      },
+      pull_requests: {
+        merge: {
+          enabled: true,
+          method: "rebase",
+          require_review_decision: true,
+          require_status_success: false
+        }
+      },
+      state: { root: path.join(root, "custom-state") }
+    });
+    expect(prompted).toEqual([
+      "stateRoot",
+      "pollingIntervalMs",
+      "mergeEnabled",
+      "mergeMethod",
+      "requireStatusSuccess",
+      "requireReviewDecision",
+      "codexCommand",
+      "claudeCommand"
+    ]);
+  });
+});
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-init-test-"));
+  tempRoots.push(root);
+  return root;
+}


### PR DESCRIPTION
## Summary

- split global Service Config initialization from per-repository Project registration
- add interactive prompts and --yes defaults for both commands, with duplicate-safe --force replacement
- preserve existing YAML Projects/comments, create starter workflows, and provision labels for only the new Project
- update the specification, ADR, README, tutorial, and smoke guidance

## Test plan

- npm run lint
- npm run typecheck
- npm test (711 tests; npm 12 install scripts temporarily enabled for the existing npm-link test)
- npm run build

Closes #181