### PR TITLE
feat(routines): add routine scaffold command

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1083,6 +1083,7 @@ states (§12.6).
 Bootstrap CLI commands:
 
 - `symphonika init [--provider codex|claude] [--force]`
+- `symphonika add-routine <name> --project <project> (--schedule <expr> | --at <iso8601>) --kind <git|report> [--provider <codex|claude>] [--tz <iana>] [--config <path>]`
 - `symphonika doctor [--config <path>]`
 - `symphonika init-project [--config <path>] --yes`
 - `symphonika daemon [--config <path>] [--port <port>]`
@@ -1107,11 +1108,20 @@ config path and points the operator to `symphonika init`.
 - operational labels
 - provider commands for Codex and Claude
 - workflow contract path and parse
+- every Routine declaration enumerated by each Project, including duplicate Routine names
 - database path
 - workspace root
 
 `init` writes local files only and never mutates GitHub. `init-project` creates missing operational
 labels only after explicit confirmation.
+
+`add-routine` writes `<cwd>/routines/<name>.md` with validated YAML front matter and a placeholder
+prompt, then registers the declaration path in the named Project's `routines` list. It preserves
+the Service Config's YAML comments and key ordering where supported by the YAML document parser,
+refuses missing Projects, unsafe names, duplicate names, invalid schedules, and existing target
+files, and never contacts GitHub or triggers a daemon reload. When the generated file is outside
+the Service Config directory, registration uses its absolute path; otherwise it uses a `./`-prefixed
+path relative to the Service Config.
 
 `service install --config <path>` resolves the selected Service Config to an absolute path and
 bakes it into the generated unit as `daemon --config <absolute-path>`. Omitting `--config` keeps the

--- a/docs/specs/2026-07-21-add-routine-design.md
+++ b/docs/specs/2026-07-21-add-routine-design.md
@@ -1,0 +1,61 @@
+# Add-routine and Routine validation design
+
+Issue #194 supplies the approved behavior for the Routine creation and validation surface. This
+document records the implementation choices needed to apply that behavior to the current codebase.
+
+## Public seams
+
+- `RoutineConfigEditor` registers a declaration path in one named Project while preserving the YAML
+  document's comments and key ordering.
+- `runAddRoutine` and the `symphonika add-routine` command scaffold and register one declaration
+  using only local filesystem operations.
+- `runDoctor` validates every Routine path enumerated by an enabled or disabled Project and reports
+  declaration and duplicate-name errors beside Workflow Contract errors.
+- `RuntimeConfigReloader` remains the daemon boundary for defensive Routine reloads. Its existing
+  last-known-good snapshot behavior and operator reload status are reused unchanged.
+
+## File and config behavior
+
+The command creates `<cwd>/routines/<name>.md`. The current Service Config has no separate Routine
+directory setting, so the command does not infer a directory from existing declaration paths. When
+the generated file is beneath the Service Config directory, the editor records a `./`-prefixed,
+config-relative path. Otherwise it records an absolute path, matching `init`'s existing handling of
+repository-owned Workflow Contracts in user-level Service Config.
+
+`RoutineConfigEditor` parses `symphonika.yml` as a YAML document rather than converting it through a
+plain JavaScript object. It locates the named Project, verifies that `routines` is absent or a
+sequence, and loads existing Routine declarations through `RoutineDeclarationLoader`. Re-adding the
+same resolved path is an unchanged, successful operation. A different path whose declaration has
+the requested Routine name is rejected.
+
+## Validation and failure handling
+
+Generated Markdown is validated with the same declaration parser used by daemon reload and doctor.
+This catches unsafe names, invalid or unknown cron forms, invalid timezones, invalid one-shot dates,
+and unsupported kinds or providers without running provider or GitHub probes. Exactly one of
+`--schedule` and `--at` is required, and `--tz` is valid only with `--schedule`.
+
+The target Markdown file is created without overwriting an existing file. If config registration
+then fails, the command removes only the file it just created, leaving the Service Config unchanged.
+The command does not contact the daemon or trigger reload; the next normal tick observes both local
+file changes together.
+
+## Generated declaration
+
+Front matter preserves the operator's cron expression rather than replacing aliases with their
+normalized cron form. Optional `provider` and `schedule.tz` keys are emitted only when supplied. The
+Markdown body contains non-empty HTML TODO comments so the declaration is valid but visibly needs
+operator-authored prompt instructions.
+
+## Tests
+
+Tests exercise behavior through the four public seams:
+
+1. `RoutineConfigEditor` appends or creates `routines`, rejects missing Projects and name
+   collisions, is idempotent by resolved path, and preserves unrelated comments and ordering.
+2. `runAddRoutine`/CLI creates valid cron and one-shot declarations, registers them, rejects invalid
+   flags and collisions without partial writes, and succeeds without GitHub or provider adapters.
+3. `runDoctor` reports malformed Routine declarations and duplicate Routine names through its
+   existing error report and CLI failure output.
+4. Existing reload tests continue to prove that an invalid Routine edit retains the last-known-good
+   snapshot and exposes the structured reload error.

--- a/src/add-routine.ts
+++ b/src/add-routine.ts
@@ -1,0 +1,163 @@
+import { mkdir, rmdir, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { stringify } from "yaml";
+
+import { resolveServiceConfigPath } from "./config-paths.js";
+import type { AgentProviderName } from "./provider.js";
+import { RoutineConfigEditor } from "./routines/config-editor.js";
+import { parseRoutineDeclaration } from "./routines/declaration-loader.js";
+import type { RoutineKind } from "./routines/types.js";
+
+export type AddRoutineOptions = {
+  at?: string;
+  configPath?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  kind: RoutineKind;
+  name: string;
+  project: string;
+  provider?: AgentProviderName;
+  schedule?: string;
+  tz?: string;
+};
+
+export type AddRoutineReport = {
+  configPath: string;
+  errors: string[];
+  filePath: string;
+  ok: boolean;
+  project: string;
+  registeredPath: string;
+  routineName: string;
+};
+
+export async function runAddRoutine(
+  options: AddRoutineOptions
+): Promise<AddRoutineReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const configPath = resolveServiceConfigPath({
+    ...(options.configPath === undefined
+      ? {}
+      : { configPath: options.configPath }),
+    cwd,
+    env: options.env ?? process.env
+  }).configPath;
+  const filePath = path.resolve(cwd, "routines", `${options.name}.md`);
+  const registeredPath = registrationPath(configPath, filePath);
+  const errors: string[] = [];
+  const report = (ok: boolean): AddRoutineReport => ({
+    configPath,
+    errors,
+    filePath,
+    ok,
+    project: options.project,
+    registeredPath,
+    routineName: options.name
+  });
+
+  if ((options.schedule === undefined) === (options.at === undefined)) {
+    errors.push("exactly one of --schedule or --at must be supplied");
+    return report(false);
+  }
+  if (options.tz !== undefined && options.schedule === undefined) {
+    errors.push("--tz may only be supplied with --schedule");
+    return report(false);
+  }
+
+  const source = routineSource(options);
+  const validation = parseRoutineDeclaration(source, filePath);
+  if (validation.routine === null) {
+    errors.push(...validation.errors);
+    return report(false);
+  }
+
+  const routinesDirectory = path.dirname(filePath);
+  const createdDirectory = await mkdir(routinesDirectory, { recursive: true });
+  try {
+    await writeFile(filePath, source, { encoding: "utf8", flag: "wx" });
+  } catch (error) {
+    errors.push(
+      isAlreadyExistsError(error)
+        ? `routine file already exists at ${filePath}`
+        : `routine file could not be created at ${filePath}: ${errorMessage(error)}`
+    );
+    await removeCreatedDirectory(createdDirectory, routinesDirectory);
+    return report(false);
+  }
+
+  try {
+    await new RoutineConfigEditor(configPath).addRoutine({
+      projectName: options.project,
+      routinePath: registeredPath
+    });
+  } catch (error) {
+    errors.push(errorMessage(error));
+    await unlink(filePath).catch(() => undefined);
+    await removeCreatedDirectory(createdDirectory, routinesDirectory);
+    return report(false);
+  }
+
+  return report(true);
+}
+
+function routineSource(options: AddRoutineOptions): string {
+  const schedule =
+    options.at === undefined
+      ? {
+          cron: options.schedule,
+          ...(options.tz === undefined ? {} : { tz: options.tz })
+        }
+      : { at: options.at };
+  const frontMatter = {
+    name: options.name,
+    schedule,
+    kind: options.kind,
+    ...(options.provider === undefined ? {} : { provider: options.provider })
+  };
+  return [
+    "---",
+    stringify(frontMatter).trimEnd(),
+    "---",
+    "",
+    "<!-- TODO: Describe what this routine should accomplish. -->",
+    "<!-- TODO: Include expected outputs and repository-specific checks. -->",
+    ""
+  ].join("\n");
+}
+
+function registrationPath(configPath: string, filePath: string): string {
+  const configDir = path.dirname(configPath);
+  const relative = path.relative(configDir, filePath);
+  if (
+    relative.length > 0 &&
+    !path.isAbsolute(relative) &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`)
+  ) {
+    return `./${relative.split(path.sep).join("/")}`;
+  }
+  return filePath;
+}
+
+async function removeCreatedDirectory(
+  createdDirectory: string | undefined,
+  routinesDirectory: string
+): Promise<void> {
+  if (createdDirectory !== undefined) {
+    await rmdir(routinesDirectory).catch(() => undefined);
+  }
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "EEXIST"
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,8 @@ import { realpathSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import type { AddRoutineOptions, AddRoutineReport } from "./add-routine.js";
+import { runAddRoutine } from "./add-routine.js";
 import type { DaemonHandle, StartDaemonOptions } from "./daemon.js";
 import { startDaemon } from "./daemon.js";
 import { resolveServiceConfigPath } from "./config-paths.js";
@@ -21,7 +23,7 @@ import { runClearStale, runDoctor, runInitProject } from "./doctor.js";
 import type { InitOptions, InitProvider, InitReport } from "./init.js";
 import { runInit } from "./init.js";
 import type { ProjectIssuePollReport } from "./issue-polling.js";
-import type { RoutineStatus } from "./routines/types.js";
+import type { RoutineKind, RoutineStatus } from "./routines/types.js";
 import {
   resolveWatchdogConfig,
   RuntimeConfigReloader,
@@ -76,6 +78,7 @@ export type CliDependencies = {
   fetch?: FetchFn;
   openRunStore?: (options: OpenRunStoreOptions) => RunStore;
   registerSignalHandlers?: boolean;
+  runAddRoutine?: (options: AddRoutineOptions) => Promise<AddRoutineReport>;
   runClearStale?: (options: ClearStaleOptions) => Promise<ClearStaleReport>;
   runDoctor?: (options: DoctorOptions) => Promise<DoctorReport>;
   runInit?: (options: InitOptions) => Promise<InitReport>;
@@ -128,6 +131,7 @@ type RoutinesOptions = {
 const DEFAULT_STATUS_WATCH_DOCTOR_TTL_MS = 5000;
 
 export function buildCli(dependencies: CliDependencies = {}): Command {
+  const addRoutine = dependencies.runAddRoutine ?? runAddRoutine;
   const doctor = dependencies.runDoctor ?? runDoctor;
   const init = dependencies.runInit ?? runInit;
   const initProject = dependencies.runInitProject ?? runInitProject;
@@ -222,6 +226,66 @@ export function buildCli(dependencies: CliDependencies = {}): Command {
       );
       writeOut(program, "then:      symphonika init-project --yes\n");
     });
+
+  program
+    .command("add-routine")
+    .description("create and register a Project Routine declaration")
+    .argument("<name>", "path-safe Routine name")
+    .requiredOption("--project <name>", "project name from symphonika.yml")
+    .option("--schedule <expr>", "cron expression or supported alias")
+    .option("--at <iso8601>", "one-shot ISO 8601 timestamp")
+    .requiredOption(
+      "--kind <kind>",
+      "Routine kind (git or report)",
+      parseRoutineKind
+    )
+    .option("--provider <name>", "provider override", parseProvider)
+    .option("--tz <iana>", "IANA timezone for a recurring schedule")
+    .option("--config <path>", "service config path")
+    .action(
+      async (
+        name: string,
+        options: {
+          at?: string;
+          config?: string;
+          kind: RoutineKind;
+          project: string;
+          provider?: InitProvider;
+          schedule?: string;
+          tz?: string;
+        }
+      ) => {
+        const report = await addRoutine({
+          ...(options.at === undefined ? {} : { at: options.at }),
+          ...withConfigPath(options.config),
+          kind: options.kind,
+          name,
+          project: options.project,
+          ...(options.provider === undefined
+            ? {}
+            : { provider: options.provider }),
+          ...(options.schedule === undefined
+            ? {}
+            : { schedule: options.schedule }),
+          ...(options.tz === undefined ? {} : { tz: options.tz })
+        });
+
+        if (!report.ok) {
+          writeErr(program, "add-routine failed:\n");
+          for (const error of report.errors) {
+            writeErr(program, `- ${error}\n`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        writeOut(program, "add-routine ok\n");
+        writeOut(program, `project:    ${report.project}\n`);
+        writeOut(program, `routine:    ${report.routineName}\n`);
+        writeOut(program, `file:       ${report.filePath}\n`);
+        writeOut(program, `registered: ${report.registeredPath}\n`);
+      }
+    );
 
   program
     .command("init-project")
@@ -1916,6 +1980,13 @@ function parseProvider(value: string): InitProvider {
     return value;
   }
   throw new InvalidArgumentError("provider must be one of codex, claude");
+}
+
+function parseRoutineKind(value: string): RoutineKind {
+  if (value === "git" || value === "report") {
+    return value;
+  }
+  throw new InvalidArgumentError("kind must be one of git, report");
 }
 
 function pluralize(word: string, count: number): string {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -21,6 +21,7 @@ import {
 import { REQUIRED_OPERATIONAL_LABELS } from "./operational-labels.js";
 import type { AgentProviderRegistry } from "./provider.js";
 import { DEFAULT_AGENT_PROVIDERS } from "./providers/index.js";
+import { loadRoutineDeclaration } from "./routines/declaration-loader.js";
 import {
   loadExpandedWorkflow,
   validateExpandedWorkflowReferences
@@ -204,6 +205,7 @@ const projectSchema = z
         provider: providerNameSchema
       })
       .passthrough(),
+    routines: z.array(pathStringSchema).optional(),
     workflow: workflowReferenceSchema
   })
   .passthrough();
@@ -280,6 +282,13 @@ export async function runDoctor(
       project.workflow.format
     );
     errors.push(...workflowErrors);
+    errors.push(
+      ...(await collectRoutineErrors(
+        (project.routines ?? []).map((routinePath) =>
+          path.resolve(path.dirname(configPath), routinePath)
+        )
+      ))
+    );
     const staleIssues = await fetchStaleIssues(project, env, githubIssuesApi);
     projects.push({
       ...validation,
@@ -290,6 +299,27 @@ export async function runDoctor(
   }
 
   return report(configPath, errors, projects);
+}
+
+async function collectRoutineErrors(routinePaths: string[]): Promise<string[]> {
+  const errors: string[] = [];
+  const seenNames = new Map<string, string>();
+  for (const routinePath of routinePaths) {
+    const result = await loadRoutineDeclaration(routinePath);
+    if (result.routine === null) {
+      errors.push(...result.errors);
+      continue;
+    }
+    const existing = seenNames.get(result.routine.name);
+    if (existing !== undefined) {
+      errors.push(
+        `duplicate routine name "${result.routine.name}" declared by ${existing} and ${result.routine.sourcePath}`
+      );
+      continue;
+    }
+    seenNames.set(result.routine.name, result.routine.sourcePath);
+  }
+  return errors;
 }
 
 async function collectWorkflowErrors(

--- a/src/routines/config-editor.ts
+++ b/src/routines/config-editor.ts
@@ -1,0 +1,92 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { isMap, isScalar, isSeq, parseDocument } from "yaml";
+
+import { loadRoutineDeclaration } from "./declaration-loader.js";
+
+export type AddRoutineConfigInput = {
+  projectName: string;
+  routinePath: string;
+};
+
+export type AddRoutineConfigResult = {
+  changed: boolean;
+  routineName: string;
+};
+
+export class RoutineConfigEditor {
+  constructor(private readonly configPath: string) {}
+
+  async addRoutine(
+    input: AddRoutineConfigInput
+  ): Promise<AddRoutineConfigResult> {
+    const configDir = path.dirname(this.configPath);
+    const declaration = await loadRoutineDeclaration(
+      path.resolve(configDir, input.routinePath)
+    );
+    if (declaration.routine === null) {
+      throw new Error(declaration.errors.join("; "));
+    }
+
+    const source = await readFile(this.configPath, "utf8");
+    const document = parseDocument(source);
+    if (document.errors.length > 0) {
+      throw new Error(
+        `service config could not be parsed: ${document.errors.map((error) => error.message).join("; ")}`
+      );
+    }
+    if (!isMap(document.contents)) {
+      throw new Error("service config must be a mapping");
+    }
+
+    const projects = document.contents.get("projects", true);
+    if (!isSeq(projects)) {
+      throw new Error("service config projects must be a sequence");
+    }
+    const project = projects.items.find(
+      (candidate) =>
+        isMap(candidate) && candidate.get("name") === input.projectName
+    );
+    if (!isMap(project)) {
+      throw new Error(
+        `project "${input.projectName}" not found in service config`
+      );
+    }
+
+    const routines = project.get("routines", true);
+    if (routines === undefined) {
+      project.set("routines", [input.routinePath]);
+    } else if (!isSeq(routines)) {
+      throw new Error(
+        `project "${input.projectName}" routines must be a sequence`
+      );
+    } else {
+      const requestedPath = path.resolve(configDir, input.routinePath);
+      for (const item of routines.items) {
+        if (!isScalar(item) || typeof item.value !== "string") {
+          throw new Error(
+            `project "${input.projectName}" routines entries must be paths`
+          );
+        }
+        const existingPath = path.resolve(configDir, item.value);
+        if (existingPath === requestedPath) {
+          return { changed: false, routineName: declaration.routine.name };
+        }
+        const existing = await loadRoutineDeclaration(existingPath);
+        if (existing.routine === null) {
+          throw new Error(existing.errors.join("; "));
+        }
+        if (existing.routine.name === declaration.routine.name) {
+          throw new Error(
+            `routine name "${declaration.routine.name}" already exists in project "${input.projectName}" at ${item.value}`
+          );
+        }
+      }
+      routines.add(input.routinePath);
+    }
+    await writeFile(this.configPath, String(document), "utf8");
+
+    return { changed: true, routineName: declaration.routine.name };
+  }
+}

--- a/src/routines/declaration-loader.ts
+++ b/src/routines/declaration-loader.ts
@@ -38,7 +38,7 @@ export async function loadRoutineDeclaration(
   return parseRoutineDeclaration(contents, absolutePath);
 }
 
-function parseRoutineDeclaration(
+export function parseRoutineDeclaration(
   contents: string,
   routinePath: string
 ): RoutineDeclarationLoadResult {

--- a/tests/add-routine.test.ts
+++ b/tests/add-routine.test.ts
@@ -1,0 +1,356 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runAddRoutine } from "../src/add-routine.js";
+import { buildCli } from "../src/cli.js";
+import { loadRoutineDeclaration } from "../src/routines/declaration-loader.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-add-routine-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("add-routine", () => {
+  it("creates and registers a recurring Routine with all supplied flags", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeConfig(configPath);
+
+    const report = await runAddRoutine({
+      configPath,
+      cwd: root,
+      kind: "git",
+      name: "weekly-maintenance",
+      project: "alpha",
+      provider: "claude",
+      schedule: "@weekly",
+      tz: "Europe/Berlin"
+    });
+
+    const routinePath = path.join(root, "routines", "weekly-maintenance.md");
+    expect(report).toMatchObject({
+      configPath,
+      filePath: routinePath,
+      ok: true,
+      project: "alpha",
+      registeredPath: "./routines/weekly-maintenance.md",
+      routineName: "weekly-maintenance"
+    });
+    const source = await readFile(routinePath, "utf8");
+    expect(source).toContain("name: weekly-maintenance");
+    expect(source).toContain('cron: "@weekly"');
+    expect(source).toContain("tz: Europe/Berlin");
+    expect(source).toContain("kind: git");
+    expect(source).toContain("provider: claude");
+    expect(source).toContain("<!-- TODO:");
+    expect((await loadRoutineDeclaration(routinePath)).routine).toMatchObject({
+      kind: "git",
+      name: "weekly-maintenance",
+      provider: "claude",
+      schedule: { cron: "0 0 * * 0", tz: "Europe/Berlin" }
+    });
+    expect(await readFile(configPath, "utf8")).toContain(
+      "    routines:\n      - ./routines/weekly-maintenance.md\n"
+    );
+  });
+
+  it("creates a one-shot Routine and uses an absolute registration from user config", async () => {
+    const root = await makeTempRoot();
+    const projectRoot = path.join(root, "project");
+    const configPath = path.join(root, "config", "symphonika.yml");
+    await mkdir(projectRoot);
+    await writeConfig(configPath);
+
+    const report = await runAddRoutine({
+      at: "2026-08-01T09:30:00+02:00",
+      configPath,
+      cwd: projectRoot,
+      kind: "report",
+      name: "launch-report",
+      project: "alpha"
+    });
+
+    const routinePath = path.join(projectRoot, "routines", "launch-report.md");
+    expect(report).toMatchObject({
+      ok: true,
+      registeredPath: routinePath
+    });
+    expect((await loadRoutineDeclaration(routinePath)).routine).toMatchObject({
+      kind: "report",
+      name: "launch-report",
+      provider: null,
+      schedule: { at: "2026-08-01T07:30:00.000Z" }
+    });
+    expect(await readFile(routinePath, "utf8")).not.toContain("provider:");
+    expect(await readFile(configPath, "utf8")).toContain(
+      `    routines:\n      - ${routinePath}\n`
+    );
+  });
+
+  it.each([
+    {
+      label: "unknown alias",
+      name: "bad-alias",
+      options: { schedule: "fortnightly" },
+      problem: "expected exactly five fields or a supported alias"
+    },
+    {
+      label: "invalid cron",
+      name: "bad-cron",
+      options: { schedule: "99 99 * * *" },
+      problem: "schedule.cron is invalid"
+    },
+    {
+      label: "invalid timezone",
+      name: "bad-timezone",
+      options: { schedule: "daily", tz: "Mars/Olympus" },
+      problem: "is not a valid IANA timezone"
+    },
+    {
+      label: "unsafe name",
+      name: "../escape",
+      options: { schedule: "daily" },
+      problem: "is not path-safe"
+    }
+  ])("refuses a $label without creating or registering it", async (input) => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeConfig(configPath);
+    const original = await readFile(configPath, "utf8");
+
+    const report = await runAddRoutine({
+      configPath,
+      cwd: root,
+      kind: "report",
+      name: input.name,
+      project: "alpha",
+      ...input.options
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors.join("\n")).toContain(input.problem);
+    await expect(readFile(report.filePath, "utf8")).rejects.toThrow();
+    expect(await readFile(configPath, "utf8")).toBe(original);
+  });
+
+  it("requires exactly one of a recurring schedule or one-shot time", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeConfig(configPath);
+
+    const report = await runAddRoutine({
+      at: "2026-08-01T09:30:00Z",
+      configPath,
+      cwd: root,
+      kind: "report",
+      name: "ambiguous",
+      project: "alpha",
+      schedule: "daily"
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "exactly one of --schedule or --at must be supplied"
+    );
+    await expect(readFile(report.filePath, "utf8")).rejects.toThrow();
+  });
+
+  it("refuses a timezone for a one-shot Routine", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeConfig(configPath);
+
+    const report = await runAddRoutine({
+      at: "2026-08-01T09:30:00Z",
+      configPath,
+      cwd: root,
+      kind: "report",
+      name: "one-shot-with-timezone",
+      project: "alpha",
+      tz: "Europe/Berlin"
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "--tz may only be supplied with --schedule"
+    );
+    await expect(readFile(report.filePath, "utf8")).rejects.toThrow();
+  });
+
+  it("refuses an unknown Project without leaving a Routine file", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeConfig(configPath);
+    const original = await readFile(configPath, "utf8");
+
+    const report = await runAddRoutine({
+      configPath,
+      cwd: root,
+      kind: "report",
+      name: "orphan",
+      project: "missing",
+      schedule: "daily"
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      'project "missing" not found in service config'
+    );
+    await expect(readFile(report.filePath, "utf8")).rejects.toThrow();
+    expect(await readFile(configPath, "utf8")).toBe(original);
+  });
+
+  it("refuses a Routine name already registered under another path", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    const routinesDirectory = path.join(root, "routines");
+    await mkdir(routinesDirectory);
+    await writeFile(
+      path.join(routinesDirectory, "existing.md"),
+      [
+        "---",
+        "name: daily-report",
+        "schedule:",
+        "  cron: daily",
+        "kind: report",
+        "---",
+        "Create the report.",
+        ""
+      ].join("\n")
+    );
+    await writeConfig(configPath, ["./routines/existing.md"]);
+    const original = await readFile(configPath, "utf8");
+
+    const report = await runAddRoutine({
+      configPath,
+      cwd: root,
+      kind: "report",
+      name: "daily-report",
+      project: "alpha",
+      schedule: "weekly"
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors.join("\n")).toContain(
+      'routine name "daily-report" already exists in project "alpha"'
+    );
+    await expect(readFile(report.filePath, "utf8")).rejects.toThrow();
+    expect(await readFile(configPath, "utf8")).toBe(original);
+  });
+
+  it("does not overwrite an existing Routine file", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    const routinePath = path.join(root, "routines", "daily-report.md");
+    await writeConfig(configPath);
+    await mkdir(path.dirname(routinePath));
+    await writeFile(routinePath, "operator-owned contents\n");
+
+    const report = await runAddRoutine({
+      configPath,
+      cwd: root,
+      kind: "report",
+      name: "daily-report",
+      project: "alpha",
+      schedule: "daily"
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      `routine file already exists at ${routinePath}`
+    );
+    expect(await readFile(routinePath, "utf8")).toBe(
+      "operator-owned contents\n"
+    );
+  });
+
+  it("exposes the filesystem-only behavior through the add-routine CLI command", async () => {
+    const previousCwd = process.cwd();
+    const previousExitCode = process.exitCode;
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await writeConfig(configPath);
+    const output = { stderr: "", stdout: "" };
+    let networkCalls = 0;
+    const program = buildCli({
+      fetch: () => {
+        networkCalls += 1;
+        return Promise.reject(new Error("network access is forbidden"));
+      },
+      registerSignalHandlers: false
+    });
+    program.configureOutput({
+      writeErr: (message) => {
+        output.stderr += message;
+      },
+      writeOut: (message) => {
+        output.stdout += message;
+      }
+    });
+
+    try {
+      process.chdir(root);
+      process.exitCode = 0;
+      await program.parseAsync([
+        "node",
+        "symphonika",
+        "add-routine",
+        "nightly-report",
+        "--project",
+        "alpha",
+        "--schedule",
+        "daily",
+        "--kind",
+        "report",
+        "--config",
+        configPath
+      ]);
+
+      expect(process.exitCode).not.toBe(1);
+      expect(output.stderr).toBe("");
+      expect(output.stdout).toContain("add-routine ok");
+      expect(output.stdout).toContain(
+        path.join(root, "routines", "nightly-report.md")
+      );
+      expect(networkCalls).toBe(0);
+    } finally {
+      process.chdir(previousCwd);
+      process.exitCode = previousExitCode;
+    }
+  });
+});
+
+async function writeConfig(
+  configPath: string,
+  routines: string[] = []
+): Promise<void> {
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(
+    configPath,
+    [
+      "projects:",
+      "  - name: alpha",
+      "    workflow: ./WORKFLOW.md",
+      ...(routines.length === 0
+        ? []
+        : [
+            "    routines:",
+            ...routines.map((routine) => `      - ${routine}`)
+          ]),
+      ""
+    ].join("\n")
+  );
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -79,6 +79,7 @@ describe("CLI", () => {
 
       expect(stdout).toContain("Usage: symphonika");
       expect(stdout).toContain("Commands:");
+      expect(stdout).toContain("add-routine");
       expect(stdout).toContain("doctor");
       expect(stdout).toContain("workflow");
       expect(stdout).toContain("show-run");
@@ -103,6 +104,7 @@ describe("CLI", () => {
 
     expect(stdout).toContain("Usage: symphonika");
     expect(stdout).toContain("Commands:");
+    expect(stdout).toContain("add-routine");
     expect(stdout).toContain("doctor");
     expect(stdout).toContain("clear-stale");
     expect(stdout).toContain("workflow");

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -139,6 +139,77 @@ describe("doctor", () => {
     expect(output.stderr).toContain("workflow contract not found");
   });
 
+  it("reports invalid enumerated Routine declarations beside workflow errors", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    const routinePath = path.join(root, "routines", "broken.md");
+    await writeValidConfig(configPath, {
+      routinePaths: ["./routines/broken.md"]
+    });
+    await mkdir(path.dirname(routinePath));
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}} for {{project.name}}.\n"
+    );
+    await writeFile(
+      routinePath,
+      [
+        "---",
+        "name: broken",
+        "schedule:",
+        "  cron: fortnightly",
+        "kind: report",
+        "---",
+        "Create a report.",
+        ""
+      ].join("\n")
+    );
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stdout).toBe("");
+    expect(output.stderr).toContain("doctor failed");
+    expect(output.stderr).toContain(`routine at ${routinePath}`);
+    expect(output.stderr).toContain("schedule.cron is invalid");
+  });
+
+  it("reports duplicate Routine names within one Project", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    const firstPath = path.join(root, "routines", "first.md");
+    const secondPath = path.join(root, "routines", "second.md");
+    await writeValidConfig(configPath, {
+      routinePaths: ["./routines/first.md", "./routines/second.md"]
+    });
+    await mkdir(path.dirname(firstPath));
+    await writeFile(
+      path.join(root, "WORKFLOW.md"),
+      "Work on {{issue.title}} for {{project.name}}.\n"
+    );
+    const routine = [
+      "---",
+      "name: repeated",
+      "schedule:",
+      "  cron: daily",
+      "kind: report",
+      "---",
+      "Create a report.",
+      ""
+    ].join("\n");
+    await writeFile(firstPath, routine);
+    await writeFile(secondPath, routine);
+    process.env.GITHUB_TOKEN = "test-secret-token";
+
+    const output = await runDoctorCommand(configPath);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.stderr).toContain('duplicate routine name "repeated"');
+    expect(output.stderr).toContain(firstPath);
+    expect(output.stderr).toContain(secondPath);
+  });
+
   it("resolves environment-backed tracker tokens without printing secret values", async () => {
     const root = await makeTempRoot();
     const configPath = path.join(root, "symphonika.yml");
@@ -451,6 +522,7 @@ async function writeValidConfig(
     agentProvider?: string;
     claudeCommand?: string;
     codexCommand?: string;
+    routinePaths?: string[];
     token?: string;
     trackerKind?: string;
     workspaceHookLines?: string[];
@@ -500,6 +572,14 @@ async function writeValidConfig(
       "    agent:",
       `      provider: ${overrides.agentProvider ?? "codex"}`,
       `    workflow: ${overrides.workflowPath ?? "./WORKFLOW.md"}`,
+      ...(overrides.routinePaths === undefined
+        ? []
+        : [
+            "    routines:",
+            ...overrides.routinePaths.map(
+              (routinePath) => `      - ${routinePath}`
+            )
+          ]),
       ""
     ].join("\n")
   );

--- a/tests/routine-config-editor.test.ts
+++ b/tests/routine-config-editor.test.ts
@@ -1,0 +1,198 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { RoutineConfigEditor } from "../src/routines/config-editor.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "symphonika-routine-editor-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe("RoutineConfigEditor", () => {
+  it("appends a declaration path to an existing Project routines list", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await mkdir(path.join(root, "routines"));
+    await writeRoutine(path.join(root, "routines", "daily.md"), "daily");
+    await writeRoutine(path.join(root, "routines", "weekly.md"), "weekly");
+    await writeFile(
+      configPath,
+      [
+        "projects:",
+        "  - name: alpha",
+        "    routines:",
+        "      - ./routines/daily.md",
+        "    workflow: ./WORKFLOW.md",
+        ""
+      ].join("\n")
+    );
+
+    const result = await new RoutineConfigEditor(configPath).addRoutine({
+      projectName: "alpha",
+      routinePath: "./routines/weekly.md"
+    });
+
+    expect(result).toEqual({ changed: true, routineName: "weekly" });
+    expect(await readFile(configPath, "utf8")).toContain(
+      "      - ./routines/daily.md\n      - ./routines/weekly.md\n"
+    );
+  });
+
+  it("creates a Project routines list when it is absent", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await mkdir(path.join(root, "routines"));
+    await writeRoutine(path.join(root, "routines", "weekly.md"), "weekly");
+    await writeFile(
+      configPath,
+      ["projects:", "  - name: alpha", "    workflow: ./WORKFLOW.md", ""].join(
+        "\n"
+      )
+    );
+
+    await new RoutineConfigEditor(configPath).addRoutine({
+      projectName: "alpha",
+      routinePath: "./routines/weekly.md"
+    });
+
+    expect(await readFile(configPath, "utf8")).toContain(
+      "    workflow: ./WORKFLOW.md\n    routines:\n      - ./routines/weekly.md\n"
+    );
+  });
+
+  it("refuses to edit a Project that does not exist", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await mkdir(path.join(root, "routines"));
+    await writeRoutine(path.join(root, "routines", "weekly.md"), "weekly");
+    const original = "projects:\n  - name: alpha\n";
+    await writeFile(configPath, original);
+
+    await expect(
+      new RoutineConfigEditor(configPath).addRoutine({
+        projectName: "missing",
+        routinePath: "./routines/weekly.md"
+      })
+    ).rejects.toThrow('project "missing" not found in service config');
+    expect(await readFile(configPath, "utf8")).toBe(original);
+  });
+
+  it("refuses a different declaration path with the same Routine name", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await mkdir(path.join(root, "routines"));
+    await writeRoutine(path.join(root, "routines", "weekly-old.md"), "weekly");
+    await writeRoutine(path.join(root, "routines", "weekly-new.md"), "weekly");
+    const original = [
+      "projects:",
+      "  - name: alpha",
+      "    routines:",
+      "      - ./routines/weekly-old.md",
+      ""
+    ].join("\n");
+    await writeFile(configPath, original);
+
+    await expect(
+      new RoutineConfigEditor(configPath).addRoutine({
+        projectName: "alpha",
+        routinePath: "./routines/weekly-new.md"
+      })
+    ).rejects.toThrow(
+      'routine name "weekly" already exists in project "alpha" at ./routines/weekly-old.md'
+    );
+    expect(await readFile(configPath, "utf8")).toBe(original);
+  });
+
+  it("is idempotent when the same resolved declaration path is re-added", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await mkdir(path.join(root, "routines"));
+    await writeRoutine(path.join(root, "routines", "weekly.md"), "weekly");
+    const original = [
+      "projects:",
+      "  - name: alpha",
+      "    routines:",
+      "      - ./routines/weekly.md",
+      ""
+    ].join("\n");
+    await writeFile(configPath, original);
+
+    const result = await new RoutineConfigEditor(configPath).addRoutine({
+      projectName: "alpha",
+      routinePath: "routines/weekly.md"
+    });
+
+    expect(result).toEqual({ changed: false, routineName: "weekly" });
+    expect(await readFile(configPath, "utf8")).toBe(original);
+  });
+
+  it("preserves comments and unrelated key ordering", async () => {
+    const root = await makeTempRoot();
+    const configPath = path.join(root, "symphonika.yml");
+    await mkdir(path.join(root, "routines"));
+    await writeRoutine(path.join(root, "routines", "weekly.md"), "weekly");
+    const original = [
+      "# service heading",
+      "providers: # provider comment",
+      "  codex:",
+      "    command: codex",
+      "projects:",
+      "  - name: alpha # selected project",
+      "    workflow: ./WORKFLOW.md # workflow comment",
+      "polling:",
+      "  interval_ms: 30000 # cadence",
+      ""
+    ].join("\n");
+    await writeFile(configPath, original);
+
+    await new RoutineConfigEditor(configPath).addRoutine({
+      projectName: "alpha",
+      routinePath: "./routines/weekly.md"
+    });
+
+    const edited = await readFile(configPath, "utf8");
+    expect(edited).toContain("# service heading");
+    expect(edited).toContain("# provider comment");
+    expect(edited).toContain("# selected project");
+    expect(edited).toContain("# workflow comment");
+    expect(edited).toContain("# cadence");
+    expect(edited.indexOf("providers:")).toBeLessThan(
+      edited.indexOf("projects:")
+    );
+    expect(edited.indexOf("projects:")).toBeLessThan(
+      edited.indexOf("polling:")
+    );
+    expect(edited).toContain(
+      "    workflow: ./WORKFLOW.md # workflow comment\n    routines:\n      - ./routines/weekly.md\n"
+    );
+  });
+});
+
+async function writeRoutine(filePath: string, name: string): Promise<void> {
+  await writeFile(
+    filePath,
+    [
+      "---",
+      `name: ${name}`,
+      "schedule:",
+      "  cron: daily",
+      "kind: report",
+      "---",
+      "Do the work.",
+      ""
+    ].join("\n")
+  );
+}

--- a/tests/routine-daemon.test.ts
+++ b/tests/routine-daemon.test.ts
@@ -126,6 +126,76 @@ describe("daemon routine firing", () => {
     }
   });
 
+  it("keeps a last-known-good Routine live when its declaration reload becomes invalid", async () => {
+    const root = await makeTempRoot();
+    const fireAt = new Date(Date.now() + 1_000).toISOString();
+    const routinePath = path.join(root, "daily-report.md");
+    await writeRoutineProject(root, fireAt);
+    const provider = quietProvider();
+    const workspacePath = path.join(
+      root,
+      ".symphonika",
+      "workspaces",
+      "alpha",
+      "routines",
+      "daily-report",
+      "routine-fire-lkg"
+    );
+
+    const daemon = await startDaemon({
+      agentProviders: { codex: provider },
+      createRoutineFiringId: () => "routine-fire-lkg",
+      cwd: root,
+      env: { GITHUB_TOKEN: "secret-token" },
+      githubIssuesApi: {
+        addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+        listOpenIssues: vi.fn().mockResolvedValue([]),
+        removeLabelsFromIssue: vi.fn().mockResolvedValue(undefined)
+      },
+      logger: pino({ enabled: false }),
+      port: 0,
+      prepareRoutineWorkspace: vi.fn().mockResolvedValue({
+        branchName: "main",
+        branchRef: "refs/remotes/origin/main",
+        cachePath: path.join(root, ".cache", "repo.git"),
+        reused: false,
+        workspacePath
+      })
+    });
+
+    try {
+      await waitForRoutine(daemon.url, "active");
+      await writeFile(
+        routinePath,
+        ["---", "name: ../unsafe", "kind: report", "---", "Body", ""].join("\n")
+      );
+      await fetch(`${daemon.url}/api/poll-now`, { method: "POST" });
+
+      const status = (await fetch(`${daemon.url}/api/status`).then((response) =>
+        response.json()
+      )) as {
+        reload?: {
+          errors: string[];
+          ok: boolean;
+          usingLastKnownGood: boolean;
+        };
+      };
+      expect(status.reload).toMatchObject({
+        ok: false,
+        usingLastKnownGood: true
+      });
+      expect(status.reload?.errors.join("\n")).toContain(
+        'name "../unsafe" is not path-safe'
+      );
+      await waitForRoutine(daemon.url, "expired");
+      await vi.waitFor(() => {
+        expect(provider.runAttempt).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it("hides disabled Project routines and restores expired one-shots without refiring", async () => {
     const root = await makeTempRoot();
     await writeRoutineProject(root, "2026-05-22T10:00:00.000Z");


### PR DESCRIPTION
## Summary

- add a comment-preserving `RoutineConfigEditor` with duplicate-name and missing-project safeguards
- add the filesystem-only `symphonika add-routine` scaffold command for cron and one-shot declarations
- extend `doctor` to validate enumerated Routine declarations and duplicate names
- prove invalid Routine reloads remain operator-visible while the daemon fires the last-known-good snapshot

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` (727 tests)
- `npm run build`
- `npm run format:check`
- `npm run knip`

Closes #194
